### PR TITLE
Fixed broken getting of body as a string

### DIFF
--- a/src/Transporters/HttpTransporter.php
+++ b/src/Transporters/HttpTransporter.php
@@ -44,7 +44,7 @@ final class HttpTransporter implements Transporter
             throw new TransporterException($clientException);
         }
 
-        $contents = $response->getBody()->getContents();
+        $contents = (string) $response->getBody();
 
         try {
             /** @var array{error?: array{message: string, type: string, code: string}} $response */


### PR DESCRIPTION
`->getContents()` only reads the stream from wherever the current position is - it does not rewind it. This can be hugely problematic if, for example, a logging middleware is attached to the client, which leaves the pointer not at the start of the stream/