### PR TITLE
#30 Add method to create client with custom base URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ $result = $client->completions()->create([
 echo $result['choices'][0]['text']; // an open-source, widely-used, server-side scripting language.
 ```
 
+You can also instantiate the client with an organization or with a custom base api URI:
+
+```php
+$client = OpenAI::factory('YOUR_API_KEY')
+    ->withOrganization('YOUR_ORGANIZATION')
+    ->withBaseUri('CUSTOM_BASE_URI')
+    ->make();
+```
+
 ## Usage
 
 ### `Models` Resource

--- a/src/Factory/ClientFactory.php
+++ b/src/Factory/ClientFactory.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Factory;
+
+use GuzzleHttp\Client as GuzzleClient;
+use OpenAI\Client;
+use OpenAI\Transporters\HttpTransporter;
+use OpenAI\ValueObjects\ApiKey;
+use OpenAI\ValueObjects\Transporter\BaseUri;
+use OpenAI\ValueObjects\Transporter\Headers;
+
+final class ClientFactory
+{
+    public function __construct(
+        private readonly string $apiKey
+    ) {
+    }
+
+    private string $baseUri = 'api.openai.com/v1';
+
+    private ?string $organization = null;
+
+    public function make(): Client
+    {
+        $apiKey = ApiKey::from($this->apiKey);
+
+        $baseUri = BaseUri::from($this->baseUri);
+
+        $headers = Headers::withAuthorization($apiKey);
+
+        if ($this->organization !== null) {
+            $headers = $headers->withOrganization($this->organization);
+        }
+
+        $client = new GuzzleClient();
+
+        $transporter = new HttpTransporter($client, $baseUri, $headers);
+
+        return new Client($transporter);
+    }
+
+    public function withBaseUri(string $baseUri): self
+    {
+        $this->baseUri = $baseUri;
+
+        return $this;
+    }
+
+    public function withOrganization(?string $organization): self
+    {
+        $this->organization = $organization;
+
+        return $this;
+    }
+}

--- a/src/OpenAI.php
+++ b/src/OpenAI.php
@@ -2,34 +2,26 @@
 
 declare(strict_types=1);
 
-use GuzzleHttp\Client as GuzzleClient;
 use OpenAI\Client;
-use OpenAI\Transporters\HttpTransporter;
-use OpenAI\ValueObjects\ApiKey;
-use OpenAI\ValueObjects\Transporter\BaseUri;
-use OpenAI\ValueObjects\Transporter\Headers;
+use OpenAI\Factory\ClientFactory;
 
 final class OpenAI
 {
     /**
-     * Creates a new Open AI Client with the given API token.
+     * Creates a new Open AI Client with the given API key.
      */
     public static function client(string $apiKey, string $organization = null): Client
     {
-        $apiKey = ApiKey::from($apiKey);
+        return self::factory($apiKey)
+            ->withOrganization($organization)
+            ->make();
+    }
 
-        $baseUri = BaseUri::from('api.openai.com/v1');
-
-        $headers = Headers::withAuthorization($apiKey);
-
-        if ($organization !== null) {
-            $headers = $headers->withOrganization($organization);
-        }
-
-        $client = new GuzzleClient();
-
-        $transporter = new HttpTransporter($client, $baseUri, $headers);
-
-        return new Client($transporter);
+    /**
+     * Creates a new Open AI Client factory with the given API key.
+     */
+    public static function factory(string $apiKey): ClientFactory
+    {
+        return new ClientFactory($apiKey);
     }
 }

--- a/src/ValueObjects/Transporter/BaseUri.php
+++ b/src/ValueObjects/Transporter/BaseUri.php
@@ -32,6 +32,26 @@ final class BaseUri implements Stringable
      */
     public function toString(): string
     {
-        return "https://{$this->baseUri}/";
+        $baseUri = $this->baseUri;
+        $baseUriStartsWithProtocol = preg_match('#^https?://.+#', $baseUri) !== 0;
+        if (! $baseUriStartsWithProtocol) {
+            $baseUri = $this->prefixWithHttps($baseUri);
+        }
+
+        if (! str_ends_with('/', $baseUri)) {
+            return $this->suffixWithSlash($baseUri);
+        }
+
+        return $baseUri;
+    }
+
+    private function prefixWithHttps(string $string): string
+    {
+        return "https://{$string}";
+    }
+
+    private function suffixWithSlash(string $string): string
+    {
+        return "{$string}/";
     }
 }

--- a/tests/Factory/ClientFactory.php
+++ b/tests/Factory/ClientFactory.php
@@ -1,0 +1,57 @@
+<?php
+
+use GuzzleHttp\Client as GuzzleClient;
+use OpenAI\Client;
+use OpenAI\Factory\ClientFactory;
+use OpenAI\Transporters\HttpTransporter;
+use OpenAI\ValueObjects\ApiKey;
+use OpenAI\ValueObjects\Transporter\BaseUri;
+use OpenAI\ValueObjects\Transporter\Headers;
+
+it('may create a client', function () {
+    $openAI = (new ClientFactory('foo'))
+        ->make();
+
+    $expected = new Client(
+        new HttpTransporter(
+            new GuzzleClient(),
+            BaseUri::from('api.openai.com/v1'),
+            Headers::withAuthorization(ApiKey::from('foo'))
+        )
+    );
+
+    expect($openAI)->toEqual($expected);
+});
+
+it('may create a client with base URI', function () {
+    $openAI = (new ClientFactory('foo'))
+        ->withBaseUri('http://api.custom-domain.com/v1')
+        ->make();
+
+    $expected = new Client(
+        new HttpTransporter(
+            new GuzzleClient(),
+            BaseUri::from('http://api.custom-domain.com/v1'),
+            Headers::withAuthorization(ApiKey::from('foo'))
+        )
+    );
+
+    expect($openAI)->toEqual($expected);
+});
+
+it('may create a client with organization', function () {
+    $openAI = (new ClientFactory('foo'))
+        ->withOrganization('bar')
+        ->make();
+
+    $expected = new Client(
+        new HttpTransporter(
+            new GuzzleClient(),
+            BaseUri::from('api.openai.com/v1'),
+            Headers::withAuthorization(ApiKey::from('foo'))
+                ->withOrganization('bar')
+        )
+    );
+
+    expect($openAI)->toEqual($expected);
+});

--- a/tests/OpenAI.php
+++ b/tests/OpenAI.php
@@ -1,6 +1,7 @@
 <?php
 
 use OpenAI\Client;
+use OpenAI\Factory\ClientFactory;
 
 it('may create a client', function () {
     $openAI = OpenAI::client('foo');
@@ -12,4 +13,10 @@ it('sets organization when provided', function () {
     $openAI = OpenAI::client('foo', 'nunomaduro');
 
     expect($openAI)->toBeInstanceOf(Client::class);
+});
+
+it('may create a client factory', function () {
+    $openAI = OpenAI::factory('foo');
+
+    expect($openAI)->toBeInstanceOf(ClientFactory::class);
 });

--- a/tests/ValueObjects/Transporter/BaseUri.php
+++ b/tests/ValueObjects/Transporter/BaseUri.php
@@ -2,8 +2,21 @@
 
 use OpenAI\ValueObjects\Transporter\BaseUri;
 
-it('can be created from a string', function () {
-    $baseUri = BaseUri::from('api.openai.com/v1');
+it('can be created from a string', function (string $expected, string $string) {
+    $baseUri = BaseUri::from($string);
 
-    expect($baseUri->toString())->toBe('https://api.openai.com/v1/');
-});
+    expect($baseUri->toString())->toBe($expected);
+})->with([
+    'without protocol' => [
+        'expected' => 'https://api.openai.com/v1/',
+        'string' => 'api.openai.com/v1',
+    ],
+    'with https protocol' => [
+        'expected' => 'https://api.openai.com/v1/',
+        'string' => 'https://api.openai.com/v1',
+    ],
+    'with http protocol' => [
+        'expected' => 'http://api.openai.com/v1/',
+        'string' => 'http://api.openai.com/v1',
+    ],
+]);


### PR DESCRIPTION
This solves #30. Please also see my comment here https://github.com/openai-php/client/issues/30#issuecomment-1367486440

`BaseUri::toString` will now check, if the given base URI starts with a protocol. If not, it adds `https://` as protocol as prefix to the URI.

Also, the method will now check, if the given base URI ends with a slash and only append a trailing slash to it, if not.

That can be used, so users can create clients with a custom base URI, that is not required to use `https` as protocol, e.g.

```php
$client = OpenAI::clientWithBaseUri('sk-...', 'http://mock-api/v1');
```