### PR TITLE
fix: response error code can be null

### DIFF
--- a/src/Exceptions/ErrorException.php
+++ b/src/Exceptions/ErrorException.php
@@ -37,7 +37,7 @@ final class ErrorException extends Exception
     /**
      * Returns the error type.
      */
-    public function getErrorCode(): string
+    public function getErrorCode(): ?string
     {
         return $this->contents['code'];
     }


### PR DESCRIPTION
Gateway timeouts result in an error response where the code field is null causing a type error on the getErrorCode() method since it's return value is typed as a non-nullable string:

```
array:1 [ // vendor/openai-php/client/src/Transporters/HttpTransporter.php:64
  "error" => array:4 [
    "message" => "The server had an error while processing your request. Sorry about that!"
    "type" => "server_error"
    "param" => null
    "code" => null
  ]
]
```