### PR TITLE
add testing ability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## v0.4.0 (2023-03-17)
+### Changed
+- Removed dependency for `guzzlehttp/guzzle` and use PSR-18 client discovery instead ([#75](https://github.com/openai-php/client/pull/75))
+- Add Client factory which allows for a custom HTTP client
+- Client factory further accepts custom HTTP headers, query parameters and API URI
+
 ## v0.3.5 (2023-03-08)
 ### Fixed
 - `status_details` can be a string in file responses. Affects Files and FineTunes resources ([#68](https://github.com/openai-php/client/pull/68))

--- a/README.md
+++ b/README.md
@@ -767,6 +767,24 @@ $client->completions()->assertNotSent();
 $client->assertNothingSent();
 ```
 
+To write tests expecting the API request to fail you can provide a `Throwable` object as the response.
+
+```php
+$client = new ClientFake([
+    new \OpenAI\Exceptions\ErrorException([
+        'message' => 'The model `gpt-1` does not exist',
+        'type' => 'invalid_request_error',
+        'code' => null,
+    ])
+]);
+
+// the `ErrorException` will be thrown
+$completion = $client->completions()->create([
+    'model' => 'text-davinci-003',
+    'prompt' => 'PHP is ',
+]);
+```
+
 ---
 
 OpenAI PHP is an open-sourced software licensed under the **[MIT license](https://opensource.org/licenses/MIT)**.

--- a/README.md
+++ b/README.md
@@ -741,6 +741,27 @@ $completion = $client->completions()->create([
 expect($completion['choices'][0]['text'])->toBe('awesome!');
 ```
 
+In case of a streamed response you can optionally provide a resource holding the fake response data.
+
+```php
+use OpenAI\Testing\ClientFake;
+use OpenAI\Responses\Chat\CreateStreamedResponse;
+
+$client = new ClientFake([
+    CreateStreamedResponse::fake(fopen('file.txt', 'r'););
+]);
+
+$completion = $client->chat()->createStreamed([
+        'model' => 'gpt-3.5-turbo',
+        'messages' => [
+            ['role' => 'user', 'content' => 'Hello!'],
+        ],
+]);
+
+expect($response->getIterator()->current())
+        ->id->toBe('chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl');
+```
+
 After the requests have been sent there are various methods to ensure that the expected requests were sent:
 
 ```php

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ First, install OpenAI via the [Composer](https://getcomposer.org/) package manag
 composer require openai-php/client
 ```
 
+Ensure that the `php-http/discovery` composer plugin is allowed to run or install a client manually if your project does not already have a PSR-18 client integrated.
+```bash
+composer require guzzlehttp/guzzle
+```
+
 Then, interact with OpenAI's API:
 
 ```php
@@ -51,6 +56,21 @@ $result = $client->completions()->create([
 ]);
 
 echo $result['choices'][0]['text']; // an open-source, widely-used, server-side scripting language.
+```
+
+If necessary, it is possible to configure and create a separate client.
+
+```php
+$yourApiKey = getenv('YOUR_API_KEY');
+
+$client = OpenAI::factory()
+    ->withApiKey($yourApiKey)
+    ->withOrganization('your-organization') // default: null
+    ->withBaseUri('openai.example.com/v1') // default: api.openai.com/v1
+    ->withHttpClient(new \GuzzleHttp\Client([])) // default: HTTP client found using PSR-18 HTTP Client Discovery
+    ->withHttpHeader('X-My-Header', 'foo')
+    ->withQueryParam('my-param', 'bar')
+    ->make();
 ```
 
 ## Usage

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
     },
     "require-dev": {
         "laravel/pint": "^1.6.0",
-        "nunomaduro/collision": "^7.0.5",
+        "nunomaduro/collision": "^7.1.0",
         "pestphp/pest": "^2.0.0",
         "pestphp/pest-plugin-arch": "^2.0.0",
         "pestphp/pest-plugin-mock": "^2.0.0",
-        "phpstan/phpstan": "^1.10.3",
+        "phpstan/phpstan": "^1.10.6",
         "rector/rector": "^0.14.8",
         "symfony/var-dumper": "^6.2.7"
     },

--- a/composer.json
+++ b/composer.json
@@ -7,13 +7,23 @@
         {
             "name": "Nuno Maduro",
             "email": "enunomaduro@gmail.com"
+        },
+        {
+            "name": "Sandro Gehri"
         }
     ],
     "require": {
         "php": "^8.1.0",
-        "guzzlehttp/guzzle": "^7.5.0"
+        "php-http/discovery": "^1.15.2",
+        "php-http/multipart-stream-builder": "^1.2.0",
+        "psr/http-client": "^1.0.1",
+        "psr/http-client-implementation": "^1.0.1",
+        "psr/http-factory-implementation": "*",
+        "psr/http-message": "^1.0.1"
     },
     "require-dev": {
+        "guzzlehttp/psr7": "^2.4.4",
+        "guzzlehttp/guzzle": "^7.5.0",
         "laravel/pint": "^1.6.0",
         "nunomaduro/collision": "^7.1.2",
         "pestphp/pest": "^2.0.0",
@@ -42,7 +52,8 @@
         "sort-packages": true,
         "preferred-install": "dist",
         "allow-plugins": {
-            "pestphp/pest-plugin": true
+            "pestphp/pest-plugin": true,
+            "php-http/discovery": false
         }
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
     },
     "require-dev": {
         "laravel/pint": "^1.6.0",
-        "nunomaduro/collision": "^7.1.0",
+        "nunomaduro/collision": "^7.1.2",
         "pestphp/pest": "^2.0.0",
         "pestphp/pest-plugin-arch": "^2.0.0",
         "pestphp/pest-plugin-mock": "^2.0.0",
-        "phpstan/phpstan": "^1.10.6",
+        "phpstan/phpstan": "^1.10.7",
         "rector/rector": "^0.14.8",
         "symfony/var-dumper": "^6.2.7"
     },

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,5 +2,8 @@ parameters:
     level: max
     paths:
         - src
+    excludePaths:
+            analyse:
+                - src/Testing
 
     reportUnmatchedIgnoredErrors: true

--- a/src/Client.php
+++ b/src/Client.php
@@ -8,6 +8,7 @@ use OpenAI\Contracts\Transporter;
 use OpenAI\Resources\Audio;
 use OpenAI\Resources\Chat;
 use OpenAI\Resources\Completions;
+use OpenAI\Resources\Contracts\AudioContract;
 use OpenAI\Resources\Edits;
 use OpenAI\Resources\Embeddings;
 use OpenAI\Resources\Files;
@@ -16,7 +17,7 @@ use OpenAI\Resources\Images;
 use OpenAI\Resources\Models;
 use OpenAI\Resources\Moderations;
 
-final class Client
+final class Client implements \OpenAI\Contracts\Client
 {
     /**
      * Creates a Client instance with the given API token.
@@ -32,7 +33,7 @@ final class Client
      *
      * @see https://beta.openai.com/docs/api-reference/completions
      */
-    public function completions(): Completions
+    public function completions(): Resources\Contracts\CompletionsContract
     {
         return new Completions($this->transporter);
     }
@@ -62,7 +63,7 @@ final class Client
      *
      * @see https://platform.openai.com/docs/api-reference/audio
      */
-    public function audio(): Audio
+    public function audio(): AudioContract
     {
         return new Audio($this->transporter);
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -8,7 +8,6 @@ use OpenAI\Contracts\Transporter;
 use OpenAI\Resources\Audio;
 use OpenAI\Resources\Chat;
 use OpenAI\Resources\Completions;
-use OpenAI\Resources\Contracts\AudioContract;
 use OpenAI\Resources\Edits;
 use OpenAI\Resources\Embeddings;
 use OpenAI\Resources\Files;
@@ -33,7 +32,7 @@ final class Client implements \OpenAI\Contracts\Client
      *
      * @see https://beta.openai.com/docs/api-reference/completions
      */
-    public function completions(): Resources\Contracts\CompletionsContract
+    public function completions(): Completions
     {
         return new Completions($this->transporter);
     }
@@ -63,7 +62,7 @@ final class Client implements \OpenAI\Contracts\Client
      *
      * @see https://platform.openai.com/docs/api-reference/audio
      */
-    public function audio(): AudioContract
+    public function audio(): Audio
     {
         return new Audio($this->transporter);
     }

--- a/src/Contracts/Client.php
+++ b/src/Contracts/Client.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace OpenAI\Contracts;
+
+use OpenAI\Resources\Contracts\AudioContract;
+use OpenAI\Resources\Contracts\ChatContract;
+use OpenAI\Resources\Contracts\CompletionsContract;
+use OpenAI\Resources\Contracts\EditsContract;
+use OpenAI\Resources\Contracts\EmbeddingsContract;
+use OpenAI\Resources\Contracts\FilesContract;
+use OpenAI\Resources\Contracts\FineTunesContract;
+use OpenAI\Resources\Contracts\ImagesContract;
+use OpenAI\Resources\Contracts\ModelsContract;
+use OpenAI\Resources\Contracts\ModerationsContract;
+
+interface Client
+{
+    /**
+     * Given a prompt, the model will return one or more predicted completions, and can also return the probabilities
+     * of alternative tokens at each position.
+     *
+     * @see https://beta.openai.com/docs/api-reference/completions
+     */
+    public function completions(): CompletionsContract;
+
+    /**
+     * Given a chat conversation, the model will return a chat completion response.
+     *
+     * @see https://platform.openai.com/docs/api-reference/chat
+     */
+    public function chat(): ChatContract;
+
+    /**
+     * Get a vector representation of a given input that can be easily consumed by machine learning models and algorithms.
+     *
+     * @see https://beta.openai.com/docs/api-reference/embeddings
+     */
+    public function embeddings(): EmbeddingsContract;
+
+    /**
+     * Learn how to turn audio into text.
+     *
+     * @see https://platform.openai.com/docs/api-reference/audio
+     */
+    public function audio(): AudioContract;
+
+    /**
+     * Given a prompt and an instruction, the model will return an edited version of the prompt.
+     *
+     * @see https://beta.openai.com/docs/api-reference/edits
+     */
+    public function edits(): EditsContract;
+
+    /**
+     * Files are used to upload documents that can be used with features like Fine-tuning.
+     *
+     * @see https://beta.openai.com/docs/api-reference/files
+     */
+    public function files(): FilesContract;
+
+    /**
+     * List and describe the various models available in the API.
+     *
+     * @see https://beta.openai.com/docs/api-reference/models
+     */
+    public function models(): ModelsContract;
+
+    /**
+     * Manage fine-tuning jobs to tailor a model to your specific training data.
+     *
+     * @see https://beta.openai.com/docs/api-reference/fine-tunes
+     */
+    public function fineTunes(): FineTunesContract;
+
+    /**
+     * Given a input text, outputs if the model classifies it as violating OpenAI's content policy.
+     *
+     * @see https://beta.openai.com/docs/api-reference/moderations
+     */
+    public function moderations(): ModerationsContract;
+
+    /**
+     * Given a prompt and/or an input image, the model will generate a new image.
+     *
+     * @see https://beta.openai.com/docs/api-reference/images
+     */
+    public function images(): ImagesContract;
+}

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace OpenAI;
+
+use Http\Discovery\Psr18ClientDiscovery;
+use OpenAI\Transporters\HttpTransporter;
+use OpenAI\ValueObjects\ApiKey;
+use OpenAI\ValueObjects\Transporter\BaseUri;
+use OpenAI\ValueObjects\Transporter\Headers;
+use OpenAI\ValueObjects\Transporter\QueryParams;
+use Psr\Http\Client\ClientInterface;
+
+final class Factory
+{
+    /**
+     * The API key for the requests.
+     */
+    private ?string $apiKey = null;
+
+    /**
+     * The organization for the requests.
+     */
+    private ?string $organization = null;
+
+    /**
+     * The HTTP client for the requests.
+     */
+    private ?ClientInterface $httpClient = null;
+
+    /**
+     * The base URI for the requests.
+     */
+    private ?string $baseUri = null;
+
+    /**
+     * The HTTP headers for the requests.
+     *
+     * @var array<string, string>
+     */
+    private array $headers = [];
+
+    /**
+     * The query parameters for the requests.
+     *
+     * @var array<string, string|int>
+     */
+    private array $queryParams = [];
+
+    /**
+     * Sets the API key for the requests.
+     */
+    public function withApiKey(string $apiKey): self
+    {
+        $this->apiKey = $apiKey;
+
+        return $this;
+    }
+
+    /**
+     * Sets the organization for the requests.
+     */
+    public function withOrganization(?string $organization): self
+    {
+        $this->organization = $organization;
+
+        return $this;
+    }
+
+    /**
+     * Sets the HTTP client for the requests.
+     * If no client is provided the factory will try to find one using PSR-18 HTTP Client Discovery.
+     */
+    public function withHttpClient(ClientInterface $client): self
+    {
+        $this->httpClient = $client;
+
+        return $this;
+    }
+
+    /**
+     * Sets the base URI for the requests.
+     * If no URI is provided the factory will use the default OpenAI API URI.
+     */
+    public function withBaseUri(string $baseUri): self
+    {
+        $this->baseUri = $baseUri;
+
+        return $this;
+    }
+
+    /**
+     * Adds a custom HTTP header to the requests.
+     */
+    public function withHttpHeader(string $name, string $value): self
+    {
+        $this->headers[$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Adds a custom query parameter to the request url.
+     */
+    public function withQueryParam(string $name, string $value): self
+    {
+        $this->queryParams[$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Creates a new Open AI Client.
+     */
+    public function make(): Client
+    {
+        $headers = Headers::create();
+
+        if ($this->apiKey !== null) {
+            $headers = Headers::withAuthorization(ApiKey::from($this->apiKey));
+        }
+
+        if ($this->organization !== null) {
+            $headers = $headers->withOrganization($this->organization);
+        }
+
+        foreach ($this->headers as $name => $value) {
+            $headers = $headers->withCustomHeader($name, $value);
+        }
+
+        $baseUri = BaseUri::from($this->baseUri ?: 'api.openai.com/v1');
+
+        $queryParams = QueryParams::create();
+        foreach ($this->queryParams as $name => $value) {
+            $queryParams = $queryParams->withParam($name, $value);
+        }
+
+        $client = $this->httpClient ??= Psr18ClientDiscovery::find();
+
+        $transporter = new HttpTransporter($client, $baseUri, $headers, $queryParams);
+
+        return new Client($transporter);
+    }
+}

--- a/src/OpenAI.php
+++ b/src/OpenAI.php
@@ -2,12 +2,8 @@
 
 declare(strict_types=1);
 
-use GuzzleHttp\Client as GuzzleClient;
 use OpenAI\Client;
-use OpenAI\Transporters\HttpTransporter;
-use OpenAI\ValueObjects\ApiKey;
-use OpenAI\ValueObjects\Transporter\BaseUri;
-use OpenAI\ValueObjects\Transporter\Headers;
+use OpenAI\Factory;
 
 final class OpenAI
 {
@@ -16,20 +12,17 @@ final class OpenAI
      */
     public static function client(string $apiKey, string $organization = null): Client
     {
-        $apiKey = ApiKey::from($apiKey);
+        return self::factory()
+            ->withApiKey($apiKey)
+            ->withOrganization($organization)
+            ->make();
+    }
 
-        $baseUri = BaseUri::from('api.openai.com/v1');
-
-        $headers = Headers::withAuthorization($apiKey);
-
-        if ($organization !== null) {
-            $headers = $headers->withOrganization($organization);
-        }
-
-        $client = new GuzzleClient();
-
-        $transporter = new HttpTransporter($client, $baseUri, $headers);
-
-        return new Client($transporter);
+    /**
+     * Creates a new factory instance to configure a custom Open AI Client
+     */
+    public static function factory(): Factory
+    {
+        return new Factory();
     }
 }

--- a/src/Resources/Audio.php
+++ b/src/Resources/Audio.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace OpenAI\Resources;
 
+use OpenAI\Resources\Contracts\AudioContract;
 use OpenAI\Responses\Audio\TranscriptionResponse;
 use OpenAI\Responses\Audio\TranslationResponse;
 use OpenAI\ValueObjects\Transporter\Payload;
 
-final class Audio
+final class Audio implements AudioContract
 {
     use Concerns\Transportable;
 

--- a/src/Resources/Chat.php
+++ b/src/Resources/Chat.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace OpenAI\Resources;
 
+use OpenAI\Resources\Contracts\ChatContract;
 use OpenAI\Responses\Chat\CreateResponse;
 use OpenAI\ValueObjects\Transporter\Payload;
 
-final class Chat
+final class Chat implements ChatContract
 {
     use Concerns\Transportable;
 

--- a/src/Resources/Completions.php
+++ b/src/Resources/Completions.php
@@ -7,7 +7,7 @@ namespace OpenAI\Resources;
 use OpenAI\Responses\Completions\CreateResponse;
 use OpenAI\ValueObjects\Transporter\Payload;
 
-final class Completions
+final class Completions implements \OpenAI\Resources\Contracts\CompletionsContract
 {
     use Concerns\Transportable;
 

--- a/src/Resources/Completions.php
+++ b/src/Resources/Completions.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace OpenAI\Resources;
 
+use OpenAI\Resources\Contracts\CompletionsContract;
 use OpenAI\Responses\Completions\CreateResponse;
 use OpenAI\ValueObjects\Transporter\Payload;
 
-final class Completions implements \OpenAI\Resources\Contracts\CompletionsContract
+final class Completions implements CompletionsContract
 {
     use Concerns\Transportable;
 

--- a/src/Resources/Contracts/AudioContract.php
+++ b/src/Resources/Contracts/AudioContract.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace OpenAI\Resources\Contracts;
+
+use OpenAI\Responses\Audio\TranscriptionResponse;
+use OpenAI\Responses\Audio\TranslationResponse;
+
+interface AudioContract
+{
+    /**
+     * Transcribes audio into the input language.
+     *
+     * @see https://platform.openai.com/docs/api-reference/audio/create
+     *
+     * @param  array<string, mixed>  $parameters
+     */
+    public function transcribe(array $parameters): TranscriptionResponse;
+
+    /**
+     * Translates audio into English.
+     *
+     * @see https://platform.openai.com/docs/api-reference/audio/create
+     *
+     * @param  array<string, mixed>  $parameters
+     */
+    public function translate(array $parameters): TranslationResponse;
+}

--- a/src/Resources/Contracts/ChatContract.php
+++ b/src/Resources/Contracts/ChatContract.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace OpenAI\Resources\Contracts;
+
+use OpenAI\Responses\Chat\CreateResponse;
+
+interface ChatContract
+{
+    /**
+     * Creates a completion for the chat message
+     *
+     * @see https://platform.openai.com/docs/api-reference/chat/create
+     *
+     * @param  array<string, mixed>  $parameters
+     */
+    public function create(array $parameters): CreateResponse;
+}

--- a/src/Resources/Contracts/ChatContract.php
+++ b/src/Resources/Contracts/ChatContract.php
@@ -3,6 +3,8 @@
 namespace OpenAI\Resources\Contracts;
 
 use OpenAI\Responses\Chat\CreateResponse;
+use OpenAI\Responses\Chat\CreateStreamedResponse;
+use OpenAI\Responses\StreamResponse;
 
 interface ChatContract
 {
@@ -14,4 +16,14 @@ interface ChatContract
      * @param  array<string, mixed>  $parameters
      */
     public function create(array $parameters): CreateResponse;
+
+    /**
+     * Creates a streamed completion for the chat message
+     *
+     * @see https://platform.openai.com/docs/api-reference/chat/create
+     *
+     * @param  array<string, mixed>  $parameters
+     * @return StreamResponse<CreateStreamedResponse>
+     */
+    public function createStreamed(array $parameters): StreamResponse;
 }

--- a/src/Resources/Contracts/CompletionsContract.php
+++ b/src/Resources/Contracts/CompletionsContract.php
@@ -3,6 +3,8 @@
 namespace OpenAI\Resources\Contracts;
 
 use OpenAI\Responses\Completions\CreateResponse;
+use OpenAI\Responses\Completions\CreateStreamedResponse;
+use OpenAI\Responses\StreamResponse;
 
 interface CompletionsContract
 {
@@ -14,4 +16,14 @@ interface CompletionsContract
      * @param  array<string, mixed>  $parameters
      */
     public function create(array $parameters): CreateResponse;
+
+    /**
+     * Creates a streamed completion for the provided prompt and parameters
+     *
+     * @see https://beta.openai.com/docs/api-reference/completions/create-completion
+     *
+     * @param  array<string, mixed>  $parameters
+     * @return StreamResponse<CreateStreamedResponse>
+     */
+    public function createStreamed(array $parameters): StreamResponse;
 }

--- a/src/Resources/Contracts/CompletionsContract.php
+++ b/src/Resources/Contracts/CompletionsContract.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace OpenAI\Resources\Contracts;
+
+use OpenAI\Responses\Completions\CreateResponse;
+
+interface CompletionsContract
+{
+    /**
+     * Creates a completion for the provided prompt and parameters
+     *
+     * @see https://beta.openai.com/docs/api-reference/completions/create-completion
+     *
+     * @param  array<string, mixed>  $parameters
+     */
+    public function create(array $parameters): CreateResponse;
+}

--- a/src/Resources/Contracts/EditsContract.php
+++ b/src/Resources/Contracts/EditsContract.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace OpenAI\Resources\Contracts;
+
+use OpenAI\Responses\Edits\CreateResponse;
+
+interface EditsContract
+{
+    /**
+     * Creates a new edit for the provided input, instruction, and parameters.
+     *
+     * @see https://beta.openai.com/docs/api-reference/edits/create
+     *
+     * @param  array<string, mixed>  $parameters
+     */
+    public function create(array $parameters): CreateResponse;
+}

--- a/src/Resources/Contracts/EmbeddingsContract.php
+++ b/src/Resources/Contracts/EmbeddingsContract.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace OpenAI\Resources\Contracts;
+
+use OpenAI\Responses\Embeddings\CreateResponse;
+
+interface EmbeddingsContract
+{
+    /**
+     * Creates an embedding vector representing the input text.
+     *
+     * @see https://beta.openai.com/docs/api-reference/embeddings/create
+     *
+     * @param  array<string, mixed>  $parameters
+     */
+    public function create(array $parameters): CreateResponse;
+}

--- a/src/Resources/Contracts/FilesContract.php
+++ b/src/Resources/Contracts/FilesContract.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace OpenAI\Resources\Contracts;
+
+use OpenAI\Responses\Files\CreateResponse;
+use OpenAI\Responses\Files\DeleteResponse;
+use OpenAI\Responses\Files\ListResponse;
+use OpenAI\Responses\Files\RetrieveResponse;
+
+interface FilesContract
+{
+    /**
+     * Returns a list of files that belong to the user's organization.
+     *
+     * @see https://beta.openai.com/docs/api-reference/files/list
+     */
+    public function list(): ListResponse;
+
+    /**
+     * Returns information about a specific file.
+     *
+     * @see https://beta.openai.com/docs/api-reference/files/retrieve
+     */
+    public function retrieve(string $file): RetrieveResponse;
+
+    /**
+     * Returns the contents of the specified file.
+     *
+     * @see https://beta.openai.com/docs/api-reference/files/retrieve-content
+     */
+    public function download(string $file): string;
+
+    /**
+     * Upload a file that contains document(s) to be used across various endpoints/features.
+     *
+     * @see https://beta.openai.com/docs/api-reference/files/upload
+     *
+     * @param  array<string, mixed>  $parameters
+     */
+    public function upload(array $parameters): CreateResponse;
+
+    /**
+     * Delete a file.
+     *
+     * @see https://beta.openai.com/docs/api-reference/files/delete
+     */
+    public function delete(string $file): DeleteResponse;
+}

--- a/src/Resources/Contracts/FineTunesContract.php
+++ b/src/Resources/Contracts/FineTunesContract.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace OpenAI\Resources\Contracts;
+
+use OpenAI\Responses\FineTunes\ListEventsResponse;
+use OpenAI\Responses\FineTunes\ListResponse;
+use OpenAI\Responses\FineTunes\RetrieveResponse;
+
+interface FineTunesContract
+{
+    /**
+     * Creates a job that fine-tunes a specified model from a given dataset.
+     *
+     * Response includes details of the enqueued job including job status and the name of the fine-tuned models once complete.
+     *
+     * @see https://beta.openai.com/docs/api-reference/fine-tunes/create
+     *
+     * @param  array<string, mixed>  $parameters
+     */
+    public function create(array $parameters): RetrieveResponse;
+
+    /**
+     * List your organization's fine-tuning jobs.
+     *
+     * @see https://beta.openai.com/docs/api-reference/fine-tunes/list
+     */
+    public function list(): ListResponse;
+
+    /**
+     * Gets info about the fine-tune job.
+     *
+     * @see https://beta.openai.com/docs/api-reference/fine-tunes/list
+     */
+    public function retrieve(string $fineTuneId): RetrieveResponse;
+
+    /**
+     * Immediately cancel a fine-tune job.
+     *
+     * @see https://beta.openai.com/docs/api-reference/fine-tunes/cancel
+     */
+    public function cancel(string $fineTuneId): RetrieveResponse;
+
+    /**
+     * Get fine-grained status updates for a fine-tune job.
+     *
+     * @see https://beta.openai.com/docs/api-reference/fine-tunes/events
+     */
+    public function listEvents(string $fineTuneId): ListEventsResponse;
+}

--- a/src/Resources/Contracts/FineTunesContract.php
+++ b/src/Resources/Contracts/FineTunesContract.php
@@ -5,6 +5,8 @@ namespace OpenAI\Resources\Contracts;
 use OpenAI\Responses\FineTunes\ListEventsResponse;
 use OpenAI\Responses\FineTunes\ListResponse;
 use OpenAI\Responses\FineTunes\RetrieveResponse;
+use OpenAI\Responses\FineTunes\RetrieveStreamedResponseEvent;
+use OpenAI\Responses\StreamResponse;
 
 interface FineTunesContract
 {
@@ -46,4 +48,13 @@ interface FineTunesContract
      * @see https://beta.openai.com/docs/api-reference/fine-tunes/events
      */
     public function listEvents(string $fineTuneId): ListEventsResponse;
+
+    /**
+     * Get streamed fine-grained status updates for a fine-tune job.
+     *
+     * @see https://beta.openai.com/docs/api-reference/fine-tunes/events
+     *
+     * @return StreamResponse<RetrieveStreamedResponseEvent>
+     */
+    public function listEventsStreamed(string $fineTuneId): StreamResponse;
 }

--- a/src/Resources/Contracts/ImagesContract.php
+++ b/src/Resources/Contracts/ImagesContract.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace OpenAI\Resources\Contracts;
+
+use OpenAI\Responses\Images\CreateResponse;
+use OpenAI\Responses\Images\EditResponse;
+use OpenAI\Responses\Images\VariationResponse;
+
+interface ImagesContract
+{
+    /**
+     * Creates an image given a prompt.
+     *
+     * @see https://beta.openai.com/docs/api-reference/images/create
+     *
+     * @param  array<string, mixed>  $parameters
+     */
+    public function create(array $parameters): CreateResponse;
+
+    /**
+     * Creates an edited or extended image given an original image and a prompt.
+     *
+     * @see https://beta.openai.com/docs/api-reference/images/create-edit
+     *
+     * @param  array<string, mixed>  $parameters
+     */
+    public function edit(array $parameters): EditResponse;
+
+    /**
+     * Creates a variation of a given image.
+     *
+     * @see https://beta.openai.com/docs/api-reference/images/create-variation
+     *
+     * @param  array<string, mixed>  $parameters
+     */
+    public function variation(array $parameters): VariationResponse;
+}

--- a/src/Resources/Contracts/ModelsContract.php
+++ b/src/Resources/Contracts/ModelsContract.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace OpenAI\Resources\Contracts;
+
+use OpenAI\Responses\Models\DeleteResponse;
+use OpenAI\Responses\Models\ListResponse;
+use OpenAI\Responses\Models\RetrieveResponse;
+
+interface ModelsContract
+{
+    /**
+     * Lists the currently available models, and provides basic information about each one such as the owner and availability.
+     *
+     * @see https://beta.openai.com/docs/api-reference/models/list
+     */
+    public function list(): ListResponse;
+
+    /**
+     * Retrieves a model instance, providing basic information about the model such as the owner and permissioning.
+     *
+     * @see https://beta.openai.com/docs/api-reference/models/retrieve
+     */
+    public function retrieve(string $model): RetrieveResponse;
+
+    /**
+     * Delete a fine-tuned model. You must have the Owner role in your organization.
+     *
+     * @see https://beta.openai.com/docs/api-reference/fine-tunes/delete-model
+     */
+    public function delete(string $model): DeleteResponse;
+}

--- a/src/Resources/Contracts/ModerationsContract.php
+++ b/src/Resources/Contracts/ModerationsContract.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace OpenAI\Resources\Contracts;
+
+use OpenAI\Responses\Moderations\CreateResponse;
+
+interface ModerationsContract
+{
+    /**
+     * Classifies if text violates OpenAI's Content Policy.
+     *
+     * @see https://beta.openai.com/docs/api-reference/moderations/create
+     *
+     * @param  array<string, mixed>  $parameters
+     */
+    public function create(array $parameters): CreateResponse;
+}

--- a/src/Resources/Edits.php
+++ b/src/Resources/Edits.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace OpenAI\Resources;
 
+use OpenAI\Resources\Contracts\EditsContract;
 use OpenAI\Responses\Edits\CreateResponse;
 use OpenAI\ValueObjects\Transporter\Payload;
 
-final class Edits
+final class Edits implements EditsContract
 {
     use Concerns\Transportable;
 

--- a/src/Resources/Embeddings.php
+++ b/src/Resources/Embeddings.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace OpenAI\Resources;
 
+use OpenAI\Resources\Contracts\EmbeddingsContract;
 use OpenAI\Responses\Embeddings\CreateResponse;
 use OpenAI\ValueObjects\Transporter\Payload;
 
-final class Embeddings
+final class Embeddings implements EmbeddingsContract
 {
     use Concerns\Transportable;
 

--- a/src/Resources/Files.php
+++ b/src/Resources/Files.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace OpenAI\Resources;
 
+use OpenAI\Resources\Contracts\FilesContract;
 use OpenAI\Responses\Files\CreateResponse;
 use OpenAI\Responses\Files\DeleteResponse;
 use OpenAI\Responses\Files\ListResponse;
 use OpenAI\Responses\Files\RetrieveResponse;
 use OpenAI\ValueObjects\Transporter\Payload;
 
-final class Files
+final class Files implements FilesContract
 {
     use Concerns\Transportable;
 

--- a/src/Resources/FineTunes.php
+++ b/src/Resources/FineTunes.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace OpenAI\Resources;
 
+use OpenAI\Resources\Contracts\FineTunesContract;
 use OpenAI\Responses\FineTunes\ListEventsResponse;
 use OpenAI\Responses\FineTunes\ListResponse;
 use OpenAI\Responses\FineTunes\RetrieveResponse;
 use OpenAI\ValueObjects\Transporter\Payload;
 
-final class FineTunes
+final class FineTunes implements FineTunesContract
 {
     use Concerns\Transportable;
 

--- a/src/Resources/Images.php
+++ b/src/Resources/Images.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace OpenAI\Resources;
 
+use OpenAI\Resources\Contracts\ImagesContract;
 use OpenAI\Responses\Images\CreateResponse;
 use OpenAI\Responses\Images\EditResponse;
 use OpenAI\Responses\Images\VariationResponse;
 use OpenAI\ValueObjects\Transporter\Payload;
 
-final class Images
+final class Images implements ImagesContract
 {
     use Concerns\Transportable;
 

--- a/src/Resources/Models.php
+++ b/src/Resources/Models.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace OpenAI\Resources;
 
+use OpenAI\Resources\Contracts\ModelsContract;
 use OpenAI\Responses\Models\DeleteResponse;
 use OpenAI\Responses\Models\ListResponse;
 use OpenAI\Responses\Models\RetrieveResponse;
 use OpenAI\ValueObjects\Transporter\Payload;
 
-final class Models
+final class Models implements ModelsContract
 {
     use Concerns\Transportable;
 

--- a/src/Resources/Moderations.php
+++ b/src/Resources/Moderations.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace OpenAI\Resources;
 
+use OpenAI\Resources\Contracts\ModerationsContract;
 use OpenAI\Responses\Moderations\CreateResponse;
 use OpenAI\ValueObjects\Transporter\Payload;
 
-final class Moderations
+final class Moderations implements ModerationsContract
 {
     use Concerns\Transportable;
 

--- a/src/Responses/Audio/TranscriptionResponse.php
+++ b/src/Responses/Audio/TranscriptionResponse.php
@@ -6,6 +6,7 @@ namespace OpenAI\Responses\Audio;
 
 use OpenAI\Contracts\Response;
 use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
  * @implements Response<array{task: ?string, language: ?string, duration: ?float, segments: array<int, array{id: int, seek: int, start: float, end: float, text: string, tokens: array<int, int>, temperature: float, avg_logprob: float, compression_ratio: float, no_speech_prob: float, transient: bool}>, text: string}>
@@ -16,6 +17,8 @@ final class TranscriptionResponse implements Response
      * @use ArrayAccessible<array{task: ?string, language: ?string, duration: ?float, segments: array<int, array{id: int, seek: int, start: float, end: float, text: string, tokens: array<int, int>, temperature: float, avg_logprob: float, compression_ratio: float, no_speech_prob: float, transient: bool}>, text: string}>
      */
     use ArrayAccessible;
+
+    use Fakeable;
 
     /**
      * @param  array<int, TranscriptionResponseSegment>  $segments

--- a/src/Responses/Audio/TranslationResponse.php
+++ b/src/Responses/Audio/TranslationResponse.php
@@ -6,6 +6,7 @@ namespace OpenAI\Responses\Audio;
 
 use OpenAI\Contracts\Response;
 use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
  * @implements Response<array{task: ?string, language: ?string, duration: ?float, segments: array<int, array{id: int, seek: int, start: float, end: float, text: string, tokens: array<int, int>, temperature: float, avg_logprob: float, compression_ratio: float, no_speech_prob: float, transient: bool}>, text: string}>
@@ -16,6 +17,8 @@ final class TranslationResponse implements Response
      * @use ArrayAccessible<array{task: ?string, language: ?string, duration: ?float, segments: array<int, array{id: int, seek: int, start: float, end: float, text: string, tokens: array<int, int>, temperature: float, avg_logprob: float, compression_ratio: float, no_speech_prob: float, transient: bool}>, text: string}>
      */
     use ArrayAccessible;
+
+    use Fakeable;
 
     /**
      * @param  array<int, TranslationResponseSegment>  $segments

--- a/src/Responses/Chat/CreateResponse.php
+++ b/src/Responses/Chat/CreateResponse.php
@@ -6,6 +6,7 @@ namespace OpenAI\Responses\Chat;
 
 use OpenAI\Contracts\Response;
 use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
  * @implements Response<array{id: string, object: string, created: int, model: string, choices: array<int, array{index: int, message: array{role: string, content: string}, finish_reason: string|null}>, usage: array{prompt_tokens: int, completion_tokens: int|null, total_tokens: int}}>
@@ -16,6 +17,8 @@ final class CreateResponse implements Response
      * @use ArrayAccessible<array{id: string, object: string, created: int, model: string, choices: array<int, array{index: int, message: array{role: string, content: string}, finish_reason: string|null}>, usage: array{prompt_tokens: int, completion_tokens: int|null, total_tokens: int}}>
      */
     use ArrayAccessible;
+
+    use Fakeable;
 
     /**
      * @param  array<int, CreateResponseChoice>  $choices

--- a/src/Responses/Chat/CreateStreamedResponse.php
+++ b/src/Responses/Chat/CreateStreamedResponse.php
@@ -6,6 +6,7 @@ namespace OpenAI\Responses\Chat;
 
 use OpenAI\Contracts\Response;
 use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\FakeableForStreamedResponse;
 
 /**
  * @implements Response<array{id: string, object: string, created: int, model: string, choices: array<int, array{index: int, delta: array{role?: string, content?: string}, finish_reason: string|null}>}>
@@ -16,6 +17,8 @@ final class CreateStreamedResponse implements Response
      * @use ArrayAccessible<array{id: string, object: string, created: int, model: string, choices: array<int, array{index: int, delta: array{role?: string, content?: string}, finish_reason: string|null}>}>
      */
     use ArrayAccessible;
+
+    use FakeableForStreamedResponse;
 
     /**
      * @param  array<int, CreateStreamedResponseChoice>  $choices

--- a/src/Responses/Completions/CreateResponse.php
+++ b/src/Responses/Completions/CreateResponse.php
@@ -6,6 +6,7 @@ namespace OpenAI\Responses\Completions;
 
 use OpenAI\Contracts\Response;
 use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
  * @implements Response<array{id: string, object: string, created: int, model: string, choices: array<int, array{text: string, index: int, logprobs: array{tokens: array<int, string>, token_logprobs: array<int, float>, top_logprobs: array<int, string>|null, text_offset: array<int, int>}|null, finish_reason: string|null}>, usage: array{prompt_tokens: int, completion_tokens: int|null, total_tokens: int}}>
@@ -16,6 +17,8 @@ final class CreateResponse implements Response
      * @use ArrayAccessible<array{id: string, object: string, created: int, model: string, choices: array<int, array{text: string, index: int, logprobs: array{tokens: array<int, string>, token_logprobs: array<int, float>, top_logprobs: array<int, string>|null, text_offset: array<int, int>}|null, finish_reason: string|null}>, usage: array{prompt_tokens: int, completion_tokens: int|null, total_tokens: int}}>
      */
     use ArrayAccessible;
+
+    use Fakeable;
 
     /**
      * @param  array<int, CreateResponseChoice>  $choices

--- a/src/Responses/Completions/CreateStreamedResponse.php
+++ b/src/Responses/Completions/CreateStreamedResponse.php
@@ -6,6 +6,7 @@ namespace OpenAI\Responses\Completions;
 
 use OpenAI\Contracts\Response;
 use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\FakeableForStreamedResponse;
 
 /**
  * @implements Response<array{id: string, object: string, created: int, model: string, choices: array<int, array{text: string, index: int, logprobs: array{tokens: array<int, string>, token_logprobs: array<int, float>, top_logprobs: array<int, string>|null, text_offset: array<int, int>}|null, finish_reason: string|null}>}>
@@ -16,6 +17,8 @@ final class CreateStreamedResponse implements Response
      * @use ArrayAccessible<array{id: string, object: string, created: int, model: string, choices: array<int, array{text: string, index: int, logprobs: array{tokens: array<int, string>, token_logprobs: array<int, float>, top_logprobs: array<int, string>|null, text_offset: array<int, int>}|null, finish_reason: string|null}>}>
      */
     use ArrayAccessible;
+
+    use FakeableForStreamedResponse;
 
     /**
      * @param  array<int, CreateResponseChoice>  $choices

--- a/src/Responses/Edits/CreateResponse.php
+++ b/src/Responses/Edits/CreateResponse.php
@@ -6,6 +6,7 @@ namespace OpenAI\Responses\Edits;
 
 use OpenAI\Contracts\Response;
 use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
  * @implements Response<array{object: string, created: int, choices: array<int, array{text: string, index: int}>, usage: array{prompt_tokens: int, completion_tokens: int, total_tokens: int}}>
@@ -16,6 +17,8 @@ final class CreateResponse implements Response
      * @use ArrayAccessible<array{id: string, object: string, created: int, model: string, choices: array<int, array{text: string, index: int, logprobs: int|null, finish_reason: string}>, usage: array{prompt_tokens: int, completion_tokens: int, total_tokens: int}}>
      */
     use ArrayAccessible;
+
+    use Fakeable;
 
     /**
      * @param  array<int, CreateResponseChoice>  $choices

--- a/src/Responses/Embeddings/CreateResponse.php
+++ b/src/Responses/Embeddings/CreateResponse.php
@@ -6,6 +6,7 @@ namespace OpenAI\Responses\Embeddings;
 
 use OpenAI\Contracts\Response;
 use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
  * @implements Response<array{object: string, data: array<int, array{object: string, embedding: array<int, float>, index: int}>, usage: array{prompt_tokens: int, total_tokens: int}}>
@@ -16,6 +17,8 @@ final class CreateResponse implements Response
      * @use ArrayAccessible<array{object: string, data: array<int, array{object: string, embedding: array<int, float>, index: int}>, usage: array{prompt_tokens: int, total_tokens: int}}>
      */
     use ArrayAccessible;
+
+    use Fakeable;
 
     /**
      * @param  array<int, CreateResponseEmbedding>  $embeddings

--- a/src/Responses/Files/CreateResponse.php
+++ b/src/Responses/Files/CreateResponse.php
@@ -6,6 +6,7 @@ namespace OpenAI\Responses\Files;
 
 use OpenAI\Contracts\Response;
 use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
  * @implements Response<array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>
@@ -16,6 +17,8 @@ final class CreateResponse implements Response
      * @use ArrayAccessible<array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>
      */
     use ArrayAccessible;
+
+    use Fakeable;
 
     /**
      * @param  array<array-key, mixed>|null  $statusDetails

--- a/src/Responses/Files/DeleteResponse.php
+++ b/src/Responses/Files/DeleteResponse.php
@@ -6,6 +6,7 @@ namespace OpenAI\Responses\Files;
 
 use OpenAI\Contracts\Response;
 use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
  * @implements Response<array{id: string, object: string, deleted: bool}>
@@ -16,6 +17,8 @@ final class DeleteResponse implements Response
      * @use ArrayAccessible<array{id: string, object: string, deleted: bool}>
      */
     use ArrayAccessible;
+
+    use Fakeable;
 
     private function __construct(
         public readonly string $id,

--- a/src/Responses/Files/ListResponse.php
+++ b/src/Responses/Files/ListResponse.php
@@ -6,6 +6,7 @@ namespace OpenAI\Responses\Files;
 
 use OpenAI\Contracts\Response;
 use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
  * @implements Response<array{object: string, data: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>}>
@@ -16,6 +17,8 @@ final class ListResponse implements Response
      * @use ArrayAccessible<array{object: string, data: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>}>
      */
     use ArrayAccessible;
+
+    use Fakeable;
 
     /**
      * @param  array<int, RetrieveResponse>  $data

--- a/src/Responses/Files/RetrieveResponse.php
+++ b/src/Responses/Files/RetrieveResponse.php
@@ -6,6 +6,7 @@ namespace OpenAI\Responses\Files;
 
 use OpenAI\Contracts\Response;
 use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
  * @implements Response<array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>
@@ -16,6 +17,8 @@ final class RetrieveResponse implements Response
      * @use ArrayAccessible<array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>
      */
     use ArrayAccessible;
+
+    use Fakeable;
 
     /**
      * @param  array<array-key, mixed>|null  $statusDetails

--- a/src/Responses/FineTunes/ListEventsResponse.php
+++ b/src/Responses/FineTunes/ListEventsResponse.php
@@ -6,6 +6,7 @@ namespace OpenAI\Responses\FineTunes;
 
 use OpenAI\Contracts\Response;
 use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
  * @implements Response<array{object: string, data: array<int, array{object: string, created_at: int, level: string, message: string}>}>
@@ -16,6 +17,8 @@ final class ListEventsResponse implements Response
      * @use ArrayAccessible<array{object: string, data: array<int, array{object: string, created_at: int, level: string, message: string}>}>
      */
     use ArrayAccessible;
+
+    use Fakeable;
 
     /**
      * @param  array<int, RetrieveResponseEvent>  $data

--- a/src/Responses/FineTunes/ListResponse.php
+++ b/src/Responses/FineTunes/ListResponse.php
@@ -6,6 +6,7 @@ namespace OpenAI\Responses\FineTunes;
 
 use OpenAI\Contracts\Response;
 use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
  * @implements Response<array{object: string, data: array<int, array{id: string, object: string, model: string, created_at: int, events: array<int, array{object: string, created_at: int, level: string, message: string}>, fine_tuned_model: ?string, hyperparams: array{batch_size: ?int, learning_rate_multiplier: ?float, n_epochs: int, prompt_loss_weight: float}, organization_id: string, result_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, status: string, validation_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, training_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, updated_at: int}>}>
@@ -16,6 +17,8 @@ final class ListResponse implements Response
      * @use ArrayAccessible<array{object: string, data: array<int, array{id: string, object: string, model: string, created_at: int, events: array<int, array{object: string, created_at: int, level: string, message: string}>, fine_tuned_model: ?string, hyperparams: array{batch_size: ?int, learning_rate_multiplier: ?float, n_epochs: int, prompt_loss_weight: float}, organization_id: string, result_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, status: string, validation_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, training_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, updated_at: int}>}>
      */
     use ArrayAccessible;
+
+    use Fakeable;
 
     /**
      * @param  array<int, RetrieveResponse>  $data

--- a/src/Responses/FineTunes/RetrieveResponse.php
+++ b/src/Responses/FineTunes/RetrieveResponse.php
@@ -6,6 +6,7 @@ namespace OpenAI\Responses\FineTunes;
 
 use OpenAI\Contracts\Response;
 use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
  * @implements Response<array{id: string, object: string, model: string, created_at: int, events: array<int, array{object: string, created_at: int, level: string, message: string}>, fine_tuned_model: ?string, hyperparams: array{batch_size: ?int, learning_rate_multiplier: ?float, n_epochs: int, prompt_loss_weight: float}, organization_id: string, result_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, status: string, validation_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, training_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, updated_at: int}>
@@ -16,6 +17,8 @@ final class RetrieveResponse implements Response
      * @use ArrayAccessible<array{id: string, object: string, model: string, created_at: int, events: array<int, array{object: string, created_at: int, level: string, message: string}>, fine_tuned_model: ?string, hyperparams: array{batch_size: ?int, learning_rate_multiplier: ?float, n_epochs: int, prompt_loss_weight: float}, organization_id: string, result_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, status: string, validation_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, training_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, updated_at: int}>
      */
     use ArrayAccessible;
+
+    use Fakeable;
 
     /**
      * @param  array<int, RetrieveResponseEvent>  $events

--- a/src/Responses/FineTunes/RetrieveStreamedResponseEvent.php
+++ b/src/Responses/FineTunes/RetrieveStreamedResponseEvent.php
@@ -6,6 +6,7 @@ namespace OpenAI\Responses\FineTunes;
 
 use OpenAI\Contracts\Response;
 use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\FakeableForStreamedResponse;
 
 /**
  * @implements Response<array{object: string, created_at: int, level: string, message: string}>
@@ -16,6 +17,8 @@ final class RetrieveStreamedResponseEvent implements Response
      * @use ArrayAccessible<array{object: string, created_at: int, level: string, message: string}>
      */
     use ArrayAccessible;
+
+    use FakeableForStreamedResponse;
 
     private function __construct(
         public readonly string $object,

--- a/src/Responses/Images/CreateResponse.php
+++ b/src/Responses/Images/CreateResponse.php
@@ -6,6 +6,7 @@ namespace OpenAI\Responses\Images;
 
 use OpenAI\Contracts\Response;
 use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
  * @implements Response<array{created: int, data: array<int, array{url?: string, b64_json?: string}>}>
@@ -16,6 +17,8 @@ final class CreateResponse implements Response
      * @use ArrayAccessible<array{created: int, data: array<int, array{url?: string, b64_json?: string}>}>
      */
     use ArrayAccessible;
+
+    use Fakeable;
 
     /**
      * @param  array<int, CreateResponseData>  $data

--- a/src/Responses/Images/EditResponse.php
+++ b/src/Responses/Images/EditResponse.php
@@ -6,6 +6,7 @@ namespace OpenAI\Responses\Images;
 
 use OpenAI\Contracts\Response;
 use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
  * @implements Response<array{created: int, data: array<int, array{url?: string, b64_json?: string}>}>
@@ -16,6 +17,8 @@ final class EditResponse implements Response
      * @use ArrayAccessible<array{created: int, data: array<int, array{url?: string, b64_json?: string}>}>
      */
     use ArrayAccessible;
+
+    use Fakeable;
 
     /**
      * @param  array<int, EditResponseData>  $data

--- a/src/Responses/Images/VariationResponse.php
+++ b/src/Responses/Images/VariationResponse.php
@@ -6,6 +6,7 @@ namespace OpenAI\Responses\Images;
 
 use OpenAI\Contracts\Response;
 use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
  * @implements Response<array{created: int, data: array<int, array{url?: string, b64_json?: string}>}>
@@ -16,6 +17,8 @@ final class VariationResponse implements Response
      * @use ArrayAccessible<array{created: int, data: array<int, array{url?: string, b64_json?: string}>}>
      */
     use ArrayAccessible;
+
+    use Fakeable;
 
     /**
      * @param  array<int, VariationResponseData>  $data

--- a/src/Responses/Models/DeleteResponse.php
+++ b/src/Responses/Models/DeleteResponse.php
@@ -6,6 +6,7 @@ namespace OpenAI\Responses\Models;
 
 use OpenAI\Contracts\Response;
 use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
  * @implements Response<array{id: string, object: string, deleted: bool}>
@@ -16,6 +17,8 @@ final class DeleteResponse implements Response
      * @use ArrayAccessible<array{id: string, object: string, deleted: bool}>
      */
     use ArrayAccessible;
+
+    use Fakeable;
 
     private function __construct(
         public readonly string $id,

--- a/src/Responses/Models/ListResponse.php
+++ b/src/Responses/Models/ListResponse.php
@@ -6,6 +6,7 @@ namespace OpenAI\Responses\Models;
 
 use OpenAI\Contracts\Response;
 use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
  * @implements Response<array{object: string, data: array<int, array{id: string, object: string, created: int, owned_by: string, permission: array<int, array{id: string, object: string, created: int, allow_create_engine: bool, allow_sampling: bool, allow_logprobs: bool, allow_search_indices: bool, allow_view: bool, allow_fine_tuning: bool, organization: string, group: ?string, is_blocking: bool}>, root: string, parent: ?string}>}>
@@ -16,6 +17,8 @@ final class ListResponse implements Response
      * @use ArrayAccessible<array{object: string, data: array<int, array{id: string, object: string, created: int, owned_by: string, permission: array<int, array{id: string, object: string, created: int, allow_create_engine: bool, allow_sampling: bool, allow_logprobs: bool, allow_search_indices: bool, allow_view: bool, allow_fine_tuning: bool, organization: string, group: ?string, is_blocking: bool}>, root: string, parent: ?string}>}>
      */
     use ArrayAccessible;
+
+    use Fakeable;
 
     /**
      * @param  array<int, RetrieveResponse>  $data

--- a/src/Responses/Models/RetrieveResponse.php
+++ b/src/Responses/Models/RetrieveResponse.php
@@ -6,6 +6,7 @@ namespace OpenAI\Responses\Models;
 
 use OpenAI\Contracts\Response;
 use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
  * @implements Response<array{id: string, object: string, created: int, owned_by: string, permission: array<int, array{id: string, object: string, created: int, allow_create_engine: bool, allow_sampling: bool, allow_logprobs: bool, allow_search_indices: bool, allow_view: bool, allow_fine_tuning: bool, organization: string, group: ?string, is_blocking: bool}>, root: string, parent: ?string}>
@@ -16,6 +17,8 @@ final class RetrieveResponse implements Response
      * @use ArrayAccessible<array{id: string, object: string, created: int, owned_by: string, permission: array<int, array{id: string, object: string, created: int, allow_create_engine: bool, allow_sampling: bool, allow_logprobs: bool, allow_search_indices: bool, allow_view: bool, allow_fine_tuning: bool, organization: string, group: ?string, is_blocking: bool}>, root: string, parent: ?string}>
      */
     use ArrayAccessible;
+
+    use Fakeable;
 
     /**
      * @param  array<int, RetrieveResponsePermission>  $permission

--- a/src/Responses/Moderations/CreateResponse.php
+++ b/src/Responses/Moderations/CreateResponse.php
@@ -6,6 +6,7 @@ namespace OpenAI\Responses\Moderations;
 
 use OpenAI\Contracts\Response;
 use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
  * @implements Response<array{id: string, model: string, results: array<int, array{categories: array<string, bool>, category_scores: array<string, float>, flagged: bool}>}>
@@ -16,6 +17,8 @@ final class CreateResponse implements Response
      * @use ArrayAccessible<array{id: string, model: string, results: array<int, array{categories: array<string, bool>, category_scores: array<string, float>, flagged: bool}>}>
      */
     use ArrayAccessible;
+
+    use Fakeable;
 
     /**
      * @param  array<int, CreateResponseResult>  $results

--- a/src/Testing/ClientFake.php
+++ b/src/Testing/ClientFake.php
@@ -4,6 +4,7 @@ namespace OpenAI\Testing;
 
 use OpenAI\Contracts\Client;
 use OpenAI\Contracts\Response;
+use OpenAI\Responses\StreamResponse;
 use OpenAI\Testing\Requests\TestRequest;
 use OpenAI\Testing\Resources\AudioTestResource;
 use OpenAI\Testing\Resources\ChatTestResource;
@@ -115,7 +116,7 @@ class ClientFake implements Client
         return array_filter($this->requests, fn (TestRequest $request): bool => $request->resource() === $type);
     }
 
-    public function record(TestRequest $request): Response|string
+    public function record(TestRequest $request): Response|StreamResponse|string
     {
         $this->requests[] = $request;
 

--- a/src/Testing/ClientFake.php
+++ b/src/Testing/ClientFake.php
@@ -4,16 +4,6 @@ namespace OpenAI\Testing;
 
 use OpenAI\Contracts\Client;
 use OpenAI\Contracts\Response;
-use OpenAI\Resources\Contracts\AudioContract;
-use OpenAI\Resources\Contracts\ChatContract;
-use OpenAI\Resources\Contracts\CompletionsContract;
-use OpenAI\Resources\Contracts\EditsContract;
-use OpenAI\Resources\Contracts\EmbeddingsContract;
-use OpenAI\Resources\Contracts\FilesContract;
-use OpenAI\Resources\Contracts\FineTunesContract;
-use OpenAI\Resources\Contracts\ImagesContract;
-use OpenAI\Resources\Contracts\ModelsContract;
-use OpenAI\Resources\Contracts\ModerationsContract;
 use OpenAI\Testing\Requests\TestRequest;
 use OpenAI\Testing\Resources\AudioTestResource;
 use OpenAI\Testing\Resources\ChatTestResource;
@@ -137,52 +127,52 @@ class ClientFake implements Client
         return $response;
     }
 
-    public function completions(): CompletionsContract
+    public function completions(): CompletionsTestResource
     {
         return new CompletionsTestResource($this);
     }
 
-    public function chat(): ChatContract
+    public function chat(): ChatTestResource
     {
         return new ChatTestResource($this);
     }
 
-    public function embeddings(): EmbeddingsContract
+    public function embeddings(): EmbeddingsTestResource
     {
         return new EmbeddingsTestResource($this);
     }
 
-    public function audio(): AudioContract
+    public function audio(): AudioTestResource
     {
         return new AudioTestResource($this);
     }
 
-    public function edits(): EditsContract
+    public function edits(): EditsTestResource
     {
         return new EditsTestResource($this);
     }
 
-    public function files(): FilesContract
+    public function files(): FilesTestResource
     {
         return new FilesTestResource($this);
     }
 
-    public function models(): ModelsContract
+    public function models(): ModelsTestResource
     {
         return new ModelsTestResource($this);
     }
 
-    public function fineTunes(): FineTunesContract
+    public function fineTunes(): FineTunesTestResource
     {
         return new FineTunesTestResource($this);
     }
 
-    public function moderations(): ModerationsContract
+    public function moderations(): ModerationsTestResource
     {
         return new ModerationsTestResource($this);
     }
 
-    public function images(): ImagesContract
+    public function images(): ImagesTestResource
     {
         return new ImagesTestResource($this);
     }

--- a/src/Testing/ClientFake.php
+++ b/src/Testing/ClientFake.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace OpenAI\Testing;
+
+use OpenAI\Contracts\Client;
+use OpenAI\Contracts\Response;
+use OpenAI\Resources\Contracts\AudioContract;
+use OpenAI\Resources\Contracts\ChatContract;
+use OpenAI\Resources\Contracts\CompletionsContract;
+use OpenAI\Resources\Contracts\EditsContract;
+use OpenAI\Resources\Contracts\EmbeddingsContract;
+use OpenAI\Resources\Contracts\FilesContract;
+use OpenAI\Resources\Contracts\FineTunesContract;
+use OpenAI\Resources\Contracts\ImagesContract;
+use OpenAI\Resources\Contracts\ModelsContract;
+use OpenAI\Resources\Contracts\ModerationsContract;
+use OpenAI\Testing\Requests\TestRequest;
+use OpenAI\Testing\Resources\AudioTestResource;
+use OpenAI\Testing\Resources\ChatTestResource;
+use OpenAI\Testing\Resources\CompletionsTestResource;
+use OpenAI\Testing\Resources\EditsTestResource;
+use OpenAI\Testing\Resources\EmbeddingsTestResource;
+use OpenAI\Testing\Resources\FilesTestResource;
+use OpenAI\Testing\Resources\FineTunesTestResource;
+use OpenAI\Testing\Resources\ImagesTestResource;
+use OpenAI\Testing\Resources\ModelsTestResource;
+use OpenAI\Testing\Resources\ModerationsTestResource;
+use PHPUnit\Framework\Assert as PHPUnit;
+
+/**
+ * @noRector Rector\Privatization\Rector\Class_\FinalizeClassesWithoutChildrenRector
+ */
+class ClientFake implements Client
+{
+    /**
+     * @var array<array-key, TestRequest>
+     */
+    private array $requests = [];
+
+    /**
+     * @param  array<array-key, Response|string>  $responses
+     */
+    public function __construct(protected array $responses = [])
+    {
+    }
+
+    /**
+     * @param  array<array-key, Response>  $responses
+     */
+    public function addResponses(array $responses): void
+    {
+        $this->responses = [...$this->responses, ...$responses];
+    }
+
+    /**
+     * @param  callable|int|null  $callback
+     */
+    public function assertSent(string $resource, $callback = null): void
+    {
+        if (is_int($callback)) {
+            $this->assertSentTimes($resource, $callback);
+
+            return;
+        }
+
+        PHPUnit::assertTrue(
+            $this->sent($resource, $callback) !== [],
+            "The expected [{$resource}] request was not sent."
+        );
+    }
+
+    protected function assertSentTimes(string $resource, int $times = 1): void
+    {
+        $count = count($this->sent($resource));
+
+        PHPUnit::assertSame(
+            $times, $count,
+            "The expected [{$resource}] resource was sent {$count} times instead of {$times} times."
+        );
+    }
+
+    /**
+     * @return mixed[]
+     */
+    protected function sent(string $resource, callable $callback = null): array
+    {
+        if (! $this->hasSent($resource)) {
+            return [];
+        }
+
+        $callback = $callback ?: fn (): bool => true;
+
+        return array_filter($this->resourcesOf($resource), fn (TestRequest $resource) => $callback($resource->method(), $resource->parameters()));
+    }
+
+    protected function hasSent(string $resource): bool
+    {
+        return $this->resourcesOf($resource) !== [];
+    }
+
+    public function assertNotSent(string $resource, callable $callback = null): void
+    {
+        PHPUnit::assertCount(
+            0, $this->sent($resource, $callback),
+            "The unexpected [{$resource}] request was sent."
+        );
+    }
+
+    public function assertNothingSent(): void
+    {
+        $resourceNames = implode(
+            separator: ', ',
+            array: array_map(fn (TestRequest $request): string => $request->resource(), $this->requests)
+        );
+
+        PHPUnit::assertEmpty($this->requests, 'The following requests were sent unexpectedly: '.$resourceNames);
+    }
+
+    /**
+     * @return array<array-key, TestRequest>
+     */
+    protected function resourcesOf(string $type): array
+    {
+        return array_filter($this->requests, fn (TestRequest $request): bool => $request->resource() === $type);
+    }
+
+    public function record(TestRequest $request): Response|string
+    {
+        $this->requests[] = $request;
+
+        $response = array_shift($this->responses);
+
+        if (is_null($response)) {
+            throw new \Exception('No fake responses left.');
+        }
+
+        return $response;
+    }
+
+    public function completions(): CompletionsContract
+    {
+        return new CompletionsTestResource($this);
+    }
+
+    public function chat(): ChatContract
+    {
+        return new ChatTestResource($this);
+    }
+
+    public function embeddings(): EmbeddingsContract
+    {
+        return new EmbeddingsTestResource($this);
+    }
+
+    public function audio(): AudioContract
+    {
+        return new AudioTestResource($this);
+    }
+
+    public function edits(): EditsContract
+    {
+        return new EditsTestResource($this);
+    }
+
+    public function files(): FilesContract
+    {
+        return new FilesTestResource($this);
+    }
+
+    public function models(): ModelsContract
+    {
+        return new ModelsTestResource($this);
+    }
+
+    public function fineTunes(): FineTunesContract
+    {
+        return new FineTunesTestResource($this);
+    }
+
+    public function moderations(): ModerationsContract
+    {
+        return new ModerationsTestResource($this);
+    }
+
+    public function images(): ImagesContract
+    {
+        return new ImagesTestResource($this);
+    }
+}

--- a/src/Testing/ClientFake.php
+++ b/src/Testing/ClientFake.php
@@ -16,6 +16,7 @@ use OpenAI\Testing\Resources\ImagesTestResource;
 use OpenAI\Testing\Resources\ModelsTestResource;
 use OpenAI\Testing\Resources\ModerationsTestResource;
 use PHPUnit\Framework\Assert as PHPUnit;
+use Throwable;
 
 /**
  * @noRector Rector\Privatization\Rector\Class_\FinalizeClassesWithoutChildrenRector
@@ -122,6 +123,10 @@ class ClientFake implements Client
 
         if (is_null($response)) {
             throw new \Exception('No fake responses left.');
+        }
+
+        if ($response instanceof Throwable) {
+            throw $response;
         }
 
         return $response;

--- a/src/Testing/Requests/TestRequest.php
+++ b/src/Testing/Requests/TestRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace OpenAI\Testing\Requests;
+
+final class TestRequest
+{
+    /**
+     * @param  array<string, mixed>|string|null  $parameters
+     */
+    public function __construct(protected string $resource, protected string $method, protected array|string|null $parameters)
+    {
+    }
+
+    public function resource(): string
+    {
+        return $this->resource;
+    }
+
+    public function method(): string
+    {
+        return $this->method;
+    }
+
+    /**
+     * @return array<string, mixed>|string|null
+     */
+    public function parameters(): array|string|null
+    {
+        return $this->parameters;
+    }
+}

--- a/src/Testing/Resources/AudioTestResource.php
+++ b/src/Testing/Resources/AudioTestResource.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace OpenAI\Testing\Resources;
+
+use OpenAI\Resources\Audio;
+use OpenAI\Resources\Contracts\AudioContract;
+use OpenAI\Responses\Audio\TranscriptionResponse;
+use OpenAI\Responses\Audio\TranslationResponse;
+use OpenAI\Testing\Resources\Concerns\Testable;
+
+final class AudioTestResource implements AudioContract
+{
+    use Testable;
+
+    protected function resource(): string
+    {
+        return Audio::class;
+    }
+
+    public function transcribe(array $parameters): TranscriptionResponse
+    {
+        return $this->record(__FUNCTION__, $parameters);
+    }
+
+    public function translate(array $parameters): TranslationResponse
+    {
+        return $this->record(__FUNCTION__, $parameters);
+    }
+}

--- a/src/Testing/Resources/ChatTestResource.php
+++ b/src/Testing/Resources/ChatTestResource.php
@@ -5,6 +5,7 @@ namespace OpenAI\Testing\Resources;
 use OpenAI\Resources\Chat;
 use OpenAI\Resources\Contracts\ChatContract;
 use OpenAI\Responses\Chat\CreateResponse;
+use OpenAI\Responses\StreamResponse;
 use OpenAI\Testing\Resources\Concerns\Testable;
 
 final class ChatTestResource implements ChatContract
@@ -17,6 +18,11 @@ final class ChatTestResource implements ChatContract
     }
 
     public function create(array $parameters): CreateResponse
+    {
+        return $this->record(__FUNCTION__, $parameters);
+    }
+
+    public function createStreamed(array $parameters): StreamResponse
     {
         return $this->record(__FUNCTION__, $parameters);
     }

--- a/src/Testing/Resources/ChatTestResource.php
+++ b/src/Testing/Resources/ChatTestResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace OpenAI\Testing\Resources;
+
+use OpenAI\Resources\Chat;
+use OpenAI\Resources\Contracts\ChatContract;
+use OpenAI\Responses\Chat\CreateResponse;
+use OpenAI\Testing\Resources\Concerns\Testable;
+
+final class ChatTestResource implements ChatContract
+{
+    use Testable;
+
+    protected function resource(): string
+    {
+        return Chat::class;
+    }
+
+    public function create(array $parameters): CreateResponse
+    {
+        return $this->record(__FUNCTION__, $parameters);
+    }
+}

--- a/src/Testing/Resources/CompletionsTestResource.php
+++ b/src/Testing/Resources/CompletionsTestResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace OpenAI\Testing\Resources;
+
+use OpenAI\Resources\Completions;
+use OpenAI\Resources\Contracts\CompletionsContract;
+use OpenAI\Responses\Completions\CreateResponse;
+use OpenAI\Testing\Resources\Concerns\Testable;
+
+final class CompletionsTestResource implements CompletionsContract
+{
+    use Testable;
+
+    protected function resource(): string
+    {
+        return Completions::class;
+    }
+
+    public function create(array $parameters): CreateResponse
+    {
+        return $this->record(__FUNCTION__, $parameters);
+    }
+}

--- a/src/Testing/Resources/CompletionsTestResource.php
+++ b/src/Testing/Resources/CompletionsTestResource.php
@@ -5,6 +5,7 @@ namespace OpenAI\Testing\Resources;
 use OpenAI\Resources\Completions;
 use OpenAI\Resources\Contracts\CompletionsContract;
 use OpenAI\Responses\Completions\CreateResponse;
+use OpenAI\Responses\StreamResponse;
 use OpenAI\Testing\Resources\Concerns\Testable;
 
 final class CompletionsTestResource implements CompletionsContract
@@ -17,6 +18,11 @@ final class CompletionsTestResource implements CompletionsContract
     }
 
     public function create(array $parameters): CreateResponse
+    {
+        return $this->record(__FUNCTION__, $parameters);
+    }
+
+    public function createStreamed(array $parameters): StreamResponse
     {
         return $this->record(__FUNCTION__, $parameters);
     }

--- a/src/Testing/Resources/Concerns/Testable.php
+++ b/src/Testing/Resources/Concerns/Testable.php
@@ -3,6 +3,7 @@
 namespace OpenAI\Testing\Resources\Concerns;
 
 use OpenAI\Contracts\Response;
+use OpenAI\Responses\StreamResponse;
 use OpenAI\Testing\ClientFake;
 use OpenAI\Testing\Requests\TestRequest;
 
@@ -17,7 +18,7 @@ trait Testable
     /**
      * @param  array<string, mixed>|string|null  $parameters
      */
-    protected function record(string $method, array|string|null $parameters = null): Response|string
+    protected function record(string $method, array|string|null $parameters = null): Response|StreamResponse|string
     {
         return $this->fake->record(new TestRequest($this->resource(), $method, $parameters));
     }

--- a/src/Testing/Resources/Concerns/Testable.php
+++ b/src/Testing/Resources/Concerns/Testable.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace OpenAI\Testing\Resources\Concerns;
+
+use OpenAI\Contracts\Response;
+use OpenAI\Testing\ClientFake;
+use OpenAI\Testing\Requests\TestRequest;
+
+trait Testable
+{
+    public function __construct(protected ClientFake $fake)
+    {
+    }
+
+    abstract protected function resource(): string;
+
+    /**
+     * @param  array<string, mixed>|string|null  $parameters
+     */
+    protected function record(string $method, array|string|null $parameters = null): Response|string
+    {
+        return $this->fake->record(new TestRequest($this->resource(), $method, $parameters));
+    }
+
+    /**
+     * @param  callable|int|null  $callback
+     */
+    public function assertSent($callback = null): void
+    {
+        $this->fake->assertSent($this->resource(), $callback);
+    }
+
+    /**
+     * @param  callable|int|null  $callback
+     */
+    public function assertNotSent(callable $callback = null): void
+    {
+        $this->fake->assertNotSent($this->resource(), $callback);
+    }
+}

--- a/src/Testing/Resources/EditsTestResource.php
+++ b/src/Testing/Resources/EditsTestResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace OpenAI\Testing\Resources;
+
+use OpenAI\Resources\Contracts\EditsContract;
+use OpenAI\Resources\Edits;
+use OpenAI\Responses\Edits\CreateResponse;
+use OpenAI\Testing\Resources\Concerns\Testable;
+
+final class EditsTestResource implements EditsContract
+{
+    use Testable;
+
+    protected function resource(): string
+    {
+        return Edits::class;
+    }
+
+    public function create(array $parameters): CreateResponse
+    {
+        return $this->record(__FUNCTION__, $parameters);
+    }
+}

--- a/src/Testing/Resources/EmbeddingsTestResource.php
+++ b/src/Testing/Resources/EmbeddingsTestResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace OpenAI\Testing\Resources;
+
+use OpenAI\Resources\Contracts\EmbeddingsContract;
+use OpenAI\Resources\Embeddings;
+use OpenAI\Responses\Embeddings\CreateResponse;
+use OpenAI\Testing\Resources\Concerns\Testable;
+
+final class EmbeddingsTestResource implements EmbeddingsContract
+{
+    use Testable;
+
+    protected function resource(): string
+    {
+        return Embeddings::class;
+    }
+
+    public function create(array $parameters): CreateResponse
+    {
+        return $this->record(__FUNCTION__, $parameters);
+    }
+}

--- a/src/Testing/Resources/FilesTestResource.php
+++ b/src/Testing/Resources/FilesTestResource.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace OpenAI\Testing\Resources;
+
+use OpenAI\Resources\Contracts\FilesContract;
+use OpenAI\Resources\Files;
+use OpenAI\Responses\Files\CreateResponse;
+use OpenAI\Responses\Files\DeleteResponse;
+use OpenAI\Responses\Files\ListResponse;
+use OpenAI\Responses\Files\RetrieveResponse;
+use OpenAI\Testing\Resources\Concerns\Testable;
+
+final class FilesTestResource implements FilesContract
+{
+    use Testable;
+
+    protected function resource(): string
+    {
+        return Files::class;
+    }
+
+    public function list(): ListResponse
+    {
+        return $this->record(__FUNCTION__);
+    }
+
+    public function retrieve(string $file): RetrieveResponse
+    {
+        return $this->record(__FUNCTION__, $file);
+    }
+
+    public function download(string $file): string
+    {
+        return $this->record(__FUNCTION__, $file);
+    }
+
+    public function upload(array $parameters): CreateResponse
+    {
+        return $this->record(__FUNCTION__, $parameters);
+    }
+
+    public function delete(string $file): DeleteResponse
+    {
+        return $this->record(__FUNCTION__, $file);
+    }
+}

--- a/src/Testing/Resources/FineTunesTestResource.php
+++ b/src/Testing/Resources/FineTunesTestResource.php
@@ -7,6 +7,7 @@ use OpenAI\Resources\FineTunes;
 use OpenAI\Responses\FineTunes\ListEventsResponse;
 use OpenAI\Responses\FineTunes\ListResponse;
 use OpenAI\Responses\FineTunes\RetrieveResponse;
+use OpenAI\Responses\StreamResponse;
 use OpenAI\Testing\Resources\Concerns\Testable;
 
 final class FineTunesTestResource implements FineTunesContract
@@ -39,6 +40,11 @@ final class FineTunesTestResource implements FineTunesContract
     }
 
     public function listEvents(string $fineTuneId): ListEventsResponse
+    {
+        return $this->record(__FUNCTION__, $fineTuneId);
+    }
+
+    public function listEventsStreamed(string $fineTuneId): StreamResponse
     {
         return $this->record(__FUNCTION__, $fineTuneId);
     }

--- a/src/Testing/Resources/FineTunesTestResource.php
+++ b/src/Testing/Resources/FineTunesTestResource.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace OpenAI\Testing\Resources;
+
+use OpenAI\Resources\Contracts\FineTunesContract;
+use OpenAI\Resources\FineTunes;
+use OpenAI\Responses\FineTunes\ListEventsResponse;
+use OpenAI\Responses\FineTunes\ListResponse;
+use OpenAI\Responses\FineTunes\RetrieveResponse;
+use OpenAI\Testing\Resources\Concerns\Testable;
+
+final class FineTunesTestResource implements FineTunesContract
+{
+    use Testable;
+
+    protected function resource(): string
+    {
+        return FineTunes::class;
+    }
+
+    public function create(array $parameters): RetrieveResponse
+    {
+        return $this->record(__FUNCTION__, $parameters);
+    }
+
+    public function list(): ListResponse
+    {
+        return $this->record(__FUNCTION__);
+    }
+
+    public function retrieve(string $fineTuneId): RetrieveResponse
+    {
+        return $this->record(__FUNCTION__, $fineTuneId);
+    }
+
+    public function cancel(string $fineTuneId): RetrieveResponse
+    {
+        return $this->record(__FUNCTION__, $fineTuneId);
+    }
+
+    public function listEvents(string $fineTuneId): ListEventsResponse
+    {
+        return $this->record(__FUNCTION__, $fineTuneId);
+    }
+}

--- a/src/Testing/Resources/ImagesTestResource.php
+++ b/src/Testing/Resources/ImagesTestResource.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace OpenAI\Testing\Resources;
+
+use OpenAI\Resources\Contracts\ImagesContract;
+use OpenAI\Resources\Images;
+use OpenAI\Responses\Images\CreateResponse;
+use OpenAI\Responses\Images\EditResponse;
+use OpenAI\Responses\Images\VariationResponse;
+use OpenAI\Testing\Resources\Concerns\Testable;
+
+final class ImagesTestResource implements ImagesContract
+{
+    use Testable;
+
+    protected function resource(): string
+    {
+        return Images::class;
+    }
+
+    public function create(array $parameters): CreateResponse
+    {
+        return $this->record(__FUNCTION__, $parameters);
+    }
+
+    public function edit(array $parameters): EditResponse
+    {
+        return $this->record(__FUNCTION__, $parameters);
+    }
+
+    public function variation(array $parameters): VariationResponse
+    {
+        return $this->record(__FUNCTION__, $parameters);
+    }
+}

--- a/src/Testing/Resources/ModelsTestResource.php
+++ b/src/Testing/Resources/ModelsTestResource.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace OpenAI\Testing\Resources;
+
+use OpenAI\Resources\Contracts\ModelsContract;
+use OpenAI\Resources\Models;
+use OpenAI\Responses\Models\DeleteResponse;
+use OpenAI\Responses\Models\ListResponse;
+use OpenAI\Responses\Models\RetrieveResponse;
+use OpenAI\Testing\Resources\Concerns\Testable;
+
+final class ModelsTestResource implements ModelsContract
+{
+    use Testable;
+
+    protected function resource(): string
+    {
+        return Models::class;
+    }
+
+    public function list(): ListResponse
+    {
+        return $this->record(__FUNCTION__);
+    }
+
+    public function retrieve(string $model): RetrieveResponse
+    {
+        return $this->record(__FUNCTION__, $model);
+    }
+
+    public function delete(string $model): DeleteResponse
+    {
+        return $this->record(__FUNCTION__, $model);
+    }
+}

--- a/src/Testing/Resources/ModerationsTestResource.php
+++ b/src/Testing/Resources/ModerationsTestResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace OpenAI\Testing\Resources;
+
+use OpenAI\Resources\Contracts\ModerationsContract;
+use OpenAI\Resources\Moderations;
+use OpenAI\Responses\Moderations\CreateResponse;
+use OpenAI\Testing\Resources\Concerns\Testable;
+
+final class ModerationsTestResource implements ModerationsContract
+{
+    use Testable;
+
+    protected function resource(): string
+    {
+        return Moderations::class;
+    }
+
+    public function create(array $parameters): CreateResponse
+    {
+        return $this->record(__FUNCTION__, $parameters);
+    }
+}

--- a/src/Testing/Responses/Concerns/Fakeable.php
+++ b/src/Testing/Responses/Concerns/Fakeable.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Testing\Responses\Concerns;
+
+trait Fakeable
+{
+    /**
+     * @param  array<string, mixed>  $override
+     */
+    public static function fake($override = []): static
+    {
+        $class = str_replace('Responses\\', 'Testing\\Responses\\Fixtures\\', static::class).'Fixture';
+
+        return static::from(
+            self::buildAttributes($class::ATTRIBUTES, $override)
+        );
+    }
+
+    /**
+     * @return mixed[]
+     */
+    private static function buildAttributes(array $original, array $override): array
+    {
+        $new = [];
+
+        foreach ($original as $key => $entry) {
+            $new[$key] = is_array($entry) ?
+                self::buildAttributes($entry, $override[$key] ?? []) :
+                $override[$key] ?? $entry;
+        }
+
+        return $new;
+    }
+}

--- a/src/Testing/Responses/Concerns/Fakeable.php
+++ b/src/Testing/Responses/Concerns/Fakeable.php
@@ -9,7 +9,7 @@ trait Fakeable
     /**
      * @param  array<string, mixed>  $override
      */
-    public static function fake($override = []): static
+    public static function fake(array $override = []): static
     {
         $class = str_replace('Responses\\', 'Testing\\Responses\\Fixtures\\', static::class).'Fixture';
 

--- a/src/Testing/Responses/Concerns/FakeableForStreamedResponse.php
+++ b/src/Testing/Responses/Concerns/FakeableForStreamedResponse.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Testing\Responses\Concerns;
+
+use Http\Discovery\Psr17FactoryDiscovery;
+use OpenAI\Responses\StreamResponse;
+
+trait FakeableForStreamedResponse
+{
+    /**
+     * @param  resource  $resource
+     */
+    public static function fake($resource = null): StreamResponse
+    {
+        if ($resource === null) {
+            $filename = str_replace(['OpenAI\Responses', '\\'], [__DIR__.'/../Fixtures/', '/'], static::class).'Fixture.txt';
+            $resource = fopen($filename, 'r');
+        }
+
+        $stream = Psr17FactoryDiscovery::findStreamFactory()
+            ->createStreamFromResource($resource);
+
+        $response = Psr17FactoryDiscovery::findResponseFactory()
+            ->createResponse()
+            ->withBody($stream);
+
+        return new StreamResponse(static::class, $response);
+    }
+}

--- a/src/Testing/Responses/Fixtures/Audio/TranscriptionResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Audio/TranscriptionResponseFixture.php
@@ -14,7 +14,7 @@ final class TranscriptionResponseFixture
                 'seek' => 0,
                 'start' => 0.0,
                 'end' => 4.0,
-                'text' => ' Hello, how are you?',
+                'text' => ' Hello, this is a fake transcription response.',
                 'tokens' => [
                     50364,
                     2425,

--- a/src/Testing/Responses/Fixtures/Audio/TranscriptionResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Audio/TranscriptionResponseFixture.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace OpenAI\Testing\Responses\Fixtures\Audio;
+
+final class TranscriptionResponseFixture
+{
+    public const ATTRIBUTES = [
+        'task' => 'transcribe',
+        'language' => 'english',
+        'duration' => 2.95,
+        'segments' => [
+            [
+                'id' => 0,
+                'seek' => 0,
+                'start' => 0.0,
+                'end' => 4.0,
+                'text' => ' Hello, how are you?',
+                'tokens' => [
+                    50364,
+                    2425,
+                    11,
+                    577,
+                    366,
+                    291,
+                    30,
+                    50564,
+                ],
+                'temperature' => 0.0,
+                'avg_logprob' => -0.45045216878255206,
+                'compression_ratio' => 0.7037037037037037,
+                'no_speech_prob' => 0.1076972484588623,
+                'transient' => false,
+            ],
+        ],
+        'text' => 'Hello, how are you?',
+    ];
+}

--- a/src/Testing/Responses/Fixtures/Audio/TranslationResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Audio/TranslationResponseFixture.php
@@ -14,7 +14,7 @@ final class TranslationResponseFixture
                 'seek' => 0,
                 'start' => 0.0,
                 'end' => 4.0,
-                'text' => ' Hello, how are you?',
+                'text' => ' Hello, this is a fake translation response.',
                 'tokens' => [
                     50364,
                     2425,

--- a/src/Testing/Responses/Fixtures/Audio/TranslationResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Audio/TranslationResponseFixture.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace OpenAI\Testing\Responses\Fixtures\Audio;
+
+final class TranslationResponseFixture
+{
+    public const ATTRIBUTES = [
+        'task' => 'translate',
+        'language' => 'english',
+        'duration' => 2.95,
+        'segments' => [
+            [
+                'id' => 0,
+                'seek' => 0,
+                'start' => 0.0,
+                'end' => 4.0,
+                'text' => ' Hello, how are you?',
+                'tokens' => [
+                    50364,
+                    2425,
+                    11,
+                    577,
+                    366,
+                    291,
+                    30,
+                    50564,
+                ],
+                'temperature' => 0.0,
+                'avg_logprob' => -0.45045216878255206,
+                'compression_ratio' => 0.7037037037037037,
+                'no_speech_prob' => 0.1076972484588623,
+                'transient' => false,
+            ],
+        ],
+        'text' => 'Hello, how are you?',
+    ];
+}

--- a/src/Testing/Responses/Fixtures/Chat/CreateResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Chat/CreateResponseFixture.php
@@ -14,7 +14,7 @@ final class CreateResponseFixture
                 'index' => 0,
                 'message' => [
                     'role' => 'assistant',
-                    'content' => "\n\nHello there, how may I assist you today?",
+                    'content' => "\n\nHello there, this is a fake chat response.",
                 ],
                 'finish_reason' => 'stop',
             ],

--- a/src/Testing/Responses/Fixtures/Chat/CreateResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Chat/CreateResponseFixture.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace OpenAI\Testing\Responses\Fixtures\Chat;
+
+final class CreateResponseFixture
+{
+    public const ATTRIBUTES = [
+        'id' => 'chatcmpl-123',
+        'object' => 'chat.completion',
+        'created' => 1_677_652_288,
+        'model' => 'gpt-3.5-turbo',
+        'choices' => [
+            [
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => "\n\nHello there, how may I assist you today?",
+                ],
+                'finish_reason' => 'stop',
+            ],
+        ],
+        'usage' => [
+            'prompt_tokens' => 9,
+            'completion_tokens' => 12,
+            'total_tokens' => 21,
+        ],
+    ];
+}

--- a/src/Testing/Responses/Fixtures/Chat/CreateStreamedResponseFixture.txt
+++ b/src/Testing/Responses/Fixtures/Chat/CreateStreamedResponseFixture.txt
@@ -1,12 +1,12 @@
 data: {"id":"chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl","object":"chat.completion.chunk","created":1679432086,"model":"gpt-4-0314","choices":[{"delta":{"role":"assistant"},"index":0,"finish_reason":null}]}
 data: {"id":"chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl","object":"chat.completion.chunk","created":1679432086,"model":"gpt-4-0314","choices":[{"delta":{"content":"Hello"},"index":0,"finish_reason":null}]}
 data: {"id":"chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl","object":"chat.completion.chunk","created":1679432086,"model":"gpt-4-0314","choices":[{"delta":{"content":"!"},"index":0,"finish_reason":null}]}
-data: {"id":"chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl","object":"chat.completion.chunk","created":1679432086,"model":"gpt-4-0314","choices":[{"delta":{"content":" How"},"index":0,"finish_reason":null}]}
-data: {"id":"chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl","object":"chat.completion.chunk","created":1679432086,"model":"gpt-4-0314","choices":[{"delta":{"content":" can"},"index":0,"finish_reason":null}]}
-data: {"id":"chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl","object":"chat.completion.chunk","created":1679432086,"model":"gpt-4-0314","choices":[{"delta":{"content":" I"},"index":0,"finish_reason":null}]}
-data: {"id":"chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl","object":"chat.completion.chunk","created":1679432086,"model":"gpt-4-0314","choices":[{"delta":{"content":" help"},"index":0,"finish_reason":null}]}
-data: {"id":"chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl","object":"chat.completion.chunk","created":1679432086,"model":"gpt-4-0314","choices":[{"delta":{"content":" you"},"index":0,"finish_reason":null}]}
-data: {"id":"chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl","object":"chat.completion.chunk","created":1679432086,"model":"gpt-4-0314","choices":[{"delta":{"content":" today"},"index":0,"finish_reason":null}]}
-data: {"id":"chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl","object":"chat.completion.chunk","created":1679432086,"model":"gpt-4-0314","choices":[{"delta":{"content":"?"},"index":0,"finish_reason":null}]}
+data: {"id":"chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl","object":"chat.completion.chunk","created":1679432086,"model":"gpt-4-0314","choices":[{"delta":{"content":" This"},"index":0,"finish_reason":null}]}
+data: {"id":"chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl","object":"chat.completion.chunk","created":1679432086,"model":"gpt-4-0314","choices":[{"delta":{"content":" is"},"index":0,"finish_reason":null}]}
+data: {"id":"chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl","object":"chat.completion.chunk","created":1679432086,"model":"gpt-4-0314","choices":[{"delta":{"content":" a"},"index":0,"finish_reason":null}]}
+data: {"id":"chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl","object":"chat.completion.chunk","created":1679432086,"model":"gpt-4-0314","choices":[{"delta":{"content":" fake"},"index":0,"finish_reason":null}]}
+data: {"id":"chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl","object":"chat.completion.chunk","created":1679432086,"model":"gpt-4-0314","choices":[{"delta":{"content":" chat"},"index":0,"finish_reason":null}]}
+data: {"id":"chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl","object":"chat.completion.chunk","created":1679432086,"model":"gpt-4-0314","choices":[{"delta":{"content":" response"},"index":0,"finish_reason":null}]}
+data: {"id":"chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl","object":"chat.completion.chunk","created":1679432086,"model":"gpt-4-0314","choices":[{"delta":{"content":"."},"index":0,"finish_reason":null}]}
 data: {"id":"chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl","object":"chat.completion.chunk","created":1679432086,"model":"gpt-4-0314","choices":[{"delta":{},"index":0,"finish_reason":"stop"}]}
 data: [DONE]

--- a/src/Testing/Responses/Fixtures/Chat/CreateStreamedResponseFixture.txt
+++ b/src/Testing/Responses/Fixtures/Chat/CreateStreamedResponseFixture.txt
@@ -1,0 +1,12 @@
+data: {"id":"chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl","object":"chat.completion.chunk","created":1679432086,"model":"gpt-4-0314","choices":[{"delta":{"role":"assistant"},"index":0,"finish_reason":null}]}
+data: {"id":"chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl","object":"chat.completion.chunk","created":1679432086,"model":"gpt-4-0314","choices":[{"delta":{"content":"Hello"},"index":0,"finish_reason":null}]}
+data: {"id":"chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl","object":"chat.completion.chunk","created":1679432086,"model":"gpt-4-0314","choices":[{"delta":{"content":"!"},"index":0,"finish_reason":null}]}
+data: {"id":"chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl","object":"chat.completion.chunk","created":1679432086,"model":"gpt-4-0314","choices":[{"delta":{"content":" How"},"index":0,"finish_reason":null}]}
+data: {"id":"chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl","object":"chat.completion.chunk","created":1679432086,"model":"gpt-4-0314","choices":[{"delta":{"content":" can"},"index":0,"finish_reason":null}]}
+data: {"id":"chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl","object":"chat.completion.chunk","created":1679432086,"model":"gpt-4-0314","choices":[{"delta":{"content":" I"},"index":0,"finish_reason":null}]}
+data: {"id":"chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl","object":"chat.completion.chunk","created":1679432086,"model":"gpt-4-0314","choices":[{"delta":{"content":" help"},"index":0,"finish_reason":null}]}
+data: {"id":"chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl","object":"chat.completion.chunk","created":1679432086,"model":"gpt-4-0314","choices":[{"delta":{"content":" you"},"index":0,"finish_reason":null}]}
+data: {"id":"chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl","object":"chat.completion.chunk","created":1679432086,"model":"gpt-4-0314","choices":[{"delta":{"content":" today"},"index":0,"finish_reason":null}]}
+data: {"id":"chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl","object":"chat.completion.chunk","created":1679432086,"model":"gpt-4-0314","choices":[{"delta":{"content":"?"},"index":0,"finish_reason":null}]}
+data: {"id":"chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl","object":"chat.completion.chunk","created":1679432086,"model":"gpt-4-0314","choices":[{"delta":{},"index":0,"finish_reason":"stop"}]}
+data: [DONE]

--- a/src/Testing/Responses/Fixtures/Completions/CreateResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Completions/CreateResponseFixture.php
@@ -11,7 +11,7 @@ final class CreateResponseFixture
         'model' => 'text-davinci-003',
         'choices' => [
             [
-                'text' => "\n\nThis is indeed a test",
+                'text' => "\n\nThis is a fake completion response.",
                 'index' => 0,
                 'logprobs' => null,
                 'finish_reason' => 'length',

--- a/src/Testing/Responses/Fixtures/Completions/CreateResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Completions/CreateResponseFixture.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace OpenAI\Testing\Responses\Fixtures\Completions;
+
+final class CreateResponseFixture
+{
+    public const ATTRIBUTES = [
+        'id' => 'cmpl-uqkvlQyYK7bGYrRHQ0eXlWi7',
+        'object' => 'text_completion',
+        'created' => 1_589_478_378,
+        'model' => 'text-davinci-003',
+        'choices' => [
+            [
+                'text' => "\n\nThis is indeed a test",
+                'index' => 0,
+                'logprobs' => null,
+                'finish_reason' => 'length',
+            ],
+        ],
+        'usage' => [
+            'prompt_tokens' => 5,
+            'completion_tokens' => 7,
+            'total_tokens' => 12,
+        ],
+    ];
+}

--- a/src/Testing/Responses/Fixtures/Completions/CreateStreamedResponseFixture.txt
+++ b/src/Testing/Responses/Fixtures/Completions/CreateStreamedResponseFixture.txt
@@ -1,0 +1,11 @@
+data: {"id": "cmpl-6ynJi2uZZnKntnEZreDcjGyoPbVAn", "object": "text_completion", "created": 1679430847, "choices": [{"text": " everyone", "index": 0, "logprobs": null, "finish_reason": null}], "model": "text-davinci-003"}
+data: {"id": "cmpl-6ynJi2uZZnKntnEZreDcjGyoPbVAn", "object": "text_completion", "created": 1679430847, "choices": [{"text": "!", "index": 0, "logprobs": null, "finish_reason": null}], "model": "text-davinci-003"}
+data: {"id": "cmpl-6ynJi2uZZnKntnEZreDcjGyoPbVAn", "object": "text_completion", "created": 1679430847, "choices": [{"text": "\n", "index": 0, "logprobs": null, "finish_reason": null}], "model": "text-davinci-003"}
+data: {"id": "cmpl-6ynJi2uZZnKntnEZreDcjGyoPbVAn", "object": "text_completion", "created": 1679430847, "choices": [{"text": "\n", "index": 0, "logprobs": null, "finish_reason": null}], "model": "text-davinci-003"}
+data: {"id": "cmpl-6ynJi2uZZnKntnEZreDcjGyoPbVAn", "object": "text_completion", "created": 1679430847, "choices": [{"text": "I", "index": 0, "logprobs": null, "finish_reason": null}], "model": "text-davinci-003"}
+data: {"id": "cmpl-6ynJi2uZZnKntnEZreDcjGyoPbVAn", "object": "text_completion", "created": 1679430847, "choices": [{"text": " just", "index": 0, "logprobs": null, "finish_reason": null}], "model": "text-davinci-003"}
+data: {"id": "cmpl-6ynJi2uZZnKntnEZreDcjGyoPbVAn", "object": "text_completion", "created": 1679430847, "choices": [{"text": " wanted", "index": 0, "logprobs": null, "finish_reason": null}], "model": "text-davinci-003"}
+data: {"id": "cmpl-6ynJi2uZZnKntnEZreDcjGyoPbVAn", "object": "text_completion", "created": 1679430847, "choices": [{"text": " to", "index": 0, "logprobs": null, "finish_reason": null}], "model": "text-davinci-003"}
+data: {"id": "cmpl-6ynJi2uZZnKntnEZreDcjGyoPbVAn", "object": "text_completion", "created": 1679430847, "choices": [{"text": " check", "index": 0, "logprobs": null, "finish_reason": null}], "model": "text-davinci-003"}
+data: {"id": "cmpl-6ynJi2uZZnKntnEZreDcjGyoPbVAn", "object": "text_completion", "created": 1679430847, "choices": [{"text": " in", "index": 0, "logprobs": null, "finish_reason": "length"}], "model": "text-davinci-003"}
+data: [DONE]

--- a/src/Testing/Responses/Fixtures/Completions/CreateStreamedResponseFixture.txt
+++ b/src/Testing/Responses/Fixtures/Completions/CreateStreamedResponseFixture.txt
@@ -2,10 +2,10 @@ data: {"id": "cmpl-6ynJi2uZZnKntnEZreDcjGyoPbVAn", "object": "text_completion", 
 data: {"id": "cmpl-6ynJi2uZZnKntnEZreDcjGyoPbVAn", "object": "text_completion", "created": 1679430847, "choices": [{"text": "!", "index": 0, "logprobs": null, "finish_reason": null}], "model": "text-davinci-003"}
 data: {"id": "cmpl-6ynJi2uZZnKntnEZreDcjGyoPbVAn", "object": "text_completion", "created": 1679430847, "choices": [{"text": "\n", "index": 0, "logprobs": null, "finish_reason": null}], "model": "text-davinci-003"}
 data: {"id": "cmpl-6ynJi2uZZnKntnEZreDcjGyoPbVAn", "object": "text_completion", "created": 1679430847, "choices": [{"text": "\n", "index": 0, "logprobs": null, "finish_reason": null}], "model": "text-davinci-003"}
-data: {"id": "cmpl-6ynJi2uZZnKntnEZreDcjGyoPbVAn", "object": "text_completion", "created": 1679430847, "choices": [{"text": "I", "index": 0, "logprobs": null, "finish_reason": null}], "model": "text-davinci-003"}
-data: {"id": "cmpl-6ynJi2uZZnKntnEZreDcjGyoPbVAn", "object": "text_completion", "created": 1679430847, "choices": [{"text": " just", "index": 0, "logprobs": null, "finish_reason": null}], "model": "text-davinci-003"}
-data: {"id": "cmpl-6ynJi2uZZnKntnEZreDcjGyoPbVAn", "object": "text_completion", "created": 1679430847, "choices": [{"text": " wanted", "index": 0, "logprobs": null, "finish_reason": null}], "model": "text-davinci-003"}
-data: {"id": "cmpl-6ynJi2uZZnKntnEZreDcjGyoPbVAn", "object": "text_completion", "created": 1679430847, "choices": [{"text": " to", "index": 0, "logprobs": null, "finish_reason": null}], "model": "text-davinci-003"}
-data: {"id": "cmpl-6ynJi2uZZnKntnEZreDcjGyoPbVAn", "object": "text_completion", "created": 1679430847, "choices": [{"text": " check", "index": 0, "logprobs": null, "finish_reason": null}], "model": "text-davinci-003"}
-data: {"id": "cmpl-6ynJi2uZZnKntnEZreDcjGyoPbVAn", "object": "text_completion", "created": 1679430847, "choices": [{"text": " in", "index": 0, "logprobs": null, "finish_reason": "length"}], "model": "text-davinci-003"}
+data: {"id": "cmpl-6ynJi2uZZnKntnEZreDcjGyoPbVAn", "object": "text_completion", "created": 1679430847, "choices": [{"text": "This", "index": 0, "logprobs": null, "finish_reason": null}], "model": "text-davinci-003"}
+data: {"id": "cmpl-6ynJi2uZZnKntnEZreDcjGyoPbVAn", "object": "text_completion", "created": 1679430847, "choices": [{"text": " is", "index": 0, "logprobs": null, "finish_reason": null}], "model": "text-davinci-003"}
+data: {"id": "cmpl-6ynJi2uZZnKntnEZreDcjGyoPbVAn", "object": "text_completion", "created": 1679430847, "choices": [{"text": " a", "index": 0, "logprobs": null, "finish_reason": null}], "model": "text-davinci-003"}
+data: {"id": "cmpl-6ynJi2uZZnKntnEZreDcjGyoPbVAn", "object": "text_completion", "created": 1679430847, "choices": [{"text": " fake", "index": 0, "logprobs": null, "finish_reason": null}], "model": "text-davinci-003"}
+data: {"id": "cmpl-6ynJi2uZZnKntnEZreDcjGyoPbVAn", "object": "text_completion", "created": 1679430847, "choices": [{"text": " completion", "index": 0, "logprobs": null, "finish_reason": null}], "model": "text-davinci-003"}
+data: {"id": "cmpl-6ynJi2uZZnKntnEZreDcjGyoPbVAn", "object": "text_completion", "created": 1679430847, "choices": [{"text": " response.", "index": 0, "logprobs": null, "finish_reason": "length"}], "model": "text-davinci-003"}
 data: [DONE]

--- a/src/Testing/Responses/Fixtures/Edits/CreateResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Edits/CreateResponseFixture.php
@@ -8,13 +8,13 @@ final class CreateResponseFixture
         'object' => 'edit',
         'created' => 1_664_135_921,
         'choices' => [[
-            'text' => "What day of the week is it?\n",
+            'text' => "This is a fake edit response.\n",
             'index' => 0,
         ]],
         'usage' => [
             'prompt_tokens' => 25,
-            'completion_tokens' => 28,
-            'total_tokens' => 53,
+            'completion_tokens' => 30,
+            'total_tokens' => 55,
         ],
     ];
 }

--- a/src/Testing/Responses/Fixtures/Edits/CreateResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Edits/CreateResponseFixture.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace OpenAI\Testing\Responses\Fixtures\Edits;
+
+final class CreateResponseFixture
+{
+    public const ATTRIBUTES = [
+        'object' => 'edit',
+        'created' => 1_664_135_921,
+        'choices' => [[
+            'text' => "What day of the week is it?\n",
+            'index' => 0,
+        ]],
+        'usage' => [
+            'prompt_tokens' => 25,
+            'completion_tokens' => 28,
+            'total_tokens' => 53,
+        ],
+    ];
+}

--- a/src/Testing/Responses/Fixtures/Embeddings/CreateResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Embeddings/CreateResponseFixture.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace OpenAI\Testing\Responses\Fixtures\Embeddings;
+
+final class CreateResponseFixture
+{
+    public const ATTRIBUTES = [
+        'object' => 'list',
+        'data' => [
+            [
+                'object' => 'embedding',
+                'index' => 0,
+                'embedding' => [
+                    -0.008906792,
+                    -0.013743395,
+                ],
+            ],
+        ],
+        'usage' => [
+            'prompt_tokens' => 8,
+            'total_tokens' => 8,
+        ],
+    ];
+}

--- a/src/Testing/Responses/Fixtures/Files/CreateResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Files/CreateResponseFixture.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace OpenAI\Testing\Responses\Fixtures\Files;
+
+final class CreateResponseFixture
+{
+    public const ATTRIBUTES = [
+        'id' => 'file-XjGxS3KTG0uNmNOK362iJua3',
+        'object' => 'file',
+        'bytes' => 140,
+        'created_at' => 1_613_779_121,
+        'filename' => 'mydata.jsonl',
+        'purpose' => 'fine-tune',
+        'status' => 'succeeded',
+        'status_details' => null,
+    ];
+}

--- a/src/Testing/Responses/Fixtures/Files/CreateResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Files/CreateResponseFixture.php
@@ -9,7 +9,7 @@ final class CreateResponseFixture
         'object' => 'file',
         'bytes' => 140,
         'created_at' => 1_613_779_121,
-        'filename' => 'mydata.jsonl',
+        'filename' => 'fake-file.jsonl',
         'purpose' => 'fine-tune',
         'status' => 'succeeded',
         'status_details' => null,

--- a/src/Testing/Responses/Fixtures/Files/DeleteResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Files/DeleteResponseFixture.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace OpenAI\Testing\Responses\Fixtures\Files;
+
+final class DeleteResponseFixture
+{
+    public const ATTRIBUTES = [
+        'id' => 'file-XjGxS3KTG0uNmNOK362iJua3',
+        'object' => 'file',
+        'deleted' => true,
+    ];
+}

--- a/src/Testing/Responses/Fixtures/Files/ListResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Files/ListResponseFixture.php
@@ -12,7 +12,7 @@ final class ListResponseFixture
                 'object' => 'file',
                 'bytes' => 140,
                 'created_at' => 1_613_779_121,
-                'filename' => 'mydata.jsonl',
+                'filename' => 'fake-file.jsonl',
                 'purpose' => 'fine-tune',
                 'status' => 'succeeded',
                 'status_details' => null,

--- a/src/Testing/Responses/Fixtures/Files/ListResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Files/ListResponseFixture.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace OpenAI\Testing\Responses\Fixtures\Files;
+
+final class ListResponseFixture
+{
+    public const ATTRIBUTES = [
+        'object' => 'list',
+        'data' => [
+            [
+                'id' => 'file-XjGxS3KTG0uNmNOK362iJua3',
+                'object' => 'file',
+                'bytes' => 140,
+                'created_at' => 1_613_779_121,
+                'filename' => 'mydata.jsonl',
+                'purpose' => 'fine-tune',
+                'status' => 'succeeded',
+                'status_details' => null,
+            ],
+        ],
+    ];
+}

--- a/src/Testing/Responses/Fixtures/Files/RetrieveResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Files/RetrieveResponseFixture.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace OpenAI\Testing\Responses\Fixtures\Files;
+
+final class RetrieveResponseFixture
+{
+    public const ATTRIBUTES = [
+        'id' => 'file-XjGxS3KTG0uNmNOK362iJua3',
+        'object' => 'file',
+        'bytes' => 140,
+        'created_at' => 1_613_779_121,
+        'filename' => 'mydata.jsonl',
+        'purpose' => 'fine-tune',
+        'status' => 'succeeded',
+        'status_details' => null,
+    ];
+}

--- a/src/Testing/Responses/Fixtures/Files/RetrieveResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Files/RetrieveResponseFixture.php
@@ -9,7 +9,7 @@ final class RetrieveResponseFixture
         'object' => 'file',
         'bytes' => 140,
         'created_at' => 1_613_779_121,
-        'filename' => 'mydata.jsonl',
+        'filename' => 'fake-file.jsonl',
         'purpose' => 'fine-tune',
         'status' => 'succeeded',
         'status_details' => null,

--- a/src/Testing/Responses/Fixtures/FineTunes/ListEventsResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/FineTunes/ListEventsResponseFixture.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace OpenAI\Testing\Responses\Fixtures\FineTunes;
+
+final class ListEventsResponseFixture
+{
+    public const ATTRIBUTES = [
+        'object' => 'list',
+        'data' => [
+            [
+                'object' => 'fine-tune-event',
+                'created_at' => 1_614_807_352,
+                'level' => 'info',
+                'message' => 'Job enqueued. Waiting for jobs ahead to complete. Queue number =>  0.',
+            ],
+        ],
+    ];
+}

--- a/src/Testing/Responses/Fixtures/FineTunes/ListResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/FineTunes/ListResponseFixture.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace OpenAI\Testing\Responses\Fixtures\FineTunes;
+
+final class ListResponseFixture
+{
+    public const ATTRIBUTES = [
+        'object' => 'list',
+        'data' => [
+            RetrieveResponseFixture::ATTRIBUTES,
+        ],
+    ];
+}

--- a/src/Testing/Responses/Fixtures/FineTunes/RetrieveResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/FineTunes/RetrieveResponseFixture.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace OpenAI\Testing\Responses\Fixtures\FineTunes;
+
+use OpenAI\Testing\Responses\Fixtures\Files\CreateResponseFixture;
+
+final class RetrieveResponseFixture
+{
+    public const ATTRIBUTES = [
+        'id' => 'ft-AF1WoRqd3aJAHsqc9NY7iL8F',
+        'object' => 'fine-tune',
+        'model' => 'curie',
+        'created_at' => 1_614_807_352,
+        'events' => [
+            [
+                'object' => 'fine-tune-event',
+                'created_at' => 1_614_807_352,
+                'level' => 'info',
+                'message' => 'Job enqueued. Waiting for jobs ahead to complete. Queue number =>  0.',
+            ],
+        ],
+        'fine_tuned_model' => 'curie => ft-acmeco-2021-03-03-21-44-20',
+        'hyperparams' => [
+            'batch_size' => 4,
+            'learning_rate_multiplier' => 0.1,
+            'n_epochs' => 4,
+            'prompt_loss_weight' => 0.1,
+        ],
+        'organization_id' => 'org-jwe45798ASN82s',
+        'result_files' => [
+            CreateResponseFixture::ATTRIBUTES,
+        ],
+        'status' => 'succeeded',
+        'validation_files' => [
+            CreateResponseFixture::ATTRIBUTES,
+        ],
+        'training_files' => [
+            CreateResponseFixture::ATTRIBUTES,
+        ],
+        'updated_at' => 1_614_807_865,
+    ];
+}

--- a/src/Testing/Responses/Fixtures/FineTunes/RetrieveStreamedResponseEventFixture.txt
+++ b/src/Testing/Responses/Fixtures/FineTunes/RetrieveStreamedResponseEventFixture.txt
@@ -1,0 +1,12 @@
+data: {"object": "fine-tune-event", "level": "info", "message": "Created fine-tune: ft-y3OpNlc8B5qBVGCCVsLZsDST", "created_at": 1668021917}
+data: {"object": "fine-tune-event", "level": "info", "message": "Fine-tune costs $0.00", "created_at": 1668021926}
+data: {"object": "fine-tune-event", "level": "info", "message": "Fine-tune enqueued. Queue number: 0", "created_at": 1668021927}
+data: {"object": "fine-tune-event", "level": "info", "message": "Fine-tune started", "created_at": 1668021929}
+data: {"object": "fine-tune-event", "level": "info", "message": "Completed epoch 1/4", "created_at": 1668021976}
+data: {"object": "fine-tune-event", "level": "info", "message": "Completed epoch 2/4", "created_at": 1668021977}
+data: {"object": "fine-tune-event", "level": "info", "message": "Completed epoch 3/4", "created_at": 1668021978}
+data: {"object": "fine-tune-event", "level": "info", "message": "Completed epoch 4/4", "created_at": 1668021978}
+data: {"object": "fine-tune-event", "level": "info", "message": "Uploaded model: curie:ft-gehri-dev-2022-11-09-19-26-40", "created_at": 1668022001}
+data: {"object": "fine-tune-event", "level": "info", "message": "Uploaded result file: file-ajLKUCMsFPrT633zqwr0eI4l", "created_at": 1668022002}
+data: {"object": "fine-tune-event", "level": "info", "message": "Fine-tune succeeded", "created_at": 1668022002}
+data: [DONE]

--- a/src/Testing/Responses/Fixtures/Images/CreateResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Images/CreateResponseFixture.php
@@ -8,7 +8,7 @@ final class CreateResponseFixture
         'created' => 1_664_136_088,
         'data' => [
             [
-                'url' => 'https://openai.com/image.png',
+                'url' => 'https://openai.com/fake-image.png',
             ],
         ],
     ];

--- a/src/Testing/Responses/Fixtures/Images/CreateResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Images/CreateResponseFixture.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace OpenAI\Testing\Responses\Fixtures\Images;
+
+final class CreateResponseFixture
+{
+    public const ATTRIBUTES = [
+        'created' => 1_664_136_088,
+        'data' => [
+            [
+                'url' => 'https://openai.com/image.png',
+            ],
+        ],
+    ];
+}

--- a/src/Testing/Responses/Fixtures/Images/EditResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Images/EditResponseFixture.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace OpenAI\Testing\Responses\Fixtures\Images;
+
+final class EditResponseFixture
+{
+    public const ATTRIBUTES = [
+        'created' => 1_664_136_088,
+        'data' => [
+            [
+                'url' => 'https://openai.com/image.png',
+            ],
+        ],
+    ];
+}

--- a/src/Testing/Responses/Fixtures/Images/EditResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Images/EditResponseFixture.php
@@ -8,7 +8,7 @@ final class EditResponseFixture
         'created' => 1_664_136_088,
         'data' => [
             [
-                'url' => 'https://openai.com/image.png',
+                'url' => 'https://openai.com/fake-image.png',
             ],
         ],
     ];

--- a/src/Testing/Responses/Fixtures/Images/VariationResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Images/VariationResponseFixture.php
@@ -8,7 +8,7 @@ final class VariationResponseFixture
         'created' => 1_664_136_088,
         'data' => [
             [
-                'url' => 'https://openai.com/image.png',
+                'url' => 'https://openai.com/fake-image.png',
             ],
         ],
     ];

--- a/src/Testing/Responses/Fixtures/Images/VariationResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Images/VariationResponseFixture.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace OpenAI\Testing\Responses\Fixtures\Images;
+
+final class VariationResponseFixture
+{
+    public const ATTRIBUTES = [
+        'created' => 1_664_136_088,
+        'data' => [
+            [
+                'url' => 'https://openai.com/image.png',
+            ],
+        ],
+    ];
+}

--- a/src/Testing/Responses/Fixtures/Models/DeleteResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Models/DeleteResponseFixture.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace OpenAI\Testing\Responses\Fixtures\Models;
+
+final class DeleteResponseFixture
+{
+    public const ATTRIBUTES = [
+        'id' => 'curie:ft-acmeco-2021-03-03-21-44-20',
+        'object' => 'model',
+        'deleted' => true,
+    ];
+}

--- a/src/Testing/Responses/Fixtures/Models/ListResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Models/ListResponseFixture.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace OpenAI\Testing\Responses\Fixtures\Models;
+
+final class ListResponseFixture
+{
+    public const ATTRIBUTES = [
+        'object' => 'list',
+        'data' => [
+            RetrieveResponseFixture::ATTRIBUTES,
+        ],
+    ];
+}

--- a/src/Testing/Responses/Fixtures/Models/RetrieveResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Models/RetrieveResponseFixture.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace OpenAI\Testing\Responses\Fixtures\Models;
+
+final class RetrieveResponseFixture
+{
+    public const ATTRIBUTES = [
+        'id' => 'text-babbage:001',
+        'object' => 'model',
+        'created' => 1_642_018_370,
+        'owned_by' => 'openai',
+        'permission' => [
+            [
+                'id' => 'snapperm-7oP3WFr9x7qf5xb3eZrVABAH',
+                'object' => 'model_permission',
+                'created' => 1_642_018_480,
+                'allow_create_engine' => false,
+                'allow_sampling' => true,
+                'allow_logprobs' => true,
+                'allow_search_indices' => false,
+                'allow_view' => true,
+                'allow_fine_tuning' => false,
+                'organization' => '*',
+                'group' => null,
+                'is_blocking' => false,
+            ],
+        ],
+        'root' => 'text-babbage:001',
+        'parent' => null,
+    ];
+}

--- a/src/Testing/Responses/Fixtures/Moderations/CreateResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Moderations/CreateResponseFixture.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace OpenAI\Testing\Responses\Fixtures\Moderations;
+
+final class CreateResponseFixture
+{
+    public const ATTRIBUTES = [
+        'id' => 'modr-5MWoLO',
+        'model' => 'text-moderation-001',
+        'results' => [
+            [
+                'categories' => [
+                    'hate' => false,
+                    'hate/threatening' => true,
+                    'self-harm' => false,
+                    'sexual' => false,
+                    'sexual/minors' => false,
+                    'violence' => true,
+                    'violence/graphic' => false,
+                ],
+                'category_scores' => [
+                    'hate' => 0.22714105248451233,
+                    'hate/threatening' => 0.4132447838783264,
+                    'self-harm' => 0.005232391878962517,
+                    'sexual' => 0.01407341007143259,
+                    'sexual/minors' => 0.0038522258400917053,
+                    'violence' => 0.9223177433013916,
+                    'violence/graphic' => 0.036865197122097015,
+                ],
+                'flagged' => true,
+            ],
+        ],
+    ];
+}

--- a/src/Transporters/HttpTransporter.php
+++ b/src/Transporters/HttpTransporter.php
@@ -12,6 +12,7 @@ use OpenAI\Exceptions\UnserializableResponse;
 use OpenAI\ValueObjects\Transporter\BaseUri;
 use OpenAI\ValueObjects\Transporter\Headers;
 use OpenAI\ValueObjects\Transporter\Payload;
+use OpenAI\ValueObjects\Transporter\QueryParams;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 
@@ -27,6 +28,7 @@ final class HttpTransporter implements Transporter
         private readonly ClientInterface $client,
         private readonly BaseUri $baseUri,
         private readonly Headers $headers,
+        private readonly QueryParams $queryParams,
     ) {
         // ..
     }
@@ -36,7 +38,7 @@ final class HttpTransporter implements Transporter
      */
     public function requestObject(Payload $payload): array|string
     {
-        $request = $payload->toRequest($this->baseUri, $this->headers);
+        $request = $payload->toRequest($this->baseUri, $this->headers, $this->queryParams);
 
         try {
             $response = $this->client->sendRequest($request);
@@ -69,7 +71,7 @@ final class HttpTransporter implements Transporter
      */
     public function requestContent(Payload $payload): string
     {
-        $request = $payload->toRequest($this->baseUri, $this->headers);
+        $request = $payload->toRequest($this->baseUri, $this->headers, $this->queryParams);
 
         try {
             $response = $this->client->sendRequest($request);

--- a/src/ValueObjects/Transporter/Headers.php
+++ b/src/ValueObjects/Transporter/Headers.php
@@ -23,6 +23,14 @@ final class Headers
     }
 
     /**
+     * Creates a new Headers value object
+     */
+    public static function create(): self
+    {
+        return new self([]);
+    }
+
+    /**
      * Creates a new Headers value object with the given API token.
      */
     public static function withAuthorization(ApiKey $apiKey): self
@@ -51,6 +59,17 @@ final class Headers
         return new self([
             ...$this->headers,
             'OpenAI-Organization' => $organization,
+        ]);
+    }
+
+    /**
+     * Creates a new Headers value object, with the newly added header, and the existing headers.
+     */
+    public function withCustomHeader(string $name, string $value): self
+    {
+        return new self([
+            ...$this->headers,
+            $name => $value,
         ]);
     }
 

--- a/src/ValueObjects/Transporter/QueryParams.php
+++ b/src/ValueObjects/Transporter/QueryParams.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\ValueObjects\Transporter;
+
+/**
+ * @internal
+ */
+final class QueryParams
+{
+    /**
+     * Creates a new Query Params value object.
+     *
+     * @param  array<string, string|int>  $params
+     */
+    private function __construct(private readonly array $params)
+    {
+        // ..
+    }
+
+    /**
+     * Creates a new Query Params value object
+     */
+    public static function create(): self
+    {
+        return new self([]);
+    }
+
+    /**
+     * Creates a new Query Params value object, with the newly added param, and the existing params.
+     */
+    public function withParam(string $name, string|int $value): self
+    {
+        return new self([
+            ...$this->params,
+            $name => $value,
+        ]);
+    }
+
+    /**
+     * @return array<string, string|int>
+     */
+    public function toArray(): array
+    {
+        return $this->params;
+    }
+}

--- a/tests/Arch.php
+++ b/tests/Arch.php
@@ -24,7 +24,10 @@ test('responses')->expect('OpenAI\Responses')->toOnlyUse([
 ]);
 
 test('value objects')->expect('OpenAI\ValueObjects')->toOnlyUse([
-    'GuzzleHttp\Psr7',
+    'Http\Discovery\Psr17Factory',
+    'Http\Message\MultipartStream\MultipartStreamBuilder',
+    'Psr\Http\Message\RequestInterface',
+    'Psr\Http\Message\StreamInterface',
     'OpenAI\Enums',
     'OpenAI\Contracts',
 ]);
@@ -35,9 +38,12 @@ test('client')->expect('OpenAI\Client')->toOnlyUse([
 ]);
 
 test('openai')->expect('OpenAI')->toOnlyUse([
-    'Psr\Http\Client',
-    'GuzzleHttp\Client',
-    'GuzzleHttp\Psr7',
-    'OpenAI\Resources',
+    'Http\Discovery\Psr17Factory',
+    'Http\Discovery\Psr18ClientDiscovery',
+    'Http\Message\MultipartStream\MultipartStreamBuilder',
     'OpenAI\Contracts',
+    'OpenAI\Resources',
+    'Psr\Http\Client',
+    'Psr\Http\Message\RequestInterface',
+    'Psr\Http\Message\StreamInterface',
 ])->ignoring('OpenAI\Testing');

--- a/tests/Arch.php
+++ b/tests/Arch.php
@@ -3,6 +3,7 @@
 test('contracts')->expect('OpenAI\Contracts')->toOnlyUse([
     'OpenAI\ValueObjects',
     'OpenAI\Exceptions',
+    'OpenAI\Resources',
 ]);
 
 test('exceptions')->expect('OpenAI\Exceptions')->toOnlyUse([
@@ -19,6 +20,7 @@ test('resources')->expect('OpenAI\Resources')->toOnlyUse([
 test('responses')->expect('OpenAI\Responses')->toOnlyUse([
     'OpenAI\Enums',
     'OpenAI\Contracts',
+    'OpenAI\Testing\Responses\Concerns',
 ]);
 
 test('value objects')->expect('OpenAI\ValueObjects')->toOnlyUse([
@@ -38,4 +40,4 @@ test('openai')->expect('OpenAI')->toOnlyUse([
     'GuzzleHttp\Psr7',
     'OpenAI\Resources',
     'OpenAI\Contracts',
-]);
+])->ignoring('OpenAI\Testing');

--- a/tests/OpenAI.php
+++ b/tests/OpenAI.php
@@ -1,5 +1,6 @@
 <?php
 
+use GuzzleHttp\Client as GuzzleClient;
 use OpenAI\Client;
 
 it('may create a client', function () {
@@ -10,6 +11,54 @@ it('may create a client', function () {
 
 it('sets organization when provided', function () {
     $openAI = OpenAI::client('foo', 'nunomaduro');
+
+    expect($openAI)->toBeInstanceOf(Client::class);
+});
+
+it('may create a client via factory', function () {
+    $openAI = OpenAI::factory()
+        ->withApiKey('foo')
+        ->make();
+
+    expect($openAI)->toBeInstanceOf(Client::class);
+});
+
+it('sets an organization via factory', function () {
+    $openAI = OpenAI::factory()
+        ->withOrganization('nunomaduro')
+        ->make();
+
+    expect($openAI)->toBeInstanceOf(Client::class);
+});
+
+it('sets a custom client via factory', function () {
+    $openAI = OpenAI::factory()
+        ->withHttpClient(new GuzzleClient())
+        ->make();
+
+    expect($openAI)->toBeInstanceOf(Client::class);
+});
+
+it('sets a custom base url via factory', function () {
+    $openAI = OpenAI::factory()
+        ->withBaseUri('https://openai.example.com/v1')
+        ->make();
+
+    expect($openAI)->toBeInstanceOf(Client::class);
+});
+
+it('sets a custom header via factory', function () {
+    $openAI = OpenAI::factory()
+        ->withHttpHeader('X-My-Header', 'foo')
+        ->make();
+
+    expect($openAI)->toBeInstanceOf(Client::class);
+});
+
+it('sets a custom query parameter via factory', function () {
+    $openAI = OpenAI::factory()
+        ->withQueryParam('my-param', 'bar')
+        ->make();
 
     expect($openAI)->toBeInstanceOf(Client::class);
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -6,6 +6,7 @@ use OpenAI\ValueObjects\ApiKey;
 use OpenAI\ValueObjects\Transporter\BaseUri;
 use OpenAI\ValueObjects\Transporter\Headers;
 use OpenAI\ValueObjects\Transporter\Payload;
+use OpenAI\ValueObjects\Transporter\QueryParams;
 
 function mockClient(string $method, string $resource, array $params, array|string $response, $methodName = 'requestObject')
 {
@@ -17,8 +18,9 @@ function mockClient(string $method, string $resource, array $params, array|strin
         ->withArgs(function (Payload $payload) use ($method, $resource) {
             $baseUri = BaseUri::from('api.openai.com/v1');
             $headers = Headers::withAuthorization(ApiKey::from('foo'));
+            $queryParams = QueryParams::create();
 
-            $request = $payload->toRequest($baseUri, $headers);
+            $request = $payload->toRequest($baseUri, $headers, $queryParams);
 
             return $request->getMethod() === $method
                 && $request->getUri()->getPath() === "/v1/$resource";

--- a/tests/Responses/Audio/TranscriptionResponse.php
+++ b/tests/Responses/Audio/TranscriptionResponse.php
@@ -91,3 +91,19 @@ test('to array', function () {
         ->toBeArray()
         ->toBe(audioTranscriptionVerboseJson());
 });
+
+test('fake', function () {
+    $response = TranscriptionResponse::fake();
+
+    expect($response)
+        ->language->toBe('english');
+});
+
+test('fake with override', function () {
+    $response = TranscriptionResponse::fake([
+        'language' => 'german',
+    ]);
+
+    expect($response)
+        ->language->toBe('german');
+});

--- a/tests/Responses/Audio/TranslationResponse.php
+++ b/tests/Responses/Audio/TranslationResponse.php
@@ -91,3 +91,19 @@ test('to array', function () {
         ->toBeArray()
         ->toBe(audioTranslationVerboseJson());
 });
+
+test('fake', function () {
+    $response = TranslationResponse::fake();
+
+    expect($response)
+        ->language->toBe('english');
+});
+
+test('fake with override', function () {
+    $response = TranslationResponse::fake([
+        'language' => 'german',
+    ]);
+
+    expect($response)
+        ->language->toBe('german');
+});

--- a/tests/Responses/Chat/CreateResponse.php
+++ b/tests/Responses/Chat/CreateResponse.php
@@ -31,3 +31,29 @@ test('to array', function () {
         ->toBeArray()
         ->toBe(chatCompletion());
 });
+
+test('fake', function () {
+    $response = CreateResponse::fake();
+
+    expect($response)
+        ->id->toBe('chatcmpl-123');
+});
+
+test('fake with override', function () {
+    $response = CreateResponse::fake([
+        'id' => 'chatcmpl-111',
+        'choices' => [
+            [
+                'message' => [
+                    'content' => 'Hi, there!',
+                ],
+            ],
+        ],
+    ]);
+
+    expect($response)
+        ->id->toBe('chatcmpl-111')
+        ->and($response->choices[0])
+        ->message->content->toBe('Hi, there!')
+        ->message->role->toBe('assistant');
+});

--- a/tests/Responses/Chat/CreateStreamedResponse.php
+++ b/tests/Responses/Chat/CreateStreamedResponse.php
@@ -1,0 +1,17 @@
+<?php
+
+use OpenAI\Responses\Chat\CreateStreamedResponse;
+
+test('fake', function () {
+    $response = CreateStreamedResponse::fake();
+
+    expect($response->getIterator()->current())
+        ->id->toBe('chatcmpl-6yo21W6LVo8Tw2yBf7aGf2g17IeIl');
+});
+
+test('fake with override', function () {
+    $response = CreateStreamedResponse::fake(chatCompletionStream());
+
+    expect($response->getIterator()->current())
+        ->id->toBe('chatcmpl-6wdIE4DsUtqf1srdMTsfkJp0VWZgz');
+});

--- a/tests/Responses/Completions/CreateResponse.php
+++ b/tests/Responses/Completions/CreateResponse.php
@@ -31,3 +31,27 @@ test('to array', function () {
         ->toBeArray()
         ->toBe(completion());
 });
+
+test('fake', function () {
+    $response = CreateResponse::fake();
+
+    expect($response)
+        ->id->toBe('cmpl-uqkvlQyYK7bGYrRHQ0eXlWi7');
+});
+
+test('fake with override', function () {
+    $response = CreateResponse::fake([
+        'id' => 'cmpl-1234',
+        'choices' => [
+            [
+                'text' => 'awesome!',
+            ],
+        ],
+    ]);
+
+    expect($response)
+        ->id->toBe('cmpl-1234')
+        ->and($response->choices[0])
+        ->text->toBe('awesome!')
+        ->index->toBe(0);
+});

--- a/tests/Responses/Completions/CreateStreamedResponse.php
+++ b/tests/Responses/Completions/CreateStreamedResponse.php
@@ -1,0 +1,17 @@
+<?php
+
+use OpenAI\Responses\Completions\CreateStreamedResponse;
+
+test('fake', function () {
+    $response = CreateStreamedResponse::fake();
+
+    expect($response->getIterator()->current())
+        ->id->toBe('cmpl-6ynJi2uZZnKntnEZreDcjGyoPbVAn');
+});
+
+test('fake with override', function () {
+    $response = CreateStreamedResponse::fake(completionStream());
+
+    expect($response->getIterator()->current())
+        ->id->toBe('cmpl-6wcyFqMKXiZffiydSfWHhjcgsf3KD');
+});

--- a/tests/Responses/Edits/CreateResponse.php
+++ b/tests/Responses/Edits/CreateResponse.php
@@ -29,3 +29,24 @@ test('to array', function () {
         ->toBeArray()
         ->toBe(edit());
 });
+
+test('fake', function () {
+    $response = CreateResponse::fake();
+
+    expect($response)
+        ->object->toBe('edit');
+});
+
+test('fake with override', function () {
+    $response = CreateResponse::fake([
+        'choices' => [
+            [
+                'text' => 'This is awesome!',
+            ],
+        ],
+    ]);
+
+    expect($response->choices[0])
+        ->text->toBe('This is awesome!')
+        ->index->toBe(0);
+});

--- a/tests/Responses/Embeddings/CreateResponse.php
+++ b/tests/Responses/Embeddings/CreateResponse.php
@@ -24,3 +24,26 @@ test('to array', function () {
 
     expect($response->toArray())->toBeArray()->toBe(embeddingList());
 });
+
+test('fake', function () {
+    $response = CreateResponse::fake();
+
+    expect($response['data'][0])
+        ->object->toBe('embedding');
+});
+
+test('fake with override', function () {
+    $response = CreateResponse::fake([
+        'data' => [
+            [
+                'embedding' => [
+                    0.1234,
+                    0.5678,
+                ],
+            ],
+        ],
+    ]);
+
+    expect($response->embeddings[0])
+        ->embedding->toBe([0.1234, 0.5678]);
+});

--- a/tests/Responses/Files/CreateResponse.php
+++ b/tests/Responses/Files/CreateResponse.php
@@ -45,3 +45,19 @@ test('to array', function () {
         ->toBeArray()
         ->toBe(fileResource());
 });
+
+test('fake', function () {
+    $response = CreateResponse::fake();
+
+    expect($response)
+        ->id->toBe('file-XjGxS3KTG0uNmNOK362iJua3');
+});
+
+test('fake with override', function () {
+    $response = CreateResponse::fake([
+        'id' => 'file-1234',
+    ]);
+
+    expect($response)
+        ->id->toBe('file-1234');
+});

--- a/tests/Responses/Files/DeleteResponse.php
+++ b/tests/Responses/Files/DeleteResponse.php
@@ -23,3 +23,22 @@ test('to array', function () {
     expect($result->toArray())
         ->toBe(fileDeleteResource());
 });
+
+test('fake', function () {
+    $response = DeleteResponse::fake();
+
+    expect($response)
+        ->id->toBe('file-XjGxS3KTG0uNmNOK362iJua3')
+        ->deleted->toBe(true);
+});
+
+test('fake with override', function () {
+    $response = DeleteResponse::fake([
+        'id' => 'file-1234',
+        'deleted' => false,
+    ]);
+
+    expect($response)
+        ->id->toBe('file-1234')
+        ->deleted->toBe(false);
+});

--- a/tests/Responses/Files/ListResponse.php
+++ b/tests/Responses/Files/ListResponse.php
@@ -26,3 +26,23 @@ test('to array', function () {
         ->toBeArray()
         ->toBe(fileListResource());
 });
+
+test('fake', function () {
+    $response = ListResponse::fake();
+
+    expect($response['data'][0])
+        ->id->toBe('file-XjGxS3KTG0uNmNOK362iJua3');
+});
+
+test('fake with override', function () {
+    $response = ListResponse::fake([
+        'data' => [
+            [
+                'id' => 'file-1234',
+            ],
+        ],
+    ]);
+
+    expect($response['data'][0])
+        ->id->toBe('file-1234');
+});

--- a/tests/Responses/Files/RetrieveResponse.php
+++ b/tests/Responses/Files/RetrieveResponse.php
@@ -42,3 +42,19 @@ test('to array', function () {
     expect($result->toArray())
         ->toBe(fileResource());
 });
+
+test('fake', function () {
+    $response = RetrieveResponse::fake();
+
+    expect($response)
+        ->id->toBe('file-XjGxS3KTG0uNmNOK362iJua3');
+});
+
+test('fake with override', function () {
+    $response = RetrieveResponse::fake([
+        'id' => 'file-1234',
+    ]);
+
+    expect($response)
+        ->id->toBe('file-1234');
+});

--- a/tests/Responses/FineTunes/ListEventsResponse.php
+++ b/tests/Responses/FineTunes/ListEventsResponse.php
@@ -26,3 +26,27 @@ test('to array', function () {
         ->toBeArray()
         ->toBe(fineTuneListEventsResource());
 });
+
+test('fake', function () {
+    $response = ListEventsResponse::fake();
+
+    expect($response)
+        ->object->toBe('list')
+        ->and($response['data'][0])
+    ->level->toBe('info');
+});
+
+test('fake with override', function () {
+    $response = ListEventsResponse::fake([
+        'data' => [
+            [
+                'level' => 'error',
+            ],
+        ],
+    ]);
+
+    expect($response)
+        ->object->toBe('list')
+        ->and($response['data'][0])
+        ->level->toBe('error');
+});

--- a/tests/Responses/FineTunes/ListResponse.php
+++ b/tests/Responses/FineTunes/ListResponse.php
@@ -26,3 +26,27 @@ test('to array', function () {
         ->toBeArray()
         ->toBe(fineTuneListResource());
 });
+
+test('fake', function () {
+    $response = ListResponse::fake();
+
+    expect($response)
+        ->object->toBe('list')
+        ->and($response['data'][0])
+        ->id->toBe('ft-AF1WoRqd3aJAHsqc9NY7iL8F');
+});
+
+test('fake with override', function () {
+    $response = ListResponse::fake([
+        'data' => [
+            [
+                'id' => 'ft-1234',
+            ],
+        ],
+    ]);
+
+    expect($response)
+        ->object->toBe('list')
+        ->and($response['data'][0])
+        ->id->toBe('ft-1234');
+});

--- a/tests/Responses/FineTunes/RetrieveResponse.php
+++ b/tests/Responses/FineTunes/RetrieveResponse.php
@@ -41,3 +41,19 @@ test('to array', function () {
     expect($result->toArray())
         ->toBe(fineTuneResource());
 });
+
+test('fake', function () {
+    $response = RetrieveResponse::fake();
+
+    expect($response)
+        ->id->toBe('ft-AF1WoRqd3aJAHsqc9NY7iL8F');
+});
+
+test('fake with override', function () {
+    $response = RetrieveResponse::fake([
+        'id' => 'ft-1234',
+    ]);
+
+    expect($response)
+        ->id->toBe('ft-1234');
+});

--- a/tests/Responses/FineTunes/RetrieveStreamedResponseEvent.php
+++ b/tests/Responses/FineTunes/RetrieveStreamedResponseEvent.php
@@ -1,0 +1,17 @@
+<?php
+
+use OpenAI\Responses\FineTunes\RetrieveStreamedResponseEvent;
+
+test('fake', function () {
+    $response = RetrieveStreamedResponseEvent::fake();
+
+    expect($response->getIterator()->current())
+        ->message->toBe('Created fine-tune: ft-y3OpNlc8B5qBVGCCVsLZsDST');
+});
+
+test('fake with override', function () {
+    $response = RetrieveStreamedResponseEvent::fake(fineTuneListEventsStream());
+
+    expect($response->getIterator()->current())
+        ->message->toBe('Created fine-tune: ft-MaoEAULREoazpupm8uB7qoIl');
+});

--- a/tests/Responses/Images/CreateResponse.php
+++ b/tests/Responses/Images/CreateResponse.php
@@ -50,3 +50,23 @@ test('to array with b64_json', function () {
         ->toBeArray()
         ->toBe(imageCreateWithB46Json());
 });
+
+test('fake', function () {
+    $response = CreateResponse::fake();
+
+    expect($response['data'][0])
+        ->url->toBe('https://openai.com/image.png');
+});
+
+test('fake with override', function () {
+    $response = CreateResponse::fake([
+        'data' => [
+            [
+                'url' => 'https://openai.com/new-image.png',
+            ],
+        ],
+    ]);
+
+    expect($response['data'][0])
+        ->url->toBe('https://openai.com/new-image.png');
+});

--- a/tests/Responses/Images/CreateResponse.php
+++ b/tests/Responses/Images/CreateResponse.php
@@ -55,7 +55,7 @@ test('fake', function () {
     $response = CreateResponse::fake();
 
     expect($response['data'][0])
-        ->url->toBe('https://openai.com/image.png');
+        ->url->toBe('https://openai.com/fake-image.png');
 });
 
 test('fake with override', function () {

--- a/tests/Responses/Images/EditResponse.php
+++ b/tests/Responses/Images/EditResponse.php
@@ -55,7 +55,7 @@ test('fake', function () {
     $response = EditResponse::fake();
 
     expect($response['data'][0])
-        ->url->toBe('https://openai.com/image.png');
+        ->url->toBe('https://openai.com/fake-image.png');
 });
 
 test('fake with override', function () {

--- a/tests/Responses/Images/EditResponse.php
+++ b/tests/Responses/Images/EditResponse.php
@@ -50,3 +50,23 @@ test('to array with b64_json', function () {
         ->toBeArray()
         ->toBe(imageEditWithB46Json());
 });
+
+test('fake', function () {
+    $response = EditResponse::fake();
+
+    expect($response['data'][0])
+        ->url->toBe('https://openai.com/image.png');
+});
+
+test('fake with override', function () {
+    $response = EditResponse::fake([
+        'data' => [
+            [
+                'url' => 'https://openai.com/new-image.png',
+            ],
+        ],
+    ]);
+
+    expect($response['data'][0])
+        ->url->toBe('https://openai.com/new-image.png');
+});

--- a/tests/Responses/Images/VariationResponse.php
+++ b/tests/Responses/Images/VariationResponse.php
@@ -50,3 +50,23 @@ test('to array with b64_json', function () {
         ->toBeArray()
         ->toBe(imageVariationWithB46Json());
 });
+
+test('fake', function () {
+    $response = VariationResponse::fake();
+
+    expect($response['data'][0])
+        ->url->toBe('https://openai.com/image.png');
+});
+
+test('fake with override', function () {
+    $response = VariationResponse::fake([
+        'data' => [
+            [
+                'url' => 'https://openai.com/new-image.png',
+            ],
+        ],
+    ]);
+
+    expect($response['data'][0])
+        ->url->toBe('https://openai.com/new-image.png');
+});

--- a/tests/Responses/Images/VariationResponse.php
+++ b/tests/Responses/Images/VariationResponse.php
@@ -55,7 +55,7 @@ test('fake', function () {
     $response = VariationResponse::fake();
 
     expect($response['data'][0])
-        ->url->toBe('https://openai.com/image.png');
+        ->url->toBe('https://openai.com/fake-image.png');
 });
 
 test('fake with override', function () {

--- a/tests/Responses/Models/DeleteResponse.php
+++ b/tests/Responses/Models/DeleteResponse.php
@@ -23,3 +23,19 @@ test('to array', function () {
     expect($result->toArray())
         ->toBe(fineTunedModelDeleteResource());
 });
+
+test('fake', function () {
+    $response = DeleteResponse::fake();
+
+    expect($response)
+        ->id->toBe('curie:ft-acmeco-2021-03-03-21-44-20');
+});
+
+test('fake with override', function () {
+    $response = DeleteResponse::fake([
+        'id' => 'curie:ft-1234',
+    ]);
+
+    expect($response)
+        ->id->toBe('curie:ft-1234');
+});

--- a/tests/Responses/Models/ListResponse.php
+++ b/tests/Responses/Models/ListResponse.php
@@ -26,3 +26,27 @@ test('to array', function () {
         ->toBeArray()
         ->toBe(modelList());
 });
+
+test('fake', function () {
+    $response = ListResponse::fake();
+
+    expect($response)
+    ->object->toBe('list')
+        ->and($response->data[0])
+        ->id->toBe('text-babbage:001');
+});
+
+test('fake with override', function () {
+    $response = ListResponse::fake([
+        'data' => [
+            [
+                'id' => 'text-1234',
+            ],
+        ],
+    ]);
+
+    expect($response)
+        ->object->toBe('list')
+        ->and($response->data[0])
+        ->id->toBe('text-1234');
+});

--- a/tests/Responses/Models/RetrieveResponse.php
+++ b/tests/Responses/Models/RetrieveResponse.php
@@ -30,3 +30,28 @@ test('to array', function () {
     expect($result->toArray())
         ->toBe(model());
 });
+
+test('fake', function () {
+    $response = RetrieveResponse::fake();
+
+    expect($response)
+        ->id->toBe('text-babbage:001')
+    ->and($response->permission[0])
+        ->allowCreateEngine->toBeFalse();
+});
+
+test('fake with override', function () {
+    $response = RetrieveResponse::fake([
+        'id' => 'text-1234',
+        'permission' => [
+            [
+                'allow_create_engine' => true,
+            ],
+        ],
+    ]);
+
+    expect($response)
+        ->id->toBe('text-1234')
+        ->and($response->permission[0])
+        ->allowCreateEngine->toBeTrue();
+});

--- a/tests/Responses/Moderations/CreateResponse.php
+++ b/tests/Responses/Moderations/CreateResponse.php
@@ -27,3 +27,30 @@ test('to array', function () {
         ->toBeArray()
         ->toBe(moderationResource());
 });
+
+test('fake', function () {
+    $response = CreateResponse::fake();
+
+    expect($response)
+        ->id->toBe('modr-5MWoLO')
+        ->and($response->results[0]->categories['hate'])
+        ->violated->toBeFalse();
+});
+
+test('fake with override', function () {
+    $response = CreateResponse::fake([
+        'id' => 'modr-1234',
+        'results' => [
+            [
+                'categories' => [
+                    'hate' => true,
+                ],
+            ],
+        ],
+    ]);
+
+    expect($response)
+        ->id->toBe('modr-1234')
+        ->and($response->results[0]->categories['hate'])
+        ->violated->toBeTrue();
+});

--- a/tests/Testing/ClientFake.php
+++ b/tests/Testing/ClientFake.php
@@ -24,6 +24,21 @@ it('returns a fake response', function () {
     expect($completion['choices'][0]['text'])->toBe('awesome!');
 });
 
+it('throws fake exceptions', function () {
+    $fake = new ClientFake([
+        new \OpenAI\Exceptions\ErrorException([
+            'message' => 'The model `gpt-1` does not exist',
+            'type' => 'invalid_request_error',
+            'code' => null,
+        ]),
+    ]);
+
+    $fake->completions()->create([
+        'model' => 'text-davinci-003',
+        'prompt' => 'PHP is ',
+    ]);
+})->expectExceptionMessage('The model `gpt-1` does not exist');
+
 it('throws an exception if there is no more fake response', function () {
     $fake = new ClientFake([
         CreateResponse::fake(),

--- a/tests/Testing/ClientFake.php
+++ b/tests/Testing/ClientFake.php
@@ -1,0 +1,196 @@
+<?php
+
+use OpenAI\Resources\Completions;
+use OpenAI\Responses\Completions\CreateResponse;
+use OpenAI\Testing\ClientFake;
+use PHPUnit\Framework\ExpectationFailedException;
+
+it('returns a fake response', function () {
+    $fake = new ClientFake([
+        CreateResponse::fake([
+            'choices' => [
+                [
+                    'text' => 'awesome!',
+                ],
+            ],
+        ]),
+    ]);
+
+    $completion = $fake->completions()->create([
+        'model' => 'text-davinci-003',
+        'prompt' => 'PHP is ',
+    ]);
+
+    expect($completion['choices'][0]['text'])->toBe('awesome!');
+});
+
+it('throws an exception if there is no more fake response', function () {
+    $fake = new ClientFake([
+        CreateResponse::fake(),
+    ]);
+
+    $fake->completions()->create([
+        'model' => 'text-davinci-003',
+        'prompt' => 'PHP is ',
+    ]);
+
+    $fake->completions()->create([
+        'model' => 'text-davinci-003',
+        'prompt' => 'PHP is ',
+    ]);
+})->expectExceptionMessage('No fake responses left');
+
+it('allows to add more responses', function () {
+    $fake = new ClientFake([
+        CreateResponse::fake([
+            'id' => 'cmpl-1',
+        ]),
+    ]);
+
+    $completion = $fake->completions()->create([
+        'model' => 'text-davinci-003',
+        'prompt' => 'PHP is ',
+    ]);
+
+    expect($completion)
+        ->id->toBe('cmpl-1');
+
+    $fake->addResponses([
+        CreateResponse::fake([
+            'id' => 'cmpl-2',
+        ]),
+    ]);
+
+    $completion = $fake->completions()->create([
+        'model' => 'text-davinci-003',
+        'prompt' => 'PHP is ',
+    ]);
+
+    expect($completion)
+        ->id->toBe('cmpl-2');
+});
+
+it('asserts a request was sent', function () {
+    $fake = new ClientFake([
+        CreateResponse::fake(),
+    ]);
+
+    $fake->completions()->create([
+        'model' => 'text-davinci-003',
+        'prompt' => 'PHP is ',
+    ]);
+
+    $fake->assertSent(Completions::class, function ($method, $parameters) {
+        return $method === 'create' &&
+            $parameters['model'] === 'text-davinci-003' &&
+            $parameters['prompt'] === 'PHP is ';
+    });
+});
+
+it('throws an exception if a request was not sent', function () {
+    $fake = new ClientFake([
+        CreateResponse::fake(),
+    ]);
+
+    $fake->assertSent(Completions::class, function ($method, $parameters) {
+        return $method === 'create' &&
+            $parameters['model'] === 'text-davinci-003' &&
+            $parameters['prompt'] === 'PHP is ';
+    });
+})->expectException(ExpectationFailedException::class);
+
+it('asserts a request was sent on the resource', function () {
+    $fake = new ClientFake([
+        CreateResponse::fake(),
+    ]);
+
+    $fake->completions()->create([
+        'model' => 'text-davinci-003',
+        'prompt' => 'PHP is ',
+    ]);
+
+    $fake->completions()->assertSent(function ($method, $parameters) {
+        return $method === 'create' &&
+            $parameters['model'] === 'text-davinci-003' &&
+            $parameters['prompt'] === 'PHP is ';
+    });
+});
+
+it('asserts a request was sent n times', function () {
+    $fake = new ClientFake([
+        CreateResponse::fake(),
+        CreateResponse::fake(),
+    ]);
+
+    $fake->completions()->create([
+        'model' => 'text-davinci-003',
+        'prompt' => 'PHP is ',
+    ]);
+
+    $fake->completions()->create([
+        'model' => 'text-davinci-003',
+        'prompt' => 'PHP is ',
+    ]);
+
+    $fake->assertSent(Completions::class, 2);
+});
+
+it('throws an exception if a request was not sent n times', function () {
+    $fake = new ClientFake([
+        CreateResponse::fake(),
+        CreateResponse::fake(),
+    ]);
+
+    $fake->completions()->create([
+        'model' => 'text-davinci-003',
+        'prompt' => 'PHP is ',
+    ]);
+
+    $fake->assertSent(Completions::class, 2);
+})->expectException(ExpectationFailedException::class);
+
+it('asserts a request was not sent', function () {
+    $fake = new ClientFake();
+
+    $fake->assertNotSent(Completions::class);
+});
+
+it('throws an exception if an unexpected request was sent', function () {
+    $fake = new ClientFake([
+        CreateResponse::fake(),
+    ]);
+
+    $fake->completions()->create([
+        'model' => 'text-davinci-003',
+        'prompt' => 'PHP is ',
+    ]);
+
+    $fake->assertNotSent(Completions::class);
+})->expectException(ExpectationFailedException::class);
+
+it('asserts a request was not sent on the resource', function () {
+    $fake = new ClientFake([
+        CreateResponse::fake(),
+    ]);
+
+    $fake->completions()->assertNotSent();
+});
+
+it('asserts no request was sent', function () {
+    $fake = new ClientFake();
+
+    $fake->assertNothingSent();
+});
+
+it('throws an exception if any request was sent when non was expected', function () {
+    $fake = new ClientFake([
+        CreateResponse::fake(),
+    ]);
+
+    $fake->completions()->create([
+        'model' => 'text-davinci-003',
+        'prompt' => 'PHP is ',
+    ]);
+
+    $fake->assertNothingSent();
+})->expectException(ExpectationFailedException::class);

--- a/tests/Testing/Resources/AudioTestResource.php
+++ b/tests/Testing/Resources/AudioTestResource.php
@@ -1,0 +1,40 @@
+<?php
+
+use OpenAI\Resources\Audio;
+use OpenAI\Responses\Audio\TranscriptionResponse;
+use OpenAI\Responses\Audio\TranslationResponse;
+use OpenAI\Testing\ClientFake;
+
+it('records an audio transcription request', function () {
+    $fake = new ClientFake([
+        TranscriptionResponse::fake(),
+    ]);
+
+    $fake->audio()->transcribe([
+        'model' => 'whisper-1',
+        'response_format' => 'verbose_json',
+    ]);
+
+    $fake->assertSent(Audio::class, function ($method, $parameters) {
+        return $method === 'transcribe' &&
+            $parameters['model'] === 'whisper-1' &&
+            $parameters['response_format'] === 'verbose_json';
+    });
+});
+
+it('records an audio translation request', function () {
+    $fake = new ClientFake([
+        TranslationResponse::fake(),
+    ]);
+
+    $fake->audio()->translate([
+        'model' => 'whisper-1',
+        'response_format' => 'verbose_json',
+    ]);
+
+    $fake->assertSent(Audio::class, function ($method, $parameters) {
+        return $method === 'translate' &&
+            $parameters['model'] === 'whisper-1' &&
+            $parameters['response_format'] === 'verbose_json';
+    });
+});

--- a/tests/Testing/Resources/ChatTestResource.php
+++ b/tests/Testing/Resources/ChatTestResource.php
@@ -1,0 +1,25 @@
+<?php
+
+use OpenAI\Resources\Chat;
+use OpenAI\Responses\Chat\CreateResponse;
+use OpenAI\Testing\ClientFake;
+
+it('records a chat create request', function () {
+    $fake = new ClientFake([
+        CreateResponse::fake(),
+    ]);
+
+    $fake->chat()->create([
+        'model' => 'gpt-3.5-turbo',
+        'messages' => [
+            ['role' => 'user', 'content' => 'Hello!'],
+        ],
+    ]);
+
+    $fake->assertSent(Chat::class, function ($method, $parameters) {
+        return $method === 'create' &&
+            $parameters['model'] === 'gpt-3.5-turbo' &&
+            $parameters['messages'][0]['role'] === 'user' &&
+            $parameters['messages'][0]['content'] === 'Hello!';
+    });
+});

--- a/tests/Testing/Resources/ChatTestResource.php
+++ b/tests/Testing/Resources/ChatTestResource.php
@@ -2,6 +2,7 @@
 
 use OpenAI\Resources\Chat;
 use OpenAI\Responses\Chat\CreateResponse;
+use OpenAI\Responses\Chat\CreateStreamedResponse;
 use OpenAI\Testing\ClientFake;
 
 it('records a chat create request', function () {
@@ -18,6 +19,26 @@ it('records a chat create request', function () {
 
     $fake->assertSent(Chat::class, function ($method, $parameters) {
         return $method === 'create' &&
+            $parameters['model'] === 'gpt-3.5-turbo' &&
+            $parameters['messages'][0]['role'] === 'user' &&
+            $parameters['messages'][0]['content'] === 'Hello!';
+    });
+});
+
+it('records a streamed create create request', function () {
+    $fake = new ClientFake([
+        CreateStreamedResponse::fake(),
+    ]);
+
+    $fake->chat()->createStreamed([
+        'model' => 'gpt-3.5-turbo',
+        'messages' => [
+            ['role' => 'user', 'content' => 'Hello!'],
+        ],
+    ]);
+
+    $fake->assertSent(Chat::class, function ($method, $parameters) {
+        return $method === 'createStreamed' &&
             $parameters['model'] === 'gpt-3.5-turbo' &&
             $parameters['messages'][0]['role'] === 'user' &&
             $parameters['messages'][0]['content'] === 'Hello!';

--- a/tests/Testing/Resources/CompletionsTestResource.php
+++ b/tests/Testing/Resources/CompletionsTestResource.php
@@ -2,6 +2,7 @@
 
 use OpenAI\Resources\Completions;
 use OpenAI\Responses\Completions\CreateResponse;
+use OpenAI\Responses\Completions\CreateStreamedResponse;
 use OpenAI\Testing\ClientFake;
 
 it('records a completions create request', function () {
@@ -16,6 +17,23 @@ it('records a completions create request', function () {
 
     $fake->assertSent(Completions::class, function ($method, $parameters) {
         return $method === 'create' &&
+            $parameters['model'] === 'text-davinci-003' &&
+            $parameters['prompt'] === 'PHP is ';
+    });
+});
+
+it('records a streamed completions create request', function () {
+    $fake = new ClientFake([
+        CreateStreamedResponse::fake(),
+    ]);
+
+    $fake->completions()->createStreamed([
+        'model' => 'text-davinci-003',
+        'prompt' => 'PHP is ',
+    ]);
+
+    $fake->assertSent(Completions::class, function ($method, $parameters) {
+        return $method === 'createStreamed' &&
             $parameters['model'] === 'text-davinci-003' &&
             $parameters['prompt'] === 'PHP is ';
     });

--- a/tests/Testing/Resources/CompletionsTestResource.php
+++ b/tests/Testing/Resources/CompletionsTestResource.php
@@ -1,0 +1,22 @@
+<?php
+
+use OpenAI\Resources\Completions;
+use OpenAI\Responses\Completions\CreateResponse;
+use OpenAI\Testing\ClientFake;
+
+it('records a completions create request', function () {
+    $fake = new ClientFake([
+        CreateResponse::fake(),
+    ]);
+
+    $fake->completions()->create([
+        'model' => 'text-davinci-003',
+        'prompt' => 'PHP is ',
+    ]);
+
+    $fake->assertSent(Completions::class, function ($method, $parameters) {
+        return $method === 'create' &&
+            $parameters['model'] === 'text-davinci-003' &&
+            $parameters['prompt'] === 'PHP is ';
+    });
+});

--- a/tests/Testing/Resources/EditsTestResource.php
+++ b/tests/Testing/Resources/EditsTestResource.php
@@ -1,0 +1,24 @@
+<?php
+
+use OpenAI\Resources\Edits;
+use OpenAI\Responses\Edits\CreateResponse;
+use OpenAI\Testing\ClientFake;
+
+it('records a edits create request', function () {
+    $fake = new ClientFake([
+        CreateResponse::fake(),
+    ]);
+
+    $fake->edits()->create([
+        'model' => 'text-davinci-edit-001',
+        'input' => 'What day of the wek is it?',
+        'instruction' => 'Fix the spelling mistakes',
+    ]);
+
+    $fake->assertSent(Edits::class, function ($method, $parameters) {
+        return $method === 'create' &&
+            $parameters['model'] === 'text-davinci-edit-001' &&
+            $parameters['input'] === 'What day of the wek is it?' &&
+            $parameters['instruction'] === 'Fix the spelling mistakes';
+    });
+});

--- a/tests/Testing/Resources/EmbeddingsTestResource.php
+++ b/tests/Testing/Resources/EmbeddingsTestResource.php
@@ -1,0 +1,22 @@
+<?php
+
+use OpenAI\Resources\Embeddings;
+use OpenAI\Responses\Embeddings\CreateResponse;
+use OpenAI\Testing\ClientFake;
+
+it('records a embeddings create request', function () {
+    $fake = new ClientFake([
+        CreateResponse::fake(),
+    ]);
+
+    $fake->embeddings()->create([
+        'model' => 'text-similarity-babbage-001',
+        'input' => 'The food was delicious and the waiter...',
+    ]);
+
+    $fake->assertSent(Embeddings::class, function ($method, $parameters) {
+        return $method === 'create' &&
+            $parameters['model'] === 'text-similarity-babbage-001' &&
+            $parameters['input'] === 'The food was delicious and the waiter...';
+    });
+});

--- a/tests/Testing/Resources/FilesTestResource.php
+++ b/tests/Testing/Resources/FilesTestResource.php
@@ -1,0 +1,74 @@
+<?php
+
+use OpenAI\Resources\Files;
+use OpenAI\Responses\Files\CreateResponse;
+use OpenAI\Responses\Files\DeleteResponse;
+use OpenAI\Responses\Files\ListResponse;
+use OpenAI\Responses\Files\RetrieveResponse;
+use OpenAI\Testing\ClientFake;
+
+it('records a files retrieve request', function () {
+    $fake = new ClientFake([
+        RetrieveResponse::fake(),
+    ]);
+
+    $fake->files()->retrieve('file-XjGxS3KTG0uNmNOK362iJua3');
+
+    $fake->assertSent(Files::class, function ($method, $parameters) {
+        return $method === 'retrieve' &&
+            $parameters === 'file-XjGxS3KTG0uNmNOK362iJua3';
+    });
+});
+
+it('records a files list request', function () {
+    $fake = new ClientFake([
+        ListResponse::fake(),
+    ]);
+
+    $fake->files()->list();
+
+    $fake->assertSent(Files::class, function ($method) {
+        return $method === 'list';
+    });
+});
+
+it('records a files download request', function () {
+    $fake = new ClientFake([
+        'fake-file-content',
+    ]);
+
+    $fake->files()->download('file-XjGxS3KTG0uNmNOK362iJua3');
+
+    $fake->assertSent(Files::class, function ($method, $parameters) {
+        return $method === 'download' &&
+            $parameters === 'file-XjGxS3KTG0uNmNOK362iJua3';
+    });
+});
+
+it('records a files delete request', function () {
+    $fake = new ClientFake([
+        DeleteResponse::fake(),
+    ]);
+
+    $fake->files()->delete('file-XjGxS3KTG0uNmNOK362iJua3');
+
+    $fake->assertSent(Files::class, function ($method, $parameters) {
+        return $method === 'delete' &&
+            $parameters === 'file-XjGxS3KTG0uNmNOK362iJua3';
+    });
+});
+
+it('records a files upload request', function () {
+    $fake = new ClientFake([
+        CreateResponse::fake(),
+    ]);
+
+    $fake->files()->upload([
+        'purpose' => 'fine-tune',
+    ]);
+
+    $fake->assertSent(Files::class, function ($method, $parameters) {
+        return $method === 'upload' &&
+            $parameters['purpose'] === 'fine-tune';
+    });
+});

--- a/tests/Testing/Resources/FineTunesTestResource.php
+++ b/tests/Testing/Resources/FineTunesTestResource.php
@@ -1,0 +1,75 @@
+<?php
+
+use OpenAI\Resources\FineTunes;
+use OpenAI\Responses\FineTunes\ListEventsResponse;
+use OpenAI\Responses\FineTunes\ListResponse;
+use OpenAI\Responses\FineTunes\RetrieveResponse;
+use OpenAI\Testing\ClientFake;
+
+it('records a fine tunes create request', function () {
+    $fake = new ClientFake([
+        RetrieveResponse::fake(),
+    ]);
+
+    $fake->fineTunes()->create([
+        'model' => 'curie',
+        'training_file' => 'file-ajSREls59WBbvgSzJSVWxMCB',
+    ]);
+
+    $fake->assertSent(FineTunes::class, function ($method, $parameters) {
+        return $method === 'create' &&
+            $parameters['model'] === 'curie' &&
+            $parameters['training_file'] === 'file-ajSREls59WBbvgSzJSVWxMCB';
+    });
+});
+
+it('records a fine tunes retrieve request', function () {
+    $fake = new ClientFake([
+        RetrieveResponse::fake(),
+    ]);
+
+    $fake->fineTunes()->retrieve('ft-AF1WoRqd3aJAHsqc9NY7iL8F');
+
+    $fake->assertSent(FineTunes::class, function ($method, $parameters) {
+        return $method === 'retrieve' &&
+            $parameters === 'ft-AF1WoRqd3aJAHsqc9NY7iL8F';
+    });
+});
+
+it('records a fine tunes cancel request', function () {
+    $fake = new ClientFake([
+        RetrieveResponse::fake(),
+    ]);
+
+    $fake->fineTunes()->cancel('ft-AF1WoRqd3aJAHsqc9NY7iL8F');
+
+    $fake->assertSent(FineTunes::class, function ($method, $parameters) {
+        return $method === 'cancel' &&
+            $parameters === 'ft-AF1WoRqd3aJAHsqc9NY7iL8F';
+    });
+});
+
+it('records a fine tunes list request', function () {
+    $fake = new ClientFake([
+        ListResponse::fake(),
+    ]);
+
+    $fake->fineTunes()->list();
+
+    $fake->assertSent(FineTunes::class, function ($method) {
+        return $method === 'list';
+    });
+});
+
+it('records a fine tunes list events request', function () {
+    $fake = new ClientFake([
+        ListEventsResponse::fake(),
+    ]);
+
+    $fake->fineTunes()->listEvents('ft-AF1WoRqd3aJAHsqc9NY7iL8F');
+
+    $fake->assertSent(FineTunes::class, function ($method, $parameters) {
+        return $method === 'listEvents' &&
+            $parameters === 'ft-AF1WoRqd3aJAHsqc9NY7iL8F';
+    });
+});

--- a/tests/Testing/Resources/FineTunesTestResource.php
+++ b/tests/Testing/Resources/FineTunesTestResource.php
@@ -4,6 +4,7 @@ use OpenAI\Resources\FineTunes;
 use OpenAI\Responses\FineTunes\ListEventsResponse;
 use OpenAI\Responses\FineTunes\ListResponse;
 use OpenAI\Responses\FineTunes\RetrieveResponse;
+use OpenAI\Responses\FineTunes\RetrieveStreamedResponseEvent;
 use OpenAI\Testing\ClientFake;
 
 it('records a fine tunes create request', function () {
@@ -70,6 +71,19 @@ it('records a fine tunes list events request', function () {
 
     $fake->assertSent(FineTunes::class, function ($method, $parameters) {
         return $method === 'listEvents' &&
+            $parameters === 'ft-AF1WoRqd3aJAHsqc9NY7iL8F';
+    });
+});
+
+it('records a streamed fine tunes list events request', function () {
+    $fake = new ClientFake([
+        RetrieveStreamedResponseEvent::fake(),
+    ]);
+
+    $fake->fineTunes()->listEventsStreamed('ft-AF1WoRqd3aJAHsqc9NY7iL8F');
+
+    $fake->assertSent(FineTunes::class, function ($method, $parameters) {
+        return $method === 'listEventsStreamed' &&
             $parameters === 'ft-AF1WoRqd3aJAHsqc9NY7iL8F';
     });
 });

--- a/tests/Testing/Resources/ImagesTestResource.php
+++ b/tests/Testing/Resources/ImagesTestResource.php
@@ -1,0 +1,52 @@
+<?php
+
+use OpenAI\Resources\Images;
+use OpenAI\Responses\Images\CreateResponse;
+use OpenAI\Responses\Images\EditResponse;
+use OpenAI\Responses\Images\VariationResponse;
+use OpenAI\Testing\ClientFake;
+
+it('records a images create request', function () {
+    $fake = new ClientFake([
+        CreateResponse::fake(),
+    ]);
+
+    $fake->images()->create([
+        'prompt' => 'A cute baby sea otter',
+    ]);
+
+    $fake->assertSent(Images::class, function ($method, $parameters) {
+        return $method === 'create' &&
+            $parameters['prompt'] === 'A cute baby sea otter';
+    });
+});
+
+it('records a images edit request', function () {
+    $fake = new ClientFake([
+        EditResponse::fake(),
+    ]);
+
+    $fake->images()->edit([
+        'prompt' => 'A sunlit indoor lounge area with a pool containing a flamingo',
+    ]);
+
+    $fake->assertSent(Images::class, function ($method, $parameters) {
+        return $method === 'edit' &&
+            $parameters['prompt'] === 'A sunlit indoor lounge area with a pool containing a flamingo';
+    });
+});
+
+it('records a images variation request', function () {
+    $fake = new ClientFake([
+        VariationResponse::fake(),
+    ]);
+
+    $fake->images()->variation([
+        'size' => '256x256',
+    ]);
+
+    $fake->assertSent(Images::class, function ($method, $parameters) {
+        return $method === 'variation' &&
+            $parameters['size'] === '256x256';
+    });
+});

--- a/tests/Testing/Resources/ModelsTestResource.php
+++ b/tests/Testing/Resources/ModelsTestResource.php
@@ -1,0 +1,45 @@
+<?php
+
+use OpenAI\Resources\Models;
+use OpenAI\Responses\Models\DeleteResponse;
+use OpenAI\Responses\Models\ListResponse;
+use OpenAI\Responses\Models\RetrieveResponse;
+use OpenAI\Testing\ClientFake;
+
+it('records a model retrieve request', function () {
+    $fake = new ClientFake([
+        RetrieveResponse::fake(),
+    ]);
+
+    $fake->models()->retrieve('text-davinci-003');
+
+    $fake->assertSent(Models::class, function ($method, $parameters) {
+        return $method === 'retrieve' &&
+            $parameters === 'text-davinci-003';
+    });
+});
+
+it('records a model delete request', function () {
+    $fake = new ClientFake([
+        DeleteResponse::fake(),
+    ]);
+
+    $fake->models()->delete('curie:ft-acmeco-2021-03-03-21-44-20');
+
+    $fake->assertSent(Models::class, function ($method, $parameters) {
+        return $method === 'delete' &&
+            $parameters === 'curie:ft-acmeco-2021-03-03-21-44-20';
+    });
+});
+
+it('records a model list request', function () {
+    $fake = new ClientFake([
+        ListResponse::fake(),
+    ]);
+
+    $fake->models()->list();
+
+    $fake->assertSent(Models::class, function ($method) {
+        return $method === 'list';
+    });
+});

--- a/tests/Testing/Resources/ModerationsTestResource.php
+++ b/tests/Testing/Resources/ModerationsTestResource.php
@@ -1,0 +1,22 @@
+<?php
+
+use OpenAI\Resources\Moderations;
+use OpenAI\Responses\Moderations\CreateResponse;
+use OpenAI\Testing\ClientFake;
+
+it('records a moderations create request', function () {
+    $fake = new ClientFake([
+        CreateResponse::fake(),
+    ]);
+
+    $fake->moderations()->create([
+        'model' => 'text-moderation-latest',
+        'input' => 'I want to k*** them.',
+    ]);
+
+    $fake->assertSent(Moderations::class, function ($method, $parameters) {
+        return $method === 'create' &&
+            $parameters['model'] === 'text-moderation-latest' &&
+            $parameters['input'] === 'I want to k*** them.';
+    });
+});

--- a/tests/Transporters/HttpTransporter.php
+++ b/tests/Transporters/HttpTransporter.php
@@ -12,6 +12,7 @@ use OpenAI\ValueObjects\ApiKey;
 use OpenAI\ValueObjects\Transporter\BaseUri;
 use OpenAI\ValueObjects\Transporter\Headers;
 use OpenAI\ValueObjects\Transporter\Payload;
+use OpenAI\ValueObjects\Transporter\QueryParams;
 use Psr\Http\Client\ClientInterface;
 
 beforeEach(function () {
@@ -23,6 +24,7 @@ beforeEach(function () {
         $this->client,
         BaseUri::from('api.openai.com/v1'),
         Headers::withAuthorization($apiKey)->withContentType(ContentType::JSON),
+        QueryParams::create()->withParam('foo', 'bar'),
     );
 });
 
@@ -109,11 +111,12 @@ test('request object client errors', function () {
 
     $baseUri = BaseUri::from('api.openai.com');
     $headers = Headers::withAuthorization(ApiKey::from('foo'));
+    $queryParams = QueryParams::create();
 
     $this->client
         ->shouldReceive('sendRequest')
         ->once()
-        ->andThrow(new ConnectException('Could not resolve host.', $payload->toRequest($baseUri, $headers)));
+        ->andThrow(new ConnectException('Could not resolve host.', $payload->toRequest($baseUri, $headers, $queryParams)));
 
     expect(fn () => $this->http->requestObject($payload))->toThrow(function (TransporterException $e) {
         expect($e->getMessage())->toBe('Could not resolve host.')
@@ -193,11 +196,12 @@ test('request content client errors', function () {
 
     $baseUri = BaseUri::from('api.openai.com');
     $headers = Headers::withAuthorization(ApiKey::from('foo'));
+    $queryParams = QueryParams::create();
 
     $this->client
         ->shouldReceive('sendRequest')
         ->once()
-        ->andThrow(new ConnectException('Could not resolve host.', $payload->toRequest($baseUri, $headers)));
+        ->andThrow(new ConnectException('Could not resolve host.', $payload->toRequest($baseUri, $headers, $queryParams)));
 
     expect(fn () => $this->http->requestContent($payload))->toThrow(function (TransporterException $e) {
         expect($e->getMessage())->toBe('Could not resolve host.')

--- a/tests/ValueObjects/Transporter/Payload.php
+++ b/tests/ValueObjects/Transporter/Payload.php
@@ -5,14 +5,16 @@ use OpenAI\ValueObjects\ApiKey;
 use OpenAI\ValueObjects\Transporter\BaseUri;
 use OpenAI\ValueObjects\Transporter\Headers;
 use OpenAI\ValueObjects\Transporter\Payload;
+use OpenAI\ValueObjects\Transporter\QueryParams;
 
 it('has a method', function () {
     $payload = Payload::create('models', []);
 
     $baseUri = BaseUri::from('api.openai.com/v1');
     $headers = Headers::withAuthorization(ApiKey::from('foo'))->withContentType(ContentType::JSON);
+    $queryParams = QueryParams::create();
 
-    expect($payload->toRequest($baseUri, $headers)->getMethod())->toBe('POST');
+    expect($payload->toRequest($baseUri, $headers, $queryParams)->getMethod())->toBe('POST');
 });
 
 it('has a uri', function () {
@@ -20,12 +22,14 @@ it('has a uri', function () {
 
     $baseUri = BaseUri::from('api.openai.com/v1');
     $headers = Headers::withAuthorization(ApiKey::from('foo'))->withContentType(ContentType::JSON);
+    $queryParams = QueryParams::create()->withParam('foo', 'bar');
 
-    $uri = $payload->toRequest($baseUri, $headers)->getUri();
+    $uri = $payload->toRequest($baseUri, $headers, $queryParams)->getUri();
 
     expect($uri->getHost())->toBe('api.openai.com')
         ->and($uri->getScheme())->toBe('https')
-        ->and($uri->getPath())->toBe('/v1/models');
+        ->and($uri->getPath())->toBe('/v1/models')
+        ->and($uri->getQuery())->toBe('foo=bar');
 });
 
 test('get verb does not have a body', function () {
@@ -33,8 +37,9 @@ test('get verb does not have a body', function () {
 
     $baseUri = BaseUri::from('api.openai.com/v1');
     $headers = Headers::withAuthorization(ApiKey::from('foo'))->withContentType(ContentType::JSON);
+    $queryParams = QueryParams::create();
 
-    expect($payload->toRequest($baseUri, $headers)->getBody()->getContents())->toBe('');
+    expect($payload->toRequest($baseUri, $headers, $queryParams)->getBody()->getContents())->toBe('');
 });
 
 test('post verb has a body', function () {
@@ -44,8 +49,9 @@ test('post verb has a body', function () {
 
     $baseUri = BaseUri::from('api.openai.com/v1');
     $headers = Headers::withAuthorization(ApiKey::from('foo'))->withContentType(ContentType::JSON);
+    $queryParams = QueryParams::create();
 
-    expect($payload->toRequest($baseUri, $headers)->getBody()->getContents())->toBe(json_encode([
+    expect($payload->toRequest($baseUri, $headers, $queryParams)->getBody()->getContents())->toBe(json_encode([
         'name' => 'test',
     ]));
 });
@@ -58,8 +64,9 @@ test('builds upload request', function () {
 
     $baseUri = BaseUri::from('api.openai.com/v1');
     $headers = Headers::withAuthorization(ApiKey::from('foo'));
+    $queryParams = QueryParams::create();
 
-    $request = $payload->toRequest($baseUri, $headers);
+    $request = $payload->toRequest($baseUri, $headers, $queryParams);
 
     expect($request->getHeader('Content-Type')[0])
         ->toStartWith('multipart/form-data; boundary=');


### PR DESCRIPTION
This PR makes it easier to write tests in your application using this library.

This is related to https://github.com/openai-php/laravel/issues/23

@nunomaduro @mpociot  I have decided to create most of the testing logic within the client library itself and not in the Laravel wrapper. The main reason for this decision is to provide the same testing options to users which are using the client directly.
Additionally it should be fairly easy to provide the testing options in other wrappers too (@GromNaN)

The PR for the Laravel wrapper is here: https://github.com/openai-php/laravel/pull/27

There are multiple things to discuss:
- First of all: Do you agree to put most of the testing logic into the client library?
- I have add fixtures for all responses to make faking easier: It's not necessary to provide all response parameters, instead it's enough to provide the parameters the user is interested in. (see example below) Do you think that's too much?
- The response fixtures are at the moment classes having a constant containing the default response attributes. Maybe it could be changed to something different as it seems a bit too much to have classes.
- I have excluded the `OpenAI\Testing` namespace from `phpstan` because it's not really possible to add proper doc types as the return type could be possibly every available response.

Todos:
- [x] Add documentation

## A test using a fake response without providing all parameters
```php
it('returns the faked response', function () {
    $fake = new ClientFake([
        CreateResponse::fake([
            'choices' => [
                [
                    'text' => 'awesome!',
                ],
            ],
        ]),
    ]);

    $completions = $fake->completions()->create([
        'model' => 'text-davinci-003',
        'prompt' => 'PHP is ',
    ]);

    expect($completions['choices'][0])
        ->text->toBe('awesome!');
});
```
