### PR TITLE
feat: add client factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ $client = OpenAI::factory()
     ->withApiKey($yourApiKey)
     ->withOrganization('your-organization') // default: null
     ->withBaseUrl('openai.example.com/v1') // default: api.openai.com/v1
-    ->withHttpHeader('X-My-Header', 'foo')
     ->withHttpClient(new \GuzzleHttp\Client([])) // default: HTTP client found using PSR-18 HTTP Client Discovery
+    ->withHttpHeader('X-My-Header', 'foo')
+    ->withQueryParam('my-param', 'bar')
     ->make();
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ $yourApiKey = getenv('YOUR_API_KEY');
 $client = OpenAI::factory()
     ->withApiKey($yourApiKey)
     ->withOrganization('your-organization') // default: null
-    ->withBaseUrl('openai.example.com/v1') // default: api.openai.com/v1
+    ->withBaseUri('openai.example.com/v1') // default: api.openai.com/v1
     ->withHttpClient(new \GuzzleHttp\Client([])) // default: HTTP client found using PSR-18 HTTP Client Discovery
     ->withHttpHeader('X-My-Header', 'foo')
     ->withQueryParam('my-param', 'bar')

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ First, install OpenAI via the [Composer](https://getcomposer.org/) package manag
 composer require openai-php/client
 ```
 
-If your project does not already include a PSR-18 client you have to install one:
+If your project does not already include a PSR-18 client make sure the `php-http/discovery` composer plugin is allowed to run or install a client manually:
 ```bash
 composer require guzzlehttp/guzzle
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ First, install OpenAI via the [Composer](https://getcomposer.org/) package manag
 composer require openai-php/client
 ```
 
-If your project does not already include a PSR-18 client make sure the `php-http/discovery` composer plugin is allowed to run or install a client manually:
+Ensure that the `php-http/discovery` composer plugin is allowed to run or install a client manually if your project does not already have a PSR-18 client integrated.
 ```bash
 composer require guzzlehttp/guzzle
 ```
@@ -43,7 +43,7 @@ $result = $client->completions()->create([
 echo $result['choices'][0]['text']; // an open-source, widely-used, server-side scripting language.
 ```
 
-If required you can configure and create an individual Client:
+If necessary, it is possible to configure and create a separate client.
 
 ```php
 $yourApiKey = getenv('YOUR_API_KEY');

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ First, install OpenAI via the [Composer](https://getcomposer.org/) package manag
 composer require openai-php/client
 ```
 
+If your project does not already include a PSR-18 client you have to install one:
+```bash
+composer require guzzlehttp/guzzle
+```
+
 Then, interact with OpenAI's API:
 
 ```php
@@ -36,6 +41,20 @@ $result = $client->completions()->create([
 ]);
 
 echo $result['choices'][0]['text']; // an open-source, widely-used, server-side scripting language.
+```
+
+If required you can configure and create an individual Client:
+
+```php
+$yourApiKey = getenv('YOUR_API_KEY');
+
+$client = OpenAI::factory()
+    ->withApiKey($yourApiKey)
+    ->withOrganization('your-organization') // default: null
+    ->withBaseUrl('openai.example.com/v1') // default: api.openai.com/v1
+    ->withHttpHeader('X-My-Header', 'foo')
+    ->withHttpClient(new \GuzzleHttp\Client([])) // default: HTTP client found using PSR-18 HTTP Client Discovery
+    ->make();
 ```
 
 ## Usage

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "php": "^8.1.0",
         "php-http/discovery": "^1.15",
         "php-http/multipart-stream-builder": "^1.2",
+        "psr/http-client-implementation": "^1.0.1",
         "psr/http-client": "^1.0.1",
         "psr/http-message": "^1.0.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "php": "^8.1.0",
         "php-http/discovery": "^1.15",
         "php-http/multipart-stream-builder": "^1.2",
-        "psr/http-client": "^1.0"
+        "psr/http-client": "^1.0.1",
+        "psr/http-message": "^1.0.1"
     },
     "require-dev": {
         "guzzlehttp/psr7": "^2.4.4",

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,12 @@
     ],
     "require": {
         "php": "^8.1.0",
-        "php-http/discovery": "^1.14",
+        "php-http/discovery": "^1.15",
         "php-http/multipart-stream-builder": "^1.2",
         "psr/http-client": "^1.0"
     },
     "require-dev": {
+        "guzzlehttp/psr7": "^2.4.4",
         "guzzlehttp/guzzle": "^7.5.0",
         "laravel/pint": "^1.6.0",
         "nunomaduro/collision": "^7.1.0",

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,12 @@
     ],
     "require": {
         "php": "^8.1.0",
-        "guzzlehttp/guzzle": "^7.5.0"
+        "php-http/discovery": "^1.14",
+        "php-http/multipart-stream-builder": "^1.2",
+        "psr/http-client": "^1.0"
     },
     "require-dev": {
+        "guzzlehttp/guzzle": "^7.5.0",
         "laravel/pint": "^1.6.0",
         "nunomaduro/collision": "^7.1.0",
         "pestphp/pest": "^2.0.0",
@@ -42,7 +45,8 @@
         "sort-packages": true,
         "preferred-install": "dist",
         "allow-plugins": {
-            "pestphp/pest-plugin": true
+            "pestphp/pest-plugin": true,
+            "php-http/discovery": false
         }
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -7,12 +7,15 @@
         {
             "name": "Nuno Maduro",
             "email": "enunomaduro@gmail.com"
+        },
+        {
+            "name": "Sandro Gehri"
         }
     ],
     "require": {
         "php": "^8.1.0",
-        "php-http/discovery": "^1.15",
-        "php-http/multipart-stream-builder": "^1.2",
+        "php-http/discovery": "^1.15.2",
+        "php-http/multipart-stream-builder": "^1.2.0",
         "psr/http-client": "^1.0.1",
         "psr/http-client-implementation": "^1.0.1",
         "psr/http-factory-implementation": "*",
@@ -22,11 +25,11 @@
         "guzzlehttp/psr7": "^2.4.4",
         "guzzlehttp/guzzle": "^7.5.0",
         "laravel/pint": "^1.6.0",
-        "nunomaduro/collision": "^7.1.0",
+        "nunomaduro/collision": "^7.1.2",
         "pestphp/pest": "^2.0.0",
         "pestphp/pest-plugin-arch": "^2.0.0",
         "pestphp/pest-plugin-mock": "^2.0.0",
-        "phpstan/phpstan": "^1.10.6",
+        "phpstan/phpstan": "^1.10.7",
         "rector/rector": "^0.14.8",
         "symfony/var-dumper": "^6.2.7"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "psr/http-message": "^1.0.1"
     },
     "require-dev": {
+        "guzzlehttp/psr7": "^2.4.4",
         "guzzlehttp/guzzle": "^7.5.0",
         "laravel/pint": "^1.6.0",
         "nunomaduro/collision": "^7.1.0",

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
         "php": "^8.1.0",
         "php-http/discovery": "^1.15",
         "php-http/multipart-stream-builder": "^1.2",
-        "psr/http-client-implementation": "^1.0.1",
         "psr/http-client": "^1.0.1",
+        "psr/http-client-implementation": "^1.0.1",
+        "psr/http-factory-implementation": "*",
         "psr/http-message": "^1.0.1"
     },
     "require-dev": {
-        "guzzlehttp/psr7": "^2.4.4",
         "guzzlehttp/guzzle": "^7.5.0",
         "laravel/pint": "^1.6.0",
         "nunomaduro/collision": "^7.1.0",

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -18,7 +18,7 @@ final class Factory
 
     private ?ClientInterface $httpClient = null;
 
-    private ?string $baseUrl = null;
+    private ?string $baseUri = null;
 
     /**
      * @var array<string, string>
@@ -62,12 +62,12 @@ final class Factory
     }
 
     /**
-     * Sets the base URL for the requests.
-     * If no URL is provided the factory will use the default OpenAI API URL.
+     * Sets the base URI for the requests.
+     * If no URI is provided the factory will use the default OpenAI API URI.
      */
-    public function withBaseUrl(string $baseUrl): self
+    public function withBaseUri(string $baseUri): self
     {
-        $this->baseUrl = $baseUrl;
+        $this->baseUri = $baseUri;
 
         return $this;
     }
@@ -111,7 +111,7 @@ final class Factory
             $headers = $headers->withCustomHeader($name, $value);
         }
 
-        $baseUri = BaseUri::from($this->baseUrl ?: 'api.openai.com/v1');
+        $baseUri = BaseUri::from($this->baseUri ?: 'api.openai.com/v1');
 
         $queryParams = QueryParams::create();
         foreach ($this->queryParams as $name => $value) {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace OpenAI;
+
+use Http\Discovery\Psr18ClientDiscovery;
+use OpenAI\Transporters\HttpTransporter;
+use OpenAI\ValueObjects\ApiKey;
+use OpenAI\ValueObjects\Transporter\BaseUri;
+use OpenAI\ValueObjects\Transporter\Headers;
+use Psr\Http\Client\ClientInterface;
+
+final class Factory
+{
+    private ?string $apiKey = null;
+
+    private ?string $organization = null;
+
+    private ?ClientInterface $httpClient = null;
+
+    private ?string $baseUrl = null;
+
+    /**
+     * @var array<string, string>
+     */
+    private array $headers = [];
+
+    /**
+     * Sets the API key for the requests.
+     */
+    public function withApiKey(string $apiKey): self
+    {
+        $this->apiKey = $apiKey;
+
+        return $this;
+    }
+
+    /**
+     * Sets the organization for the requests.
+     */
+    public function withOrganization(?string $organization): self
+    {
+        $this->organization = $organization;
+
+        return $this;
+    }
+
+    /**
+     * Sets the HTTP client for the requests.
+     * If no client is provided the factory will try to find one using PSR-18 HTTP Client Discovery.
+     */
+    public function withHttpClient(ClientInterface $client): self
+    {
+        $this->httpClient = $client;
+
+        return $this;
+    }
+
+    /**
+     * Sets the base URL for the requests.
+     * If no URL is provided the factory will use the default OpenAI API URL.
+     */
+    public function withBaseUrl(string $baseUrl): self
+    {
+        $this->baseUrl = $baseUrl;
+
+        return $this;
+    }
+
+    /**
+     * Adds a custom HTTP header to the requests.
+     */
+    public function withHttpHeader(string $name, string $value): self
+    {
+        $this->headers[$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Creates a new Open AI Client.
+     */
+    public function make(): Client
+    {
+        $headers = Headers::create();
+
+        if ($this->apiKey !== null) {
+            $headers = Headers::withAuthorization(ApiKey::from($this->apiKey));
+        }
+
+        if ($this->organization !== null) {
+            $headers = $headers->withOrganization($this->organization);
+        }
+
+        foreach ($this->headers as $name => $value) {
+            $headers = $headers->withCustomHeader($name, $value);
+        }
+
+        $baseUri = BaseUri::from($this->baseUrl ?: 'api.openai.com/v1');
+
+        $client = $this->httpClient ??= Psr18ClientDiscovery::find();
+
+        $transporter = new HttpTransporter($client, $baseUri, $headers);
+
+        return new Client($transporter);
+    }
+}

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -12,20 +12,36 @@ use Psr\Http\Client\ClientInterface;
 
 final class Factory
 {
+    /**
+     * The API key for the requests.
+     */
     private ?string $apiKey = null;
 
+    /**
+     * The organization for the requests.
+     */
     private ?string $organization = null;
 
+    /**
+     * The HTTP client for the requests.
+     */
     private ?ClientInterface $httpClient = null;
 
+    /**
+     * The base URI for the requests.
+     */
     private ?string $baseUri = null;
 
     /**
+     * The HTTP headers for the requests.
+     *
      * @var array<string, string>
      */
     private array $headers = [];
 
     /**
+     * The query parameters for the requests.
+     *
      * @var array<string, string|int>
      */
     private array $queryParams = [];

--- a/src/OpenAI.php
+++ b/src/OpenAI.php
@@ -2,12 +2,8 @@
 
 declare(strict_types=1);
 
-use GuzzleHttp\Client as GuzzleClient;
 use OpenAI\Client;
-use OpenAI\Transporters\HttpTransporter;
-use OpenAI\ValueObjects\ApiKey;
-use OpenAI\ValueObjects\Transporter\BaseUri;
-use OpenAI\ValueObjects\Transporter\Headers;
+use OpenAI\Factory;
 
 final class OpenAI
 {
@@ -16,20 +12,17 @@ final class OpenAI
      */
     public static function client(string $apiKey, string $organization = null): Client
     {
-        $apiKey = ApiKey::from($apiKey);
+        return self::factory()
+            ->withApiKey($apiKey)
+            ->withOrganization($organization)
+            ->make();
+    }
 
-        $baseUri = BaseUri::from('api.openai.com/v1');
-
-        $headers = Headers::withAuthorization($apiKey);
-
-        if ($organization !== null) {
-            $headers = $headers->withOrganization($organization);
-        }
-
-        $client = new GuzzleClient();
-
-        $transporter = new HttpTransporter($client, $baseUri, $headers);
-
-        return new Client($transporter);
+    /**
+     * Creates a new factory instance to configure a custom Open AI Client
+     */
+    public static function factory(): Factory
+    {
+        return new Factory();
     }
 }

--- a/src/Transporters/HttpTransporter.php
+++ b/src/Transporters/HttpTransporter.php
@@ -12,6 +12,7 @@ use OpenAI\Exceptions\UnserializableResponse;
 use OpenAI\ValueObjects\Transporter\BaseUri;
 use OpenAI\ValueObjects\Transporter\Headers;
 use OpenAI\ValueObjects\Transporter\Payload;
+use OpenAI\ValueObjects\Transporter\QueryParams;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 
@@ -27,6 +28,7 @@ final class HttpTransporter implements Transporter
         private readonly ClientInterface $client,
         private readonly BaseUri $baseUri,
         private readonly Headers $headers,
+        private readonly QueryParams $queryParams,
     ) {
         // ..
     }
@@ -36,7 +38,7 @@ final class HttpTransporter implements Transporter
      */
     public function requestObject(Payload $payload): array|string
     {
-        $request = $payload->toRequest($this->baseUri, $this->headers);
+        $request = $payload->toRequest($this->baseUri, $this->headers, $this->queryParams);
 
         try {
             $response = $this->client->sendRequest($request);
@@ -69,7 +71,7 @@ final class HttpTransporter implements Transporter
      */
     public function requestContent(Payload $payload): string
     {
-        $request = $payload->toRequest($this->baseUri, $this->headers);
+        $request = $payload->toRequest($this->baseUri, $this->headers, $this->queryParams);
 
         try {
             $response = $this->client->sendRequest($request);

--- a/src/ValueObjects/Transporter/Headers.php
+++ b/src/ValueObjects/Transporter/Headers.php
@@ -23,6 +23,14 @@ final class Headers
     }
 
     /**
+     * Creates a new Headers value object
+     */
+    public static function create(): self
+    {
+        return new self([]);
+    }
+
+    /**
      * Creates a new Headers value object with the given API token.
      */
     public static function withAuthorization(ApiKey $apiKey): self
@@ -51,6 +59,17 @@ final class Headers
         return new self([
             ...$this->headers,
             'OpenAI-Organization' => $organization,
+        ]);
+    }
+
+    /**
+     * Creates a new Headers value object, with the newly added header, and the existing headers.
+     */
+    public function withCustomHeader(string $name, string $value): self
+    {
+        return new self([
+            ...$this->headers,
+            $name => $value,
         ]);
     }
 

--- a/src/ValueObjects/Transporter/Payload.php
+++ b/src/ValueObjects/Transporter/Payload.php
@@ -123,12 +123,16 @@ final class Payload
     /**
      * Creates a new Psr 7 Request instance.
      */
-    public function toRequest(BaseUri $baseUri, Headers $headers): RequestInterface
+    public function toRequest(BaseUri $baseUri, Headers $headers, QueryParams $queryParams): RequestInterface
     {
         $psr17Factory = new Psr17Factory();
 
         $body = null;
+
         $uri = $baseUri->toString().$this->uri->toString();
+        if (! empty($queryParams->toArray())) {
+            $uri .= '?'.http_build_query($queryParams->toArray());
+        }
 
         $headers = $headers->withContentType($this->contentType);
 

--- a/src/ValueObjects/Transporter/Payload.php
+++ b/src/ValueObjects/Transporter/Payload.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace OpenAI\ValueObjects\Transporter;
 
-use GuzzleHttp\Psr7\MultipartStream;
-use GuzzleHttp\Psr7\Request as Psr7Request;
+use Http\Discovery\Psr17Factory;
+use Http\Message\MultipartStream\MultipartStreamBuilder;
 use OpenAI\Contracts\Request;
 use OpenAI\Enums\Transporter\ContentType;
 use OpenAI\Enums\Transporter\Method;
 use OpenAI\ValueObjects\ResourceUri;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * @internal
@@ -121,8 +123,10 @@ final class Payload
     /**
      * Creates a new Psr 7 Request instance.
      */
-    public function toRequest(BaseUri $baseUri, Headers $headers): Psr7Request
+    public function toRequest(BaseUri $baseUri, Headers $headers): RequestInterface
     {
+        $psr17Factory = new Psr17Factory();
+
         $body = null;
         $uri = $baseUri->toString().$this->uri->toString();
 
@@ -130,16 +134,37 @@ final class Payload
 
         if ($this->method === Method::POST) {
             if ($this->contentType === ContentType::MULTIPART) {
-                $body = new MultipartStream(
-                    array_map(fn ($key): array => ['name' => $key, 'contents' => $this->parameters[$key]], array_keys($this->parameters))
-                );
+                $streamBuilder = new MultipartStreamBuilder($psr17Factory);
 
-                $headers = $headers->withContentType($this->contentType, '; boundary='.$body->getBoundary());
+                /** @var array<string, StreamInterface|string|int|float|bool> $parameters */
+                $parameters = $this->parameters;
+
+                foreach ($parameters as $key => $value) {
+                    if (is_int($value) || is_float($value) || is_bool($value)) {
+                        $value = (string) $value;
+                    }
+
+                    $streamBuilder->addResource($key, $value);
+                }
+
+                $body = $streamBuilder->build();
+
+                $headers = $headers->withContentType($this->contentType, '; boundary='.$streamBuilder->getBoundary());
             } else {
-                $body = json_encode($this->parameters, JSON_THROW_ON_ERROR);
+                $body = $psr17Factory->createStream(json_encode($this->parameters, JSON_THROW_ON_ERROR));
             }
         }
 
-        return new Psr7Request($this->method->value, $uri, $headers->toArray(), $body);
+        $request = $psr17Factory->createRequest($this->method->value, $uri);
+
+        if ($body !== null) {
+            $request = $request->withBody($body);
+        }
+
+        foreach ($headers->toArray() as $name => $value) {
+            $request = $request->withHeader($name, $value);
+        }
+
+        return $request;
     }
 }

--- a/src/ValueObjects/Transporter/QueryParams.php
+++ b/src/ValueObjects/Transporter/QueryParams.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\ValueObjects\Transporter;
+
+/**
+ * @internal
+ */
+final class QueryParams
+{
+    /**
+     * Creates a new Query Params value object.
+     *
+     * @param  array<string, string|int>  $params
+     */
+    private function __construct(private readonly array $params)
+    {
+        // ..
+    }
+
+    /**
+     * Creates a new Query Params value object
+     */
+    public static function create(): self
+    {
+        return new self([]);
+    }
+
+    /**
+     * Creates a new Query Params value object, with the newly added param, and the existing params.
+     */
+    public function withParam(string $name, string|int $value): self
+    {
+        return new self([
+            ...$this->params,
+            $name => $value,
+        ]);
+    }
+
+    /**
+     * @return array<string, string|int>
+     */
+    public function toArray(): array
+    {
+        return $this->params;
+    }
+}

--- a/tests/Arch.php
+++ b/tests/Arch.php
@@ -22,7 +22,10 @@ test('responses')->expect('OpenAI\Responses')->toOnlyUse([
 ]);
 
 test('value objects')->expect('OpenAI\ValueObjects')->toOnlyUse([
-    'GuzzleHttp\Psr7',
+    'Http\Discovery\Psr17Factory',
+    'Http\Message\MultipartStream\MultipartStreamBuilder',
+    'Psr\Http\Message\RequestInterface',
+    'Psr\Http\Message\StreamInterface',
     'OpenAI\Enums',
     'OpenAI\Contracts',
 ]);
@@ -33,9 +36,12 @@ test('client')->expect('OpenAI\Client')->toOnlyUse([
 ]);
 
 test('openai')->expect('OpenAI')->toOnlyUse([
-    'Psr\Http\Client',
-    'GuzzleHttp\Client',
-    'GuzzleHttp\Psr7',
-    'OpenAI\Resources',
+    'Http\Discovery\Psr17Factory',
+    'Http\Discovery\Psr18ClientDiscovery',
+    'Http\Message\MultipartStream\MultipartStreamBuilder',
     'OpenAI\Contracts',
+    'OpenAI\Resources',
+    'Psr\Http\Client',
+    'Psr\Http\Message\RequestInterface',
+    'Psr\Http\Message\StreamInterface',
 ]);

--- a/tests/OpenAI.php
+++ b/tests/OpenAI.php
@@ -41,7 +41,7 @@ it('sets a custom client via factory', function () {
 
 it('sets a custom base url via factory', function () {
     $openAI = OpenAI::factory()
-        ->withBaseUrl('https://openai.example.com/v1')
+        ->withBaseUri('https://openai.example.com/v1')
         ->make();
 
     expect($openAI)->toBeInstanceOf(Client::class);

--- a/tests/OpenAI.php
+++ b/tests/OpenAI.php
@@ -1,5 +1,6 @@
 <?php
 
+use GuzzleHttp\Client as GuzzleClient;
 use OpenAI\Client;
 
 it('may create a client', function () {
@@ -10,6 +11,46 @@ it('may create a client', function () {
 
 it('sets organization when provided', function () {
     $openAI = OpenAI::client('foo', 'nunomaduro');
+
+    expect($openAI)->toBeInstanceOf(Client::class);
+});
+
+it('may create a client via factory', function () {
+    $openAI = OpenAI::factory()
+        ->withApiKey('foo')
+        ->make();
+
+    expect($openAI)->toBeInstanceOf(Client::class);
+});
+
+it('sets an organization via factory', function () {
+    $openAI = OpenAI::factory()
+        ->withOrganization('nunomaduro')
+        ->make();
+
+    expect($openAI)->toBeInstanceOf(Client::class);
+});
+
+it('sets a custom client via factory', function () {
+    $openAI = OpenAI::factory()
+        ->withHttpClient(new GuzzleClient())
+        ->make();
+
+    expect($openAI)->toBeInstanceOf(Client::class);
+});
+
+it('sets a custom base url via factory', function () {
+    $openAI = OpenAI::factory()
+        ->withBaseUrl('https://openai.example.com/v1')
+        ->make();
+
+    expect($openAI)->toBeInstanceOf(Client::class);
+});
+
+it('sets a custom headers via factory', function () {
+    $openAI = OpenAI::factory()
+        ->withHttpHeader('X-My-Header', 'foo')
+        ->make();
 
     expect($openAI)->toBeInstanceOf(Client::class);
 });

--- a/tests/OpenAI.php
+++ b/tests/OpenAI.php
@@ -47,9 +47,17 @@ it('sets a custom base url via factory', function () {
     expect($openAI)->toBeInstanceOf(Client::class);
 });
 
-it('sets a custom headers via factory', function () {
+it('sets a custom header via factory', function () {
     $openAI = OpenAI::factory()
         ->withHttpHeader('X-My-Header', 'foo')
+        ->make();
+
+    expect($openAI)->toBeInstanceOf(Client::class);
+});
+
+it('sets a custom query parameter via factory', function () {
+    $openAI = OpenAI::factory()
+        ->withQueryParam('my-param', 'bar')
         ->make();
 
     expect($openAI)->toBeInstanceOf(Client::class);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -6,6 +6,7 @@ use OpenAI\ValueObjects\ApiKey;
 use OpenAI\ValueObjects\Transporter\BaseUri;
 use OpenAI\ValueObjects\Transporter\Headers;
 use OpenAI\ValueObjects\Transporter\Payload;
+use OpenAI\ValueObjects\Transporter\QueryParams;
 
 function mockClient(string $method, string $resource, array $params, array|string $response, $methodName = 'requestObject')
 {
@@ -17,8 +18,9 @@ function mockClient(string $method, string $resource, array $params, array|strin
         ->withArgs(function (Payload $payload) use ($method, $resource) {
             $baseUri = BaseUri::from('api.openai.com/v1');
             $headers = Headers::withAuthorization(ApiKey::from('foo'));
+            $queryParams = QueryParams::create();
 
-            $request = $payload->toRequest($baseUri, $headers);
+            $request = $payload->toRequest($baseUri, $headers, $queryParams);
 
             return $request->getMethod() === $method
                 && $request->getUri()->getPath() === "/v1/$resource";

--- a/tests/Transporters/HttpTransporter.php
+++ b/tests/Transporters/HttpTransporter.php
@@ -12,6 +12,7 @@ use OpenAI\ValueObjects\ApiKey;
 use OpenAI\ValueObjects\Transporter\BaseUri;
 use OpenAI\ValueObjects\Transporter\Headers;
 use OpenAI\ValueObjects\Transporter\Payload;
+use OpenAI\ValueObjects\Transporter\QueryParams;
 use Psr\Http\Client\ClientInterface;
 
 beforeEach(function () {
@@ -23,6 +24,7 @@ beforeEach(function () {
         $this->client,
         BaseUri::from('api.openai.com/v1'),
         Headers::withAuthorization($apiKey)->withContentType(ContentType::JSON),
+        QueryParams::create()->withParam('foo', 'bar'),
     );
 });
 
@@ -109,11 +111,12 @@ test('request object client errors', function () {
 
     $baseUri = BaseUri::from('api.openai.com');
     $headers = Headers::withAuthorization(ApiKey::from('foo'));
+    $queryParams = QueryParams::create();
 
     $this->client
         ->shouldReceive('sendRequest')
         ->once()
-        ->andThrow(new ConnectException('Could not resolve host.', $payload->toRequest($baseUri, $headers)));
+        ->andThrow(new ConnectException('Could not resolve host.', $payload->toRequest($baseUri, $headers, $queryParams)));
 
     expect(fn () => $this->http->requestObject($payload))->toThrow(function (TransporterException $e) {
         expect($e->getMessage())->toBe('Could not resolve host.')
@@ -193,11 +196,12 @@ test('request content client errors', function () {
 
     $baseUri = BaseUri::from('api.openai.com');
     $headers = Headers::withAuthorization(ApiKey::from('foo'));
+    $queryParams = QueryParams::create();
 
     $this->client
         ->shouldReceive('sendRequest')
         ->once()
-        ->andThrow(new ConnectException('Could not resolve host.', $payload->toRequest($baseUri, $headers)));
+        ->andThrow(new ConnectException('Could not resolve host.', $payload->toRequest($baseUri, $headers, $queryParams)));
 
     expect(fn () => $this->http->requestContent($payload))->toThrow(function (TransporterException $e) {
         expect($e->getMessage())->toBe('Could not resolve host.')

--- a/tests/ValueObjects/Transporter/Payload.php
+++ b/tests/ValueObjects/Transporter/Payload.php
@@ -5,14 +5,16 @@ use OpenAI\ValueObjects\ApiKey;
 use OpenAI\ValueObjects\Transporter\BaseUri;
 use OpenAI\ValueObjects\Transporter\Headers;
 use OpenAI\ValueObjects\Transporter\Payload;
+use OpenAI\ValueObjects\Transporter\QueryParams;
 
 it('has a method', function () {
     $payload = Payload::create('models', []);
 
     $baseUri = BaseUri::from('api.openai.com/v1');
     $headers = Headers::withAuthorization(ApiKey::from('foo'))->withContentType(ContentType::JSON);
+    $queryParams = QueryParams::create();
 
-    expect($payload->toRequest($baseUri, $headers)->getMethod())->toBe('POST');
+    expect($payload->toRequest($baseUri, $headers, $queryParams)->getMethod())->toBe('POST');
 });
 
 it('has a uri', function () {
@@ -20,12 +22,14 @@ it('has a uri', function () {
 
     $baseUri = BaseUri::from('api.openai.com/v1');
     $headers = Headers::withAuthorization(ApiKey::from('foo'))->withContentType(ContentType::JSON);
+    $queryParams = QueryParams::create()->withParam('foo', 'bar');
 
-    $uri = $payload->toRequest($baseUri, $headers)->getUri();
+    $uri = $payload->toRequest($baseUri, $headers, $queryParams)->getUri();
 
     expect($uri->getHost())->toBe('api.openai.com')
         ->and($uri->getScheme())->toBe('https')
-        ->and($uri->getPath())->toBe('/v1/models');
+        ->and($uri->getPath())->toBe('/v1/models')
+        ->and($uri->getQuery())->toBe('foo=bar');
 });
 
 test('get verb does not have a body', function () {
@@ -33,8 +37,9 @@ test('get verb does not have a body', function () {
 
     $baseUri = BaseUri::from('api.openai.com/v1');
     $headers = Headers::withAuthorization(ApiKey::from('foo'))->withContentType(ContentType::JSON);
+    $queryParams = QueryParams::create();
 
-    expect($payload->toRequest($baseUri, $headers)->getBody()->getContents())->toBe('');
+    expect($payload->toRequest($baseUri, $headers, $queryParams)->getBody()->getContents())->toBe('');
 });
 
 test('post verb has a body', function () {
@@ -44,8 +49,9 @@ test('post verb has a body', function () {
 
     $baseUri = BaseUri::from('api.openai.com/v1');
     $headers = Headers::withAuthorization(ApiKey::from('foo'))->withContentType(ContentType::JSON);
+    $queryParams = QueryParams::create();
 
-    expect($payload->toRequest($baseUri, $headers)->getBody()->getContents())->toBe(json_encode([
+    expect($payload->toRequest($baseUri, $headers, $queryParams)->getBody()->getContents())->toBe(json_encode([
         'name' => 'test',
     ]));
 });
@@ -58,8 +64,9 @@ test('builds upload request', function () {
 
     $baseUri = BaseUri::from('api.openai.com/v1');
     $headers = Headers::withAuthorization(ApiKey::from('foo'));
+    $queryParams = QueryParams::create();
 
-    $request = $payload->toRequest($baseUri, $headers);
+    $request = $payload->toRequest($baseUri, $headers, $queryParams);
 
     expect($request->getHeader('Content-Type')[0])
         ->toStartWith('multipart/form-data; boundary=');


### PR DESCRIPTION
This adds the ability to configure the client instance via a new factory:

Excerpt from the updated README.
```php
$yourApiKey = getenv('YOUR_API_KEY');

$client = OpenAI::factory()
    ->withApiKey($yourApiKey)
    ->withOrganization('your-organization') // default: null
    ->withBaseUrl('openai.example.com/v1') // default: api.openai.com/v1
    ->withHttpHeader('X-My-Header', 'foo')
    ->withHttpClient(new \GuzzleHttp\Client([])) // default: HTTP client found using PSR-18 HTTP Client Discovery
    ->make();
```

This change is breaking as the "guzzlehttp/guzzle" has been removed. Existing projects without an explicitly installed HTTP client have to install the Guzzle Client manually:
```bash
composer require guzzlehttp/guzzle
``` 

With this change we can resolve various issues:
- #30 
- #31 
- #39 
- #65
- #67 
