### PR TITLE
fix: set false GuzzleClient ssl laravel local developer

### DIFF
--- a/src/OpenAI.php
+++ b/src/OpenAI.php
@@ -14,7 +14,7 @@ final class OpenAI
     /**
      * Creates a new Open AI Client with the given API token.
      */
-    public static function client(string $apiKey, string $organization = null): Client
+    public static function client(string $apiKey, string $organization = null, bool $verify = true): Client
     {
         $apiKey = ApiKey::from($apiKey);
 
@@ -26,7 +26,7 @@ final class OpenAI
             $headers = $headers->withOrganization($organization);
         }
 
-        $client = new GuzzleClient();
+        $client = new GuzzleClient(['verify' => $verify]);
 
         $transporter = new HttpTransporter($client, $baseUri, $headers);
 


### PR DESCRIPTION
During local development laravel throws ssl error. So I chose to add via service provider the verify = false option when instantiating the GuzzleClient that way it will not verify the ssl during local development.