### PR TITLE
trim api key

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -59,7 +59,7 @@ final class Factory
      */
     public function withApiKey(string $apiKey): self
     {
-        $this->apiKey = $apiKey;
+        $this->apiKey = trim($apiKey);
 
         return $this;
     }


### PR DESCRIPTION
when you are adding API key from configuration file it can add whitespace character(s) - we should trim that