### PR TITLE
Files api: add "upload"

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,17 @@ Returns information about a specific file.
 $client->files()->retrieve($file); // ['id' => 'file-XjGxS3KTG0uNmNOK362iJua3', ...]
 ```
 
+#### `upload`
+
+Upload a file that contains document(s) to be used across various endpoints/features.
+
+```php
+$client->files()->upload([
+        'purpose' => 'fine-tune',
+        'file' => fopen('my-file.jsonl', 'r'),
+    ]); // ['id' => 'file-XjGxS3KTG0uNmNOK362iJua3', ...]
+```
+
 #### `download`
 
 Returns the contents of the specified file.

--- a/src/Resources/Files.php
+++ b/src/Resources/Files.php
@@ -54,6 +54,24 @@ final class Files
     }
 
     /**
+     * Upload a file that contains document(s) to be used across various endpoints/features.
+     *
+     * @see https://beta.openai.com/docs/api-reference/files/upload
+     *
+     * @param  array<string, mixed>  $parameters
+     * @return array<string, array<string, mixed>|string>
+     */
+    public function upload(array $parameters): array
+    {
+        $payload = Payload::upload('files', $parameters);
+
+        /** @var array<string, array<string, mixed>|string> $result */
+        $result = $this->transporter->requestObject($payload);
+
+        return $result;
+    }
+
+    /**
      * Delete a file.
      *
      * @see https://beta.openai.com/docs/api-reference/files/delete

--- a/src/ValueObjects/Transporter/Headers.php
+++ b/src/ValueObjects/Transporter/Headers.php
@@ -35,11 +35,11 @@ final class Headers
     /**
      * Creates a new Headers value object, with the given content type, and the existing headers.
      */
-    public function withContentType(ContentType $contentType): self
+    public function withContentType(ContentType $contentType, string $suffix = ''): self
     {
         return new self([
             ...$this->headers,
-            'Content-Type' => $contentType->value,
+            'Content-Type' => $contentType->value.$suffix,
         ]);
     }
 

--- a/src/ValueObjects/Transporter/Payload.php
+++ b/src/ValueObjects/Transporter/Payload.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenAI\ValueObjects\Transporter;
 
+use GuzzleHttp\Psr7\MultipartStream;
 use GuzzleHttp\Psr7\Request as Psr7Request;
 use OpenAI\Enums\Transporter\ContentType;
 use OpenAI\Enums\Transporter\Method;
@@ -115,7 +116,15 @@ final class Payload
         $headers = $headers->withContentType($this->contentType);
 
         if ($this->method === Method::POST) {
-            $body = json_encode($this->parameters, JSON_THROW_ON_ERROR);
+            if ($this->contentType === ContentType::MULTIPART) {
+                $body = new MultipartStream(
+                    array_map(fn ($key): array => ['name' => $key, 'contents' => $this->parameters[$key]], array_keys($this->parameters))
+                );
+
+                $headers = $headers->withContentType($this->contentType, '; boundary='.$body->getBoundary());
+            } else {
+                $body = json_encode($this->parameters, JSON_THROW_ON_ERROR);
+            }
         }
 
         return new Psr7Request($this->method->value, $uri, $headers->toArray(), $body);

--- a/tests/Fixtures/File.php
+++ b/tests/Fixtures/File.php
@@ -20,7 +20,15 @@ function fileResource(): array
  */
 function fileContentResource(): string
 {
-    return file_get_contents(__DIR__.'/MyFile.json');
+    return file_get_contents(__DIR__.'/MyFile.jsonl');
+}
+
+/**
+ * @return resource
+ */
+function fileResourceResource()
+{
+    return fopen(__DIR__.'/MyFile.jsonl', 'r');
 }
 
 /**

--- a/tests/Fixtures/MyFile.json
+++ b/tests/Fixtures/MyFile.json
@@ -1,5 +1,0 @@
-[
-    {"prompt": "<prompt text>", "completion": "<ideal generated text>"},
-    {"prompt": "<prompt text>", "completion": "<ideal generated text>"},
-    {"prompt": "<prompt text>", "completion": "<ideal generated text>"}
-]

--- a/tests/Fixtures/MyFile.jsonl
+++ b/tests/Fixtures/MyFile.jsonl
@@ -1,0 +1,3 @@
+{"prompt": "<prompt text>", "completion": "<ideal generated text>"}
+{"prompt": "<prompt text>", "completion": "<ideal generated text>"}
+{"prompt": "<prompt text>", "completion": "<ideal generated text>"}

--- a/tests/Resources/Files.php
+++ b/tests/Resources/Files.php
@@ -36,6 +36,20 @@ test('download', function () {
     expect($result)->toBeString()->toBe(fileContentResource());
 });
 
+test('upload', function () {
+    $client = mockClient('POST', 'files', [
+        'purpose' => 'fine-tune',
+        'file' => fileResourceResource(),
+    ], fileResource());
+
+    $result = $client->files()->upload([
+        'purpose' => 'fine-tune',
+        'file' => fileResourceResource(),
+    ]);
+
+    expect($result)->toBeArray()->toBe(fileResource());
+});
+
 test('delete', function () {
     $client = mockClient('DELETE', 'files/file-XjGxS3KTG0uNmNOK362iJua3', [], fileDeleteResource());
 

--- a/tests/ValueObjects/Transporter/Payload.php
+++ b/tests/ValueObjects/Transporter/Payload.php
@@ -49,3 +49,23 @@ test('post verb has a body', function () {
         'name' => 'test',
     ]));
 });
+
+test('builds upload request', function () {
+    $payload = Payload::upload('files', [
+        'purpose' => 'fine-tune',
+        'file' => fileResourceResource(),
+    ]);
+
+    $baseUri = BaseUri::from('api.openai.com/v1');
+    $headers = Headers::withAuthorization(ApiToken::from('foo'));
+
+    $request = $payload->toRequest($baseUri, $headers);
+
+    expect($request->getHeader('Content-Type')[0])
+        ->toStartWith('multipart/form-data; boundary=');
+
+    expect($request->getBody()->getContents())
+        ->toContain('Content-Disposition: form-data; name="purpose"')
+        ->toContain('Content-Disposition: form-data; name="file"; filename="MyFile.jsonl"')
+        ->toContain('{"prompt": "<prompt text>", "completion": "<ideal generated text>"}');
+});


### PR DESCRIPTION
Hi @nunomaduro 

A PR to add the missing file upload.

The "Content-Type" header creation is a bit ugly but I had no better idea while still using your initial concept with the PSR7-Request creation.
