### PR TITLE
feat: add two more specific exception classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- More specific exceptions: `InvalidApiKeyException` and `InvalidRequestException`
+
 ## v0.1.0 (2022-10-20)
 ### Added
 - First version

--- a/src/Exceptions/ErrorException.php
+++ b/src/Exceptions/ErrorException.php
@@ -6,14 +6,14 @@ namespace OpenAI\Exceptions;
 
 use Exception;
 
-final class ErrorException extends Exception
+class ErrorException extends Exception
 {
     /**
      * Creates a new Exception instance.
      *
-     * @param  array{message: string, type: string, code: string}  $contents
+     * @param  array{message: string, type: string, code: ?string}  $contents
      */
-    public function __construct(private readonly array $contents)
+    public function __construct(protected readonly array $contents)
     {
         parent::__construct($contents['message']);
     }
@@ -37,7 +37,7 @@ final class ErrorException extends Exception
     /**
      * Returns the error type.
      */
-    public function getErrorCode(): string
+    public function getErrorCode(): ?string
     {
         return $this->contents['code'];
     }

--- a/src/Exceptions/InvalidApiKeyException.php
+++ b/src/Exceptions/InvalidApiKeyException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Exceptions;
+
+final class InvalidApiKeyException extends ErrorException
+{
+}

--- a/src/Exceptions/InvalidRequestException.php
+++ b/src/Exceptions/InvalidRequestException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Exceptions;
+
+final class InvalidRequestException extends ErrorException
+{
+}


### PR DESCRIPTION
Added a more fine granular exception handling for all so far known exceptions. But I wasn't able to find a documentation about all the errors the API possibly returns.

If the exception type is unknown it throws the existing `ErrorException`