### PR TITLE
Add missing api endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ $client->edits()->create(); // ['choices' => [...], ...]
 ```
 
 ### `Embeddings` Resource
-````
+
 #### `create`
 
 Creates an embedding vector representing the input text.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ echo $result['choices'][0]['text']; // an open-source, widely-used, server-side 
 - [x] Edits
 - [x] Embeddings
 - [x] Files
-- [ ] FineTunes
+- [x] FineTunes
 - [ ] Moderations
 - [ ] Classifications
 
@@ -67,6 +67,14 @@ Retrieves a model instance, providing basic information about the model such as 
 
 ```php
 $client->models()->retrieve($model); // ['id' => 'text-davinci-002', ...]
+```
+
+#### `delete`
+
+Delete a fine-tuned model.
+
+```php
+$client->models()->delete($model); // ['id' => 'curie:ft-acmeco-2021-03-03-21-44-20', ...]
 ```
 
 ### `Completions` Resource
@@ -143,6 +151,49 @@ Returns the contents of the specified file.
 ```php
 $client->files()->download($file); // '{"prompt": "<prompt text>", ...'
 ```
+
+### `FineTunes` Resource
+
+#### `create`
+
+Creates a job that fine-tunes a specified model from a given dataset.
+
+```php
+$client->fineTunes()->create($parameters); // ['id' => 'ft-AF1WoRqd3aJAHsqc9NY7iL8F', ...]
+```
+
+#### `list`
+
+List your organization's fine-tuning jobs.
+
+```php
+$client->fineTunes()->list(); // ['data' => [...], ...]
+```
+
+#### `retrieve`
+
+Gets info about the fine-tune job.
+
+```php
+$client->fineTunes()->retrieve($fineTuneId); // ['id' => 'ft-AF1WoRqd3aJAHsqc9NY7iL8F', ...]
+```
+
+#### `cancel`
+
+Immediately cancel a fine-tune job.
+
+```php
+$client->fineTunes()->cancel($fineTuneId); // ['id' => 'ft-AF1WoRqd3aJAHsqc9NY7iL8F', ...]
+```
+
+#### `list events`
+
+Get fine-grained status updates for a fine-tune job.
+
+```php
+$client->fineTunes()->listEvents($fineTuneId); // ['data' => [...], ...]
+```
+
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ echo $result['choices'][0]['text']; // an open-source, widely-used, server-side 
 - [x] Embeddings
 - [x] Files
 - [x] FineTunes
-- [ ] Moderations
+- [x] Moderations
 - [ ] Classifications
 
 ## Usage
@@ -98,14 +98,14 @@ $client->edits()->create(); // ['choices' => [...], ...]
 ```
 
 ### `Embeddings` Resource
-
+````
 #### `create`
 
 Creates an embedding vector representing the input text.
 
 ```php
 $client->embeddings()->create(); // ['data' => [...], ...]
-```
+```````
 
 ### `Files` Resource
 
@@ -192,6 +192,16 @@ Get fine-grained status updates for a fine-tune job.
 
 ```php
 $client->fineTunes()->listEvents($fineTuneId); // ['data' => [...], ...]
+```
+
+### `Moderations` Resource
+
+#### `create`
+
+Classifies if text violates OpenAI's Content Policy.
+
+```php
+$client->moderations()->create($parameters); // ['id' => 'modr-5MWoLO', ...]
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -36,19 +36,6 @@ $result = $client->completions()->create([
 echo $result['choices'][0]['text']; // an open-source, widely-used, server-side scripting language.
 ```
 
-## TODO
-
-
-
-- [x] Models
-- [x] Completions
-- [x] Edits
-- [x] Embeddings
-- [x] Files
-- [x] FineTunes
-- [x] Moderations
-- [ ] Classifications
-
 ## Usage
 
 ### `Models` Resource
@@ -105,7 +92,7 @@ Creates an embedding vector representing the input text.
 
 ```php
 $client->embeddings()->create(); // ['data' => [...], ...]
-```````
+```
 
 ### `Files` Resource
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -11,6 +11,7 @@ use OpenAI\Resources\Embeddings;
 use OpenAI\Resources\Files;
 use OpenAI\Resources\FineTunes;
 use OpenAI\Resources\Models;
+use OpenAI\Resources\Moderations;
 
 final class Client
 {
@@ -81,5 +82,15 @@ final class Client
     public function fineTunes(): FineTunes
     {
         return new FineTunes($this->transporter);
+    }
+
+    /**
+     * Given a input text, outputs if the model classifies it as violating OpenAI's content policy.
+     *
+     * @see https://beta.openai.com/docs/api-reference/moderations/create
+     */
+    public function moderations(): Moderations
+    {
+        return new Moderations($this->transporter);
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -87,7 +87,7 @@ final class Client
     /**
      * Given a input text, outputs if the model classifies it as violating OpenAI's content policy.
      *
-     * @see https://beta.openai.com/docs/api-reference/moderations/create
+     * @see https://beta.openai.com/docs/api-reference/moderations
      */
     public function moderations(): Moderations
     {

--- a/src/Client.php
+++ b/src/Client.php
@@ -9,6 +9,7 @@ use OpenAI\Resources\Completions;
 use OpenAI\Resources\Edits;
 use OpenAI\Resources\Embeddings;
 use OpenAI\Resources\Files;
+use OpenAI\Resources\FineTunes;
 use OpenAI\Resources\Models;
 
 final class Client
@@ -70,5 +71,15 @@ final class Client
     public function models(): Models
     {
         return new Models($this->transporter);
+    }
+
+    /**
+     * Manage fine-tuning jobs to tailor a model to your specific training data.
+     *
+     * @see https://beta.openai.com/docs/api-reference/fine-tunes
+     */
+    public function fineTunes(): FineTunes
+    {
+        return new FineTunes($this->transporter);
     }
 }

--- a/src/Resources/FineTunes.php
+++ b/src/Resources/FineTunes.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Resources;
+
+use OpenAI\ValueObjects\Transporter\Payload;
+
+final class FineTunes
+{
+    use Concerns\Transportable;
+
+    /**
+     * Creates a job that fine-tunes a specified model from a given dataset.
+     *
+     * Response includes details of the enqueued job including job status and the name of the fine-tuned models once complete.
+     *
+     * @see https://beta.openai.com/docs/api-reference/fine-tunes/create
+     *
+     * @param  array<string, mixed>  $parameters
+     * @return array<string, mixed>
+     */
+    public function create(array $parameters): array
+    {
+        $payload = Payload::create('fine-tunes', $parameters);
+
+        /** @var array<string, mixed> $result */
+        $result = $this->transporter->requestObject($payload);
+
+        return $result;
+    }
+
+    /**
+     * List your organization's fine-tuning jobs.
+     *
+     * @see https://beta.openai.com/docs/api-reference/fine-tunes/list
+     *
+     * @return array<string, array<int, array<string, mixed>>>
+     */
+    public function list(): array
+    {
+        $payload = Payload::list('fine-tunes');
+
+        /** @var array<string, array<int, array<string, mixed>>> $result */
+        $result = $this->transporter->requestObject($payload);
+
+        return $result;
+    }
+
+    /**
+     * Gets info about the fine-tune job.
+     *
+     * @see https://beta.openai.com/docs/api-reference/fine-tunes/list
+     *
+     * @return array<string, mixed>
+     */
+    public function retrieve(string $fineTuneId): array
+    {
+        $payload = Payload::retrieve('fine-tunes', $fineTuneId);
+
+        return $this->transporter->requestObject($payload);
+    }
+
+    /**
+     * Immediately cancel a fine-tune job.
+     *
+     * @see https://beta.openai.com/docs/api-reference/fine-tunes/cancel
+     *
+     * @return array<string, mixed>
+     */
+    public function cancel(string $fineTuneId): array
+    {
+        $payload = Payload::cancel('fine-tunes', $fineTuneId);
+
+        return $this->transporter->requestObject($payload);
+    }
+
+    /**
+     * Get fine-grained status updates for a fine-tune job.
+     *
+     * @see https://beta.openai.com/docs/api-reference/fine-tunes/events
+     *
+     * @return array<string, array<int, array<string, mixed>>>
+     */
+    public function listEvents(string $fineTuneId): array
+    {
+        $payload = Payload::retrieve('fine-tunes', $fineTuneId, '/events');
+
+        /** @var array<string, array<int, array<string, mixed>>> $result */
+        $result = $this->transporter->requestObject($payload);
+
+        return $result;
+    }
+}

--- a/src/Resources/Models.php
+++ b/src/Resources/Models.php
@@ -40,4 +40,18 @@ final class Models
 
         return $this->transporter->requestObject($payload);
     }
+
+    /**
+     * Delete a fine-tuned model. You must have the Owner role in your organization.
+     *
+     * @see https://beta.openai.com/docs/api-reference/fine-tunes/delete-model
+     *
+     * @return array<string, mixed>
+     */
+    public function delete(string $model): array
+    {
+        $payload = Payload::delete('models', $model);
+
+        return $this->transporter->requestObject($payload);
+    }
 }

--- a/src/Resources/Moderations.php
+++ b/src/Resources/Moderations.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Resources;
+
+use OpenAI\ValueObjects\Transporter\Payload;
+
+final class Moderations
+{
+    use Concerns\Transportable;
+
+    /**
+     * Classifies if text violates OpenAI's Content Policy.
+     *
+     * @see https://beta.openai.com/docs/api-reference/moderations/create
+     *
+     * @param  array<string, mixed>  $parameters
+     * @return array<string, mixed>
+     */
+    public function create(array $parameters): array
+    {
+        $payload = Payload::create('moderations', $parameters);
+
+        /** @var array<string, mixed> $result */
+        $result = $this->transporter->requestObject($payload);
+
+        return $result;
+    }
+}

--- a/src/ValueObjects/ResourceUri.php
+++ b/src/ValueObjects/ResourceUri.php
@@ -46,9 +46,9 @@ final class ResourceUri implements Stringable
     /**
      * Creates a new ResourceUri value object that retrieves the given resource.
      */
-    public static function retrieve(string $resource, string $id): self
+    public static function retrieve(string $resource, string $id, string $suffix): self
     {
-        return new self("{$resource}/{$id}");
+        return new self("{$resource}/{$id}{$suffix}");
     }
 
     /**
@@ -57,6 +57,14 @@ final class ResourceUri implements Stringable
     public static function retrieveContent(string $resource, string $id): self
     {
         return new self("{$resource}/{$id}/content");
+    }
+
+    /**
+     * Creates a new ResourceUri value object that cancels the given resource.
+     */
+    public static function cancel(string $resource, string $id): self
+    {
+        return new self("{$resource}/{$id}/cancel");
     }
 
     /**

--- a/src/ValueObjects/Transporter/Payload.php
+++ b/src/ValueObjects/Transporter/Payload.php
@@ -44,11 +44,11 @@ final class Payload
     /**
      * Creates a new Payload value object from the given parameters.
      */
-    public static function retrieve(string $resource, string $id): self
+    public static function retrieve(string $resource, string $id, string $suffix = ''): self
     {
         $contentType = ContentType::JSON;
         $method = Method::GET;
-        $uri = ResourceUri::retrieve($resource, $id);
+        $uri = ResourceUri::retrieve($resource, $id, $suffix);
 
         return new self($contentType, $method, $uri);
     }
@@ -91,6 +91,18 @@ final class Payload
         $uri = ResourceUri::upload($resource);
 
         return new self($contentType, $method, $uri, $parameters);
+    }
+
+    /**
+     * Creates a new Payload value object from the given parameters.
+     */
+    public static function cancel(string $resource, string $id): self
+    {
+        $contentType = ContentType::JSON;
+        $method = Method::POST;
+        $uri = ResourceUri::cancel($resource, $id);
+
+        return new self($contentType, $method, $uri);
     }
 
     /**

--- a/tests/Fixtures/FineTune.php
+++ b/tests/Fixtures/FineTune.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @return array<string, mixed>
+ */
+function fineTuneResource(): array
+{
+    return [
+        'id' => 'ft-AF1WoRqd3aJAHsqc9NY7iL8F',
+        'object' => 'fine-tune',
+        'model' => 'curie',
+        'created_at' => 1614807352,
+        'events' => [
+            fineTuneEventResource(),
+            fineTuneEventResource(),
+        ],
+        'fine_tuned_model' => 'curie => ft-acmeco-2021-03-03-21-44-20',
+        'hyperparams' => [
+            'batch_size' => 4,
+            'learning_rate_multiplier' => 0.1,
+            'n_epochs' => 4,
+            'prompt_loss_weight' => 0.1,
+        ],
+        'organization_id' => 'org-jwe45798ASN82s',
+        'result_files' => [
+            fileResource(),
+            fileResource(),
+        ],
+        'status' => 'succeeded',
+        'validation_files' => [],
+        'training_files' => [
+            fileResource(),
+            fileResource(),
+        ],
+        'updated_at' => 1614807865,
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function fineTuneEventResource(): array
+{
+    return [
+        'object' => 'fine-tune-event',
+        'created_at' => 1614807352,
+        'level' => 'info',
+        'message' => 'Job enqueued. Waiting for jobs ahead to complete. Queue number =>  0.',
+    ];
+}

--- a/tests/Fixtures/Model.php
+++ b/tests/Fixtures/Model.php
@@ -28,3 +28,15 @@ function model(): array
         'parent' => null,
     ];
 }
+
+/**
+ * @return array<string, mixed>
+ */
+function fineTunedModelDeleteResource(): array
+{
+    return [
+        'id' => 'curie:ft-acmeco-2021-03-03-21-44-20',
+        'object' => 'model',
+        'deleted' => true,
+    ];
+}

--- a/tests/Fixtures/Moderation.php
+++ b/tests/Fixtures/Moderation.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @return array<string, mixed>
+ */
+function moderationResource(): array
+{
+    return [
+        'id' => 'modr-5MWoLO',
+        'model' => 'text-moderation-001',
+        'results' => [
+            [
+                'categories' => [
+                    'hate' => false,
+                    'hate/threatening' => true,
+                    'self-harm' => false,
+                    'sexual' => false,
+                    'sexual/minors' => false,
+                    'violence' => true,
+                    'violence/graphic' => false,
+                ],
+                'category_scores' => [
+                    'hate' => 0.22714105248451233,
+                    'hate/threatening' => 0.4132447838783264,
+                    'self-harm' => 0.005232391878962517,
+                    'sexual' => 0.01407341007143259,
+                    'sexual/minors' => 0.0038522258400917053,
+                    'violence' => 0.9223177433013916,
+                    'violence/graphic' => 0.036865197122097015,
+                ],
+                'flagged' => true,
+            ],
+        ],
+    ];
+}

--- a/tests/Resources/FineTunes.php
+++ b/tests/Resources/FineTunes.php
@@ -1,0 +1,95 @@
+<?php
+
+test('create', function () {
+    $client = mockClient('POST', 'fine-tunes', [
+        'training_file' => 'file-XjGxS3KTG0uNmNOK362iJua3',
+        'validation_file' => 'file-XjGxS3KTG0uNmNOK362iJua3',
+        'model' => 'curie',
+        'n_epochs' => 4,
+        'batch_size' => null,
+        'learning_rate_multiplier' => null,
+        'prompt_loss_weight' => 0.01,
+        'compute_classification_metrics' => false,
+        'classification_n_classes' => null,
+        'classification_positive_class' => null,
+        'classification_betas' => [],
+        'suffix' => null,
+    ], [
+        fineTuneResource(),
+    ]);
+
+    $result = $client->fineTunes()->create([
+        'training_file' => 'file-XjGxS3KTG0uNmNOK362iJua3',
+        'validation_file' => 'file-XjGxS3KTG0uNmNOK362iJua3',
+        'model' => 'curie',
+        'n_epochs' => 4,
+        'batch_size' => null,
+        'learning_rate_multiplier' => null,
+        'prompt_loss_weight' => 0.01,
+        'compute_classification_metrics' => false,
+        'classification_n_classes' => null,
+        'classification_positive_class' => null,
+        'classification_betas' => [],
+        'suffix' => null,
+    ]);
+
+    expect($result)->toBeArray()->toBe([
+        fineTuneResource(),
+    ]);
+});
+
+test('list', function () {
+    $client = mockClient('GET', 'fine-tunes', [], [
+        'object' => 'list',
+        'data' => [
+            fineTuneResource(),
+            fineTuneResource(),
+        ],
+    ]);
+
+    $result = $client->fineTunes()->list();
+
+    expect($result)->toBeArray()->toBe([
+        'object' => 'list',
+        'data' => [
+            fineTuneResource(),
+            fineTuneResource(),
+        ],
+    ]);
+});
+
+test('retreive', function () {
+    $client = mockClient('GET', 'fine-tunes/ft-AF1WoRqd3aJAHsqc9NY7iL8F', [], fineTuneResource());
+
+    $result = $client->fineTunes()->retrieve('ft-AF1WoRqd3aJAHsqc9NY7iL8F');
+
+    expect($result)->toBeArray()->toBe(fineTuneResource());
+});
+
+test('cancel', function () {
+    $client = mockClient('POST', 'fine-tunes/ft-AF1WoRqd3aJAHsqc9NY7iL8F/cancel', [], fineTuneResource());
+
+    $result = $client->fineTunes()->cancel('ft-AF1WoRqd3aJAHsqc9NY7iL8F');
+
+    expect($result)->toBeArray()->toBe(fineTuneResource());
+});
+
+test('list events', function () {
+    $client = mockClient('GET', 'fine-tunes/ft-AF1WoRqd3aJAHsqc9NY7iL8F/events', [], [
+        'object' => 'list',
+        'data' => [
+            fineTuneEventResource(),
+            fineTuneEventResource(),
+        ],
+    ]);
+
+    $result = $client->fineTunes()->listEvents('ft-AF1WoRqd3aJAHsqc9NY7iL8F');
+
+    expect($result)->toBeArray()->toBe([
+        'object' => 'list',
+        'data' => [
+            fineTuneEventResource(),
+            fineTuneEventResource(),
+        ],
+    ]);
+});

--- a/tests/Resources/Models.php
+++ b/tests/Resources/Models.php
@@ -27,3 +27,11 @@ test('retreive', function () {
 
     expect($result)->toBeArray()->toBe(model());
 });
+
+test('delete fine tuned model', function () {
+    $client = mockClient('DELETE', 'models/curie:ft-acmeco-2021-03-03-21-44-20', [], fineTunedModelDeleteResource());
+
+    $result = $client->models()->delete('curie:ft-acmeco-2021-03-03-21-44-20');
+
+    expect($result)->toBeArray()->toBe(fineTunedModelDeleteResource());
+});

--- a/tests/Resources/Moderations.php
+++ b/tests/Resources/Moderations.php
@@ -1,0 +1,15 @@
+<?php
+
+test('create', function () {
+    $client = mockClient('POST', 'moderations', [
+        'model' => 'text-moderation-latest',
+        'input' => 'I want to kill them.',
+    ], moderationResource());
+
+    $result = $client->moderations()->create([
+        'model' => 'text-moderation-latest',
+        'input' => 'I want to kill them.',
+    ]);
+
+    expect($result)->toBeArray()->toBe(moderationResource());
+});


### PR DESCRIPTION
Implemented the last to endpoints.

Looks like the Classifications API is deprecated. Therefore I don't think it's worth implementing it: https://help.openai.com/en/articles/6272941-classifications-transition-guide