### PR TITLE
Assert valid response in Chat resource for model

### DIFF
--- a/src/Resources/Chat.php
+++ b/src/Resources/Chat.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenAI\Resources;
 
+use Http\Discovery\Exception\NotFoundException;
 use OpenAI\Responses\Chat\CreateResponse;
 use OpenAI\Responses\Chat\CreateStreamedResponse;
 use OpenAI\Responses\StreamResponse;
@@ -49,6 +50,26 @@ final class Chat
 
         $response = $this->transporter->requestStream($payload);
 
-        return new StreamResponse(CreateStreamedResponse::class, $response);
+        $streamResponse = new StreamResponse(CreateStreamedResponse::class, $response);
+
+        $this->assertValidResponse($streamResponse, $parameters['model']);
+
+        return $streamResponse;
+    }
+
+    /**
+     * Asserts that the given StreamResponse is valid by checking its status code.
+     * Throws a NotFoundException if the status code is 404.
+     *
+     * @param StreamResponse $streamResponse The StreamResponse to be validated
+     * @param string         $model          The model name associated with the StreamResponse
+     *
+     * @throws NotFoundException If the StreamResponse's status code is 404
+     */
+    private function assertValidResponse(StreamResponse $streamResponse, string $model): void
+    {
+        if (404 === $streamResponse->getStatusCode()) {
+            throw new NotFoundException(sprintf('Model "%s" not found', $model));
+        }
     }
 }

--- a/src/Responses/StreamResponse.php
+++ b/src/Responses/StreamResponse.php
@@ -69,4 +69,12 @@ final class StreamResponse implements IteratorAggregate
 
         return $buffer;
     }
+
+    /**
+     * @return int Return HTTP status from response
+     */
+    public function getStatusCode(): int
+    {
+        return $this->response->getStatusCode();
+    }
 }

--- a/tests/Responses/Chat/AssertValidStreamResponse.php
+++ b/tests/Responses/Chat/AssertValidStreamResponse.php
@@ -1,0 +1,44 @@
+<?php
+
+use Http\Discovery\Exception\NotFoundException;
+use OpenAI\Contracts\Transporter;
+use OpenAI\Resources\Chat;
+use OpenAI\Responses\Chat\CreateStreamedResponse;
+use OpenAI\Responses\StreamResponse;
+use Psr\Http\Message\ResponseInterface;
+
+test('assertValidResponse throws NotFoundException on 404', function () {
+    $model = 'model-do-not-exist';
+    $statusCode = 404;
+
+    $responseInterfaceMock = $this->createMock(ResponseInterface::class);
+    $responseInterfaceMock->method('getStatusCode')->willReturn($statusCode);
+
+    $streamResponse = new StreamResponse(CreateStreamedResponse::class, $responseInterfaceMock);
+
+    $transporterMock = $this->createMock(Transporter::class);
+    $chat = new Chat($transporterMock);
+
+    $this->expectException(NotFoundException::class);
+    $this->expectExceptionMessage(sprintf('Model "%s" not found', $model));
+
+    $method = new \ReflectionMethod(Chat::class, 'assertValidResponse');
+    $method->invoke($chat, $streamResponse, $model);
+});
+
+test('assertValidResponse does not throw exception on 200', function () {
+    $model = 'gpt-3.5-turbo';
+    $statusCode = 200;
+
+    $responseInterfaceMock = $this->createMock(ResponseInterface::class);
+    $responseInterfaceMock->method('getStatusCode')->willReturn($statusCode);
+
+    $streamResponse = new StreamResponse(CreateStreamedResponse::class, $responseInterfaceMock);
+
+    $transporterMock = $this->createMock(Transporter::class);
+    $chat = new Chat($transporterMock);
+
+    $method = new \ReflectionMethod(Chat::class, 'assertValidResponse');
+
+    $this->assertNull($method->invoke($chat, $streamResponse, $model));
+});


### PR DESCRIPTION
Improve the error handling in the Chat resource's assertValidResponse method to provide clearer and more informative error messages when a specified model does not exist. This enhancement helps developers to quickly identify and address issues related to non-existent models in their application.

Background to this PR:
There are examples in the documentation, with the use of the model of gpt-4, which is not yet available for everyone through openAI. Moreover, it would be good to take control if a non-existing model is given as a parameter.

![openai-playground](https://user-images.githubusercontent.com/5327617/227739033-8efc31f4-f1d0-4210-919f-c29eed6855c4.png)

My playground:
https://github.com/IshtarStar/openai-playground