### PR TITLE
Make ErrorException return types nullable

### DIFF
--- a/src/Exceptions/ErrorException.php
+++ b/src/Exceptions/ErrorException.php
@@ -29,7 +29,7 @@ final class ErrorException extends Exception
     /**
      * Returns the error type.
      */
-    public function getErrorType(): string
+    public function getErrorType(): ?string
     {
         return $this->contents['type'];
     }
@@ -37,7 +37,7 @@ final class ErrorException extends Exception
     /**
      * Returns the error type.
      */
-    public function getErrorCode(): string
+    public function getErrorCode(): ?string
     {
         return $this->contents['code'];
     }


### PR DESCRIPTION
`ErrorException` will throw a `TypeError` when attempting to use `getErrorCode()` or `getErrorType()` if they are null, this RP makes those function return nullable strings