### PR TITLE
Renamed ApiToken to ApiKey

### DIFF
--- a/src/OpenAI.php
+++ b/src/OpenAI.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use GuzzleHttp\Client as GuzzleClient;
 use OpenAI\Client;
 use OpenAI\Transporters\HttpTransporter;
-use OpenAI\ValueObjects\ApiToken;
+use OpenAI\ValueObjects\ApiKey;
 use OpenAI\ValueObjects\Transporter\BaseUri;
 use OpenAI\ValueObjects\Transporter\Headers;
 
@@ -14,13 +14,13 @@ final class OpenAI
     /**
      * Creates a new Open AI Client with the given API token.
      */
-    public static function client(string $apiToken, string $organization = null): Client
+    public static function client(string $apiKey, string $organization = null): Client
     {
-        $apiToken = ApiToken::from($apiToken);
+        $apiKey = ApiKey::from($apiKey);
 
         $baseUri = BaseUri::from('api.openai.com/v1');
 
-        $headers = Headers::withAuthorization($apiToken);
+        $headers = Headers::withAuthorization($apiKey);
 
         if ($organization !== null) {
             $headers = $headers->withOrganization($organization);

--- a/src/ValueObjects/ApiKey.php
+++ b/src/ValueObjects/ApiKey.php
@@ -12,7 +12,7 @@ use OpenAI\Contracts\Stringable;
 final class ApiKey implements Stringable
 {
     /**
-     * Creates a new API token value object.
+     * Creates a new API key value object.
      */
     private function __construct(public readonly string $apiKey)
     {

--- a/src/ValueObjects/ApiKey.php
+++ b/src/ValueObjects/ApiKey.php
@@ -9,19 +9,19 @@ use OpenAI\Contracts\Stringable;
 /**
  * @internal
  */
-final class ApiToken implements Stringable
+final class ApiKey implements Stringable
 {
     /**
      * Creates a new API token value object.
      */
-    private function __construct(public readonly string $apiToken)
+    private function __construct(public readonly string $apiKey)
     {
         // ..
     }
 
-    public static function from(string $apiToken): self
+    public static function from(string $apiKey): self
     {
-        return new self($apiToken);
+        return new self($apiKey);
     }
 
     /**
@@ -29,6 +29,6 @@ final class ApiToken implements Stringable
      */
     public function toString(): string
     {
-        return $this->apiToken;
+        return $this->apiKey;
     }
 }

--- a/src/ValueObjects/Transporter/Headers.php
+++ b/src/ValueObjects/Transporter/Headers.php
@@ -23,7 +23,7 @@ final class Headers
     }
 
     /**
-     * Creates a new Headers value object with the given API token.
+     * Creates a new Headers value object with the given API key.
      */
     public static function withAuthorization(ApiKey $apiKey): self
     {

--- a/src/ValueObjects/Transporter/Headers.php
+++ b/src/ValueObjects/Transporter/Headers.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\ValueObjects\Transporter;
 
 use OpenAI\Enums\Transporter\ContentType;
-use OpenAI\ValueObjects\ApiToken;
+use OpenAI\ValueObjects\ApiKey;
 
 /**
  * @internal
@@ -25,10 +25,10 @@ final class Headers
     /**
      * Creates a new Headers value object with the given API token.
      */
-    public static function withAuthorization(ApiToken $apiToken): self
+    public static function withAuthorization(ApiKey $apiKey): self
     {
         return new self([
-            'Authorization' => "Bearer {$apiToken->toString()}",
+            'Authorization' => "Bearer {$apiKey->toString()}",
         ]);
     }
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,7 +2,7 @@
 
 use OpenAI\Client;
 use OpenAI\Contracts\Transporter;
-use OpenAI\ValueObjects\ApiToken;
+use OpenAI\ValueObjects\ApiKey;
 use OpenAI\ValueObjects\Transporter\BaseUri;
 use OpenAI\ValueObjects\Transporter\Headers;
 use OpenAI\ValueObjects\Transporter\Payload;
@@ -16,7 +16,7 @@ function mockClient(string $method, string $resource, array $params, array|strin
         ->once()
         ->withArgs(function (Payload $payload) use ($method, $resource) {
             $baseUri = BaseUri::from('api.openai.com/v1');
-            $headers = Headers::withAuthorization(ApiToken::from('foo'));
+            $headers = Headers::withAuthorization(ApiKey::from('foo'));
 
             $request = $payload->toRequest($baseUri, $headers);
 

--- a/tests/Transporters/HttpTransporter.php
+++ b/tests/Transporters/HttpTransporter.php
@@ -8,7 +8,7 @@ use OpenAI\Exceptions\ErrorException;
 use OpenAI\Exceptions\TransporterException;
 use OpenAI\Exceptions\UnserializableResponse;
 use OpenAI\Transporters\HttpTransporter;
-use OpenAI\ValueObjects\ApiToken;
+use OpenAI\ValueObjects\ApiKey;
 use OpenAI\ValueObjects\Transporter\BaseUri;
 use OpenAI\ValueObjects\Transporter\Headers;
 use OpenAI\ValueObjects\Transporter\Payload;
@@ -17,12 +17,12 @@ use Psr\Http\Client\ClientInterface;
 beforeEach(function () {
     $this->client = Mockery::mock(ClientInterface::class);
 
-    $apiToken = ApiToken::from('foo');
+    $apiKey = ApiKey::from('foo');
 
     $this->http = new HttpTransporter(
         $this->client,
         BaseUri::from('api.openai.com/v1'),
-        Headers::withAuthorization($apiToken)->withContentType(ContentType::JSON),
+        Headers::withAuthorization($apiKey)->withContentType(ContentType::JSON),
     );
 });
 
@@ -108,7 +108,7 @@ test('request object client errors', function () {
     $payload = Payload::list('models');
 
     $baseUri = BaseUri::from('api.openai.com');
-    $headers = Headers::withAuthorization(ApiToken::from('foo'));
+    $headers = Headers::withAuthorization(ApiKey::from('foo'));
 
     $this->client
         ->shouldReceive('sendRequest')
@@ -177,7 +177,7 @@ test('request content client errors', function () {
     $payload = Payload::list('models');
 
     $baseUri = BaseUri::from('api.openai.com');
-    $headers = Headers::withAuthorization(ApiToken::from('foo'));
+    $headers = Headers::withAuthorization(ApiKey::from('foo'));
 
     $this->client
         ->shouldReceive('sendRequest')

--- a/tests/ValueObjects/ApiToken.php
+++ b/tests/ValueObjects/ApiToken.php
@@ -2,10 +2,10 @@
 
 // Generate test for API token value object...
 
-use OpenAI\ValueObjects\ApiToken;
+use OpenAI\ValueObjects\ApiKey;
 
 it('can be created from a string', function () {
-    $apiToken = ApiToken::from('foo');
+    $apiKey = ApiKey::from('foo');
 
-    expect($apiToken->toString())->toBe('foo');
+    expect($apiKey->toString())->toBe('foo');
 });

--- a/tests/ValueObjects/ApiToken.php
+++ b/tests/ValueObjects/ApiToken.php
@@ -1,6 +1,6 @@
 <?php
 
-// Generate test for API token value object...
+// Generate test for API key value object...
 
 use OpenAI\ValueObjects\ApiKey;
 

--- a/tests/ValueObjects/Transporter/Headers.php
+++ b/tests/ValueObjects/Transporter/Headers.php
@@ -4,7 +4,7 @@ use OpenAI\Enums\Transporter\ContentType;
 use OpenAI\ValueObjects\ApiKey;
 use OpenAI\ValueObjects\Transporter\Headers;
 
-it('can be created from an API Token', function () {
+it('can be created from an API Key', function () {
     $headers = Headers::withAuthorization(ApiKey::from('foo'));
 
     expect($headers->toArray())->toBe([

--- a/tests/ValueObjects/Transporter/Headers.php
+++ b/tests/ValueObjects/Transporter/Headers.php
@@ -1,11 +1,11 @@
 <?php
 
 use OpenAI\Enums\Transporter\ContentType;
-use OpenAI\ValueObjects\ApiToken;
+use OpenAI\ValueObjects\ApiKey;
 use OpenAI\ValueObjects\Transporter\Headers;
 
 it('can be created from an API Token', function () {
-    $headers = Headers::withAuthorization(ApiToken::from('foo'));
+    $headers = Headers::withAuthorization(ApiKey::from('foo'));
 
     expect($headers->toArray())->toBe([
         'Authorization' => 'Bearer foo',
@@ -13,7 +13,7 @@ it('can be created from an API Token', function () {
 });
 
 it('can have content/type', function () {
-    $headers = Headers::withAuthorization(ApiToken::from('foo'))
+    $headers = Headers::withAuthorization(ApiKey::from('foo'))
         ->withContentType(ContentType::JSON);
 
     expect($headers->toArray())->toBe([
@@ -23,7 +23,7 @@ it('can have content/type', function () {
 });
 
 it('can have organization', function () {
-    $headers = Headers::withAuthorization(ApiToken::from('foo'))
+    $headers = Headers::withAuthorization(ApiKey::from('foo'))
         ->withContentType(ContentType::JSON)
         ->withOrganization('nunomaduro');
 

--- a/tests/ValueObjects/Transporter/Payload.php
+++ b/tests/ValueObjects/Transporter/Payload.php
@@ -1,7 +1,7 @@
 <?php
 
 use OpenAI\Enums\Transporter\ContentType;
-use OpenAI\ValueObjects\ApiToken;
+use OpenAI\ValueObjects\ApiKey;
 use OpenAI\ValueObjects\Transporter\BaseUri;
 use OpenAI\ValueObjects\Transporter\Headers;
 use OpenAI\ValueObjects\Transporter\Payload;
@@ -10,7 +10,7 @@ it('has a method', function () {
     $payload = Payload::create('models', []);
 
     $baseUri = BaseUri::from('api.openai.com/v1');
-    $headers = Headers::withAuthorization(ApiToken::from('foo'))->withContentType(ContentType::JSON);
+    $headers = Headers::withAuthorization(ApiKey::from('foo'))->withContentType(ContentType::JSON);
 
     expect($payload->toRequest($baseUri, $headers)->getMethod())->toBe('POST');
 });
@@ -19,7 +19,7 @@ it('has a uri', function () {
     $payload = Payload::list('models');
 
     $baseUri = BaseUri::from('api.openai.com/v1');
-    $headers = Headers::withAuthorization(ApiToken::from('foo'))->withContentType(ContentType::JSON);
+    $headers = Headers::withAuthorization(ApiKey::from('foo'))->withContentType(ContentType::JSON);
 
     $uri = $payload->toRequest($baseUri, $headers)->getUri();
 
@@ -32,7 +32,7 @@ test('get verb does not have a body', function () {
     $payload = Payload::list('models');
 
     $baseUri = BaseUri::from('api.openai.com/v1');
-    $headers = Headers::withAuthorization(ApiToken::from('foo'))->withContentType(ContentType::JSON);
+    $headers = Headers::withAuthorization(ApiKey::from('foo'))->withContentType(ContentType::JSON);
 
     expect($payload->toRequest($baseUri, $headers)->getBody()->getContents())->toBe('');
 });
@@ -43,7 +43,7 @@ test('post verb has a body', function () {
     ]);
 
     $baseUri = BaseUri::from('api.openai.com/v1');
-    $headers = Headers::withAuthorization(ApiToken::from('foo'))->withContentType(ContentType::JSON);
+    $headers = Headers::withAuthorization(ApiKey::from('foo'))->withContentType(ContentType::JSON);
 
     expect($payload->toRequest($baseUri, $headers)->getBody()->getContents())->toBe(json_encode([
         'name' => 'test',
@@ -57,7 +57,7 @@ test('builds upload request', function () {
     ]);
 
     $baseUri = BaseUri::from('api.openai.com/v1');
-    $headers = Headers::withAuthorization(ApiToken::from('foo'));
+    $headers = Headers::withAuthorization(ApiKey::from('foo'));
 
     $request = $payload->toRequest($baseUri, $headers);
 


### PR DESCRIPTION
This PR is introduced to replace the term ApiToken|apiToken to ApiKey|apiKey as mentioned by Nuno in PR Request.

https://github.com/openai-php/client/issues/23

Also ran the test for cross check. All of them are passed.

![image](https://user-images.githubusercontent.com/24652061/209798586-423ca022-31e8-47c6-a0fc-2690200dd10d.png)
