### PR TITLE
Allows to change the HTTP client in the factory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,10 @@
     ],
     "require": {
         "php": "^8.1.0",
-        "guzzlehttp/guzzle": "^7.5.0"
+        "psr/http-client-implementation": "1.0"
     },
     "require-dev": {
+        "guzzlehttp/guzzle": "^7.5.0",
         "laravel/pint": "^1.6.0",
         "nunomaduro/collision": "^7.0.5",
         "pestphp/pest": "^2.0.0",
@@ -22,6 +23,9 @@
         "phpstan/phpstan": "^1.10.3",
         "rector/rector": "^0.14.8",
         "symfony/var-dumper": "^6.2.7"
+    },
+    "suggest": {
+        "guzzlehttp/guzzle": "^7.5.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,8 @@
     ],
     "require": {
         "php": "^8.1.0",
+        "guzzlehttp/psr7": "^2.4.4",
+        "php-http/discovery": "^1.14",
         "psr/http-client-implementation": "1.0"
     },
     "require-dev": {
@@ -23,9 +25,6 @@
         "phpstan/phpstan": "^1.10.3",
         "rector/rector": "^0.14.8",
         "symfony/var-dumper": "^6.2.7"
-    },
-    "suggest": {
-        "guzzlehttp/guzzle": "^7.5.0"
     },
     "autoload": {
         "psr-4": {
@@ -46,7 +45,8 @@
         "sort-packages": true,
         "preferred-install": "dist",
         "allow-plugins": {
-            "pestphp/pest-plugin": true
+            "pestphp/pest-plugin": true,
+            "php-http/discovery": false
         }
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^8.1.0",
         "guzzlehttp/psr7": "^2.4.4",
         "php-http/discovery": "^1.14",
-        "psr/http-client-implementation": "1.0"
+        "psr/http-client-implementation": "^1.0"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^7.5.0",

--- a/src/OpenAI.php
+++ b/src/OpenAI.php
@@ -27,7 +27,12 @@ final class OpenAI
             $headers = $headers->withOrganization($organization);
         }
 
-        $client ??= new GuzzleClient();
+        if (null === $client) {
+            if (!class_exists(GuzzleClient::class)) {
+                throw new \LogicException('Guzzle is not installed. Try running "composer require guzzlehttp/guzzle" or pass a PSR-18 client.');
+            }
+            $client = new GuzzleClient();
+        }
 
         $transporter = new HttpTransporter($client, $baseUri, $headers);
 

--- a/src/OpenAI.php
+++ b/src/OpenAI.php
@@ -8,13 +8,14 @@ use OpenAI\Transporters\HttpTransporter;
 use OpenAI\ValueObjects\ApiKey;
 use OpenAI\ValueObjects\Transporter\BaseUri;
 use OpenAI\ValueObjects\Transporter\Headers;
+use Psr\Http\Client\ClientInterface;
 
 final class OpenAI
 {
     /**
      * Creates a new Open AI Client with the given API token.
      */
-    public static function client(string $apiKey, string $organization = null): Client
+    public static function client(string $apiKey, string $organization = null, ClientInterface $client = null): Client
     {
         $apiKey = ApiKey::from($apiKey);
 
@@ -26,7 +27,7 @@ final class OpenAI
             $headers = $headers->withOrganization($organization);
         }
 
-        $client = new GuzzleClient();
+        $client ??= new GuzzleClient();
 
         $transporter = new HttpTransporter($client, $baseUri, $headers);
 

--- a/src/OpenAI.php
+++ b/src/OpenAI.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use GuzzleHttp\Client as GuzzleClient;
+use Http\Discovery\Psr18ClientDiscovery;
 use OpenAI\Client;
 use OpenAI\Transporters\HttpTransporter;
 use OpenAI\ValueObjects\ApiKey;
@@ -27,12 +27,7 @@ final class OpenAI
             $headers = $headers->withOrganization($organization);
         }
 
-        if (null === $client) {
-            if (!class_exists(GuzzleClient::class)) {
-                throw new \LogicException('Guzzle is not installed. Try running "composer require guzzlehttp/guzzle" or pass a PSR-18 client.');
-            }
-            $client = new GuzzleClient();
-        }
+        $client ??= Psr18ClientDiscovery::find();
 
         $transporter = new HttpTransporter($client, $baseUri, $headers);
 

--- a/tests/Arch.php
+++ b/tests/Arch.php
@@ -33,6 +33,7 @@ test('client')->expect('OpenAI\Client')->toOnlyUse([
 ]);
 
 test('openai')->expect('OpenAI')->toOnlyUse([
+    'Http\Discovery\Psr18ClientDiscovery',
     'Psr\Http\Client',
     'GuzzleHttp\Client',
     'GuzzleHttp\Psr7',

--- a/tests/OpenAI.php
+++ b/tests/OpenAI.php
@@ -1,9 +1,10 @@
 <?php
 
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
 use OpenAI\Client;
-use Psr\Http\Client\ClientInterface;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
 
 it('may create a client', function () {
     $openAI = OpenAI::client('foo');
@@ -18,15 +19,16 @@ it('sets organization when provided', function () {
 });
 
 it('accepts a custom http client', function () {
-    $client = new class implements ClientInterface
-    {
-        public function sendRequest(RequestInterface $request): ResponseInterface
-        {
-            throw new \LogicException('Not implemented');
-        }
-    };
-
+    $mock = new MockHandler([
+        new Response(200, [], '{"id":"test-id","object":"text_completion","created":1589478378,"model":"text-davinci-003","choices":[{"text":"\n\nThis is indeed a test","index":0,"logprobs":null,"finish_reason":"length"}],"usage":{"prompt_tokens":5,"completion_tokens":7,"total_tokens":12}}'),
+    ]);
+    $handlerStack = HandlerStack::create($mock);
+    $client = new GuzzleClient(['handler' => $handlerStack]);
     $openAI = OpenAI::client('foo', client: $client);
+    $response = $openAI->completions()->create([
+        'model' => 'text-davinci-003',
+        'prompt' => 'Say this is a test',
+    ]);
 
-    expect($openAI)->toBeInstanceOf(Client::class);
+    expect($response->id)->toBe('test-id');
 });

--- a/tests/OpenAI.php
+++ b/tests/OpenAI.php
@@ -1,6 +1,9 @@
 <?php
 
 use OpenAI\Client;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Client\ClientInterface;
 
 it('may create a client', function () {
     $openAI = OpenAI::client('foo');
@@ -10,6 +13,18 @@ it('may create a client', function () {
 
 it('sets organization when provided', function () {
     $openAI = OpenAI::client('foo', 'nunomaduro');
+
+    expect($openAI)->toBeInstanceOf(Client::class);
+});
+
+it('accepts a custom http client', function () {
+    $client = new class implements ClientInterface {
+        public function sendRequest(RequestInterface $request): ResponseInterface {
+            throw new \LogicException('Not implemented');
+        }
+    };
+
+    $openAI = OpenAI::client('foo', client: );
 
     expect($openAI)->toBeInstanceOf(Client::class);
 });

--- a/tests/OpenAI.php
+++ b/tests/OpenAI.php
@@ -1,9 +1,9 @@
 <?php
 
 use OpenAI\Client;
+use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Client\ClientInterface;
 
 it('may create a client', function () {
     $openAI = OpenAI::client('foo');
@@ -18,13 +18,15 @@ it('sets organization when provided', function () {
 });
 
 it('accepts a custom http client', function () {
-    $client = new class implements ClientInterface {
-        public function sendRequest(RequestInterface $request): ResponseInterface {
+    $client = new class implements ClientInterface
+    {
+        public function sendRequest(RequestInterface $request): ResponseInterface
+        {
             throw new \LogicException('Not implemented');
         }
     };
 
-    $openAI = OpenAI::client('foo', client: );
+    $openAI = OpenAI::client('foo', client: $client);
 
     expect($openAI)->toBeInstanceOf(Client::class);
 });


### PR DESCRIPTION
[Symfony integration](https://github.com/openai-php/client/issues/64) would be complete if the `symfony/http-client` could be used. Instead of duplicating the `OpenAI::client()` factory, I think it is more simple to allow a custom instance of `Psr\Http\Client\ClientInterface`. The [Symfony PSR-18 client](https://symfony.com/doc/current/http_client.html#psr-18-and-psr-17) would be used.