### PR TITLE
Files api: add "receive", "receive content" and "delete"

### DIFF
--- a/src/Contracts/Transporter.php
+++ b/src/Contracts/Transporter.php
@@ -22,4 +22,12 @@ interface Transporter
      * @throws ErrorException|UnserializableResponse|TransporterException
      */
     public function request(Payload $payload): array;
+
+    /**
+     * Sends a content request to a server.
+     **
+     *
+     * @throws ErrorException|UnserializableResponse|TransporterException
+     */
+    public function requestContent(Payload $payload): string;
 }

--- a/src/Resources/Files.php
+++ b/src/Resources/Files.php
@@ -26,4 +26,46 @@ final class Files
 
         return $result;
     }
+
+    /**
+     * Returns information about a specific file.
+     *
+     * @see https://beta.openai.com/docs/api-reference/files/retrieve
+     *
+     * @return array<string, mixed>
+     */
+    public function retrieve(string $file): array
+    {
+        $payload = Payload::retrieve('files', $file);
+
+        return $this->transporter->request($payload);
+    }
+
+    /**
+     * Returns the contents of the specified file.
+     *
+     * @see https://beta.openai.com/docs/api-reference/files/retrieve-content
+     *
+     * @return string
+     */
+    public function retrieveContent(string $file): string
+    {
+        $payload = Payload::retrieveContent('files', $file);
+
+        return $this->transporter->requestContent($payload);
+    }
+
+    /**
+     * Delete a file.
+     *
+     * @see https://beta.openai.com/docs/api-reference/files/delete
+     *
+     * @return array<string, mixed>
+     */
+    public function delete(string $file): array
+    {
+        $payload = Payload::delete('files', $file);
+
+        return $this->transporter->request($payload);
+    }
 }

--- a/src/Transporters/HttpTransporter.php
+++ b/src/Transporters/HttpTransporter.php
@@ -56,4 +56,20 @@ final class HttpTransporter implements Transporter
 
         return $response;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function requestContent(Payload $payload): string
+    {
+        $request = $payload->toRequest($this->baseUri, $this->headers);
+
+        try {
+            $response = $this->client->sendRequest($request);
+        } catch (ClientExceptionInterface $clientException) {
+            throw new TransporterException($clientException);
+        }
+
+        return $response->getBody()->getContents();
+    }
 }

--- a/src/ValueObjects/ResourceUri.php
+++ b/src/ValueObjects/ResourceUri.php
@@ -52,6 +52,22 @@ final class ResourceUri implements Stringable
     }
 
     /**
+     * Creates a new ResourceUri value object that retrieves the given resource content.
+     */
+    public static function retrieveContent(string $resource, string $id): self
+    {
+        return new self("{$resource}/{$id}/content");
+    }
+
+    /**
+     * Creates a new ResourceUri value object that deletes the given resource.
+     */
+    public static function delete(string $resource, string $id): self
+    {
+        return new self("{$resource}/{$id}");
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function toString(): string

--- a/src/ValueObjects/Transporter/Payload.php
+++ b/src/ValueObjects/Transporter/Payload.php
@@ -54,6 +54,18 @@ final class Payload
 
     /**
      * Creates a new Payload value object from the given parameters.
+     */
+    public static function retrieveContent(string $resource, string $id): self
+    {
+        $contentType = ContentType::JSON;
+        $method = Method::GET;
+        $uri = ResourceUri::retrieveContent($resource, $id);
+
+        return new self($contentType, $method, $uri);
+    }
+
+    /**
+     * Creates a new Payload value object from the given parameters.
      *
      * @param  array<string, mixed>  $parameters
      */
@@ -78,6 +90,18 @@ final class Payload
         $uri = ResourceUri::upload($resource);
 
         return new self($contentType, $method, $uri, $parameters);
+    }
+
+    /**
+     * Creates a new Payload value object from the given parameters.
+     */
+    public static function delete(string $resource, string $id): self
+    {
+        $contentType = ContentType::JSON;
+        $method = Method::DELETE;
+        $uri = ResourceUri::delete($resource, $id);
+
+        return new self($contentType, $method, $uri);
     }
 
     /**

--- a/tests/Fixtures/File.php
+++ b/tests/Fixtures/File.php
@@ -14,3 +14,23 @@ function fileResource(): array
         'purpose' => 'fine-tune',
     ];
 }
+
+/**
+ * @return string
+ */
+function fileContentResource(): string
+{
+    return file_get_contents(__DIR__.'/MyFile.json');
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function fileDeleteResource(): array
+{
+    return [
+        'id' => 'file-XjGxS3KTG0uNmNOK362iJua3',
+        'object' => 'file',
+        'deleted' => true,
+    ];
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -7,12 +7,12 @@ use OpenAI\ValueObjects\Transporter\BaseUri;
 use OpenAI\ValueObjects\Transporter\Headers;
 use OpenAI\ValueObjects\Transporter\Payload;
 
-function mockClient(string $method, string $resource, array $params, array $response)
+function mockClient(string $method, string $resource, array $params, array|string $response, $methodName = 'request')
 {
     $transporter = Mockery::mock(Transporter::class);
 
     $transporter
-        ->shouldReceive('request')
+        ->shouldReceive($methodName)
         ->once()
         ->withArgs(function (Payload $payload) use ($method, $resource) {
             $baseUri = BaseUri::from('api.openai.com/v1');
@@ -25,4 +25,9 @@ function mockClient(string $method, string $resource, array $params, array $resp
         })->andReturn($response);
 
     return new Client($transporter);
+}
+
+function mockContentClient(string $method, string $resource, array $params, string $response)
+{
+    return mockClient($method, $resource, $params, $response, 'requestContent');
 }

--- a/tests/Resources/Files.php
+++ b/tests/Resources/Files.php
@@ -19,3 +19,27 @@ test('list', function () {
         ],
     ]);
 });
+
+test('retreive', function () {
+    $client = mockClient('GET', 'files/file-XjGxS3KTG0uNmNOK362iJua3', [], fileResource());
+
+    $result = $client->files()->retrieve('file-XjGxS3KTG0uNmNOK362iJua3');
+
+    expect($result)->toBeArray()->toBe(fileResource());
+});
+
+test('retreive content', function () {
+    $client = mockContentClient('GET', 'files/file-XjGxS3KTG0uNmNOK362iJua3/content', [], fileContentResource());
+
+    $result = $client->files()->retrieveContent('file-XjGxS3KTG0uNmNOK362iJua3');
+
+    expect($result)->toBeString()->toBe(fileContentResource());
+});
+
+test('delete', function () {
+    $client = mockClient('DELETE', 'files/file-XjGxS3KTG0uNmNOK362iJua3', [], fileDeleteResource());
+
+    $result = $client->files()->delete('file-XjGxS3KTG0uNmNOK362iJua3');
+
+    expect($result)->toBeArray()->toBe(fileDeleteResource());
+});


### PR DESCRIPTION
Hi @nunomaduro 

I had a little time and extended the files api a bit.

Was not 100% sure how we should approach the content receiving as this will not follow the REST convention to return an array. Instead it returns just a string.
In order to keep the type definitions as tight as possible I've added a new method (`requestContent()`) on the Transport. Hope this is fine for you. Otherwise just let me know.
