### PR TITLE
Make finishReason nullable #51

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ foreach ($response->choices as $result) {
     $result->text; // '\n\nThis is a test'
     $result->index; // 0
     $result->logprobs; // null
-    $result->finishReason; // 'length'
+    $result->finishReason; // 'length' or null
 }
 
 $response->usage->promptTokens; // 5,

--- a/src/Responses/Completions/CreateResponseChoice.php
+++ b/src/Responses/Completions/CreateResponseChoice.php
@@ -10,7 +10,7 @@ final class CreateResponseChoice
         public readonly string $text,
         public readonly int $index,
         public readonly ?CreateResponseChoiceLogprobs $logprobs,
-        public readonly string $finishReason,
+        public readonly ?string $finishReason,
     ) {
     }
 

--- a/tests/Responses/Completions/CreateResponseChoice.php
+++ b/tests/Responses/Completions/CreateResponseChoice.php
@@ -10,7 +10,7 @@ test('from', function () {
         ->text->toBe("el, she elaborates more on the Corruptor's role, suggesting K")
         ->index->toBe(0)
         ->logprobs->toBe(null)
-        ->finishReason->toBe('length');
+        ->finishReason->toBeIn(['length', null]);
 });
 
 test('to array', function () {
@@ -27,7 +27,7 @@ test('from with logprobs', function () {
         ->text->toBe('PHP is')
         ->index->toBe(0)
         ->logprobs->toBeInstanceOf(CreateResponseChoiceLogprobs::class)
-        ->finishReason->toBe('length');
+        ->finishReason->toBeIn(['length', null]);
 });
 
 test('to array with logprobs', function () {


### PR DESCRIPTION
A recent change to the OpenAI API means that finish_reason is sometimes returned as NULL and causes an exception.

This change allows finishReason to be nullable.