### PR TITLE
Fix undefined Array Key 'events'

### DIFF
--- a/src/Responses/FineTunes/RetrieveResponse.php
+++ b/src/Responses/FineTunes/RetrieveResponse.php
@@ -49,7 +49,7 @@ final class RetrieveResponse implements Response
     {
         $events = array_map(fn (array $result): RetrieveResponseEvent => RetrieveResponseEvent::from(
             $result
-        ), $attributes['events']);
+        ), $attributes['events'] ?? []);
 
         $resultFiles = array_map(fn (array $result): RetrieveResponseFile => RetrieveResponseFile::from(
             $result


### PR DESCRIPTION
#38 

I was getting the same error as this issue, this resolves it for me. Simply returning an empty array for the 'events' key if it's not present in the response from OpenAI