### PR TITLE
Missing namespace causes OpenAI class to be unusable

### DIFF
--- a/src/OpenAI.php
+++ b/src/OpenAI.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace OpenAI;
+
 use GuzzleHttp\Client as GuzzleClient;
 use OpenAI\Client;
 use OpenAI\Transporters\HttpTransporter;


### PR DESCRIPTION
Since the namespace was not included, importing the class to use the static `client` method is impossible. It also creates a situation where the documentation is wrong since it uses this class and static method combination. We should check if anywhere else has such issues and release this ASAP in a fix version.