### PR TITLE
Fix: the toArray() on streamed chat response deltas should only filter null

### DIFF
--- a/src/Responses/Chat/CreateStreamedResponseDelta.php
+++ b/src/Responses/Chat/CreateStreamedResponseDelta.php
@@ -28,9 +28,9 @@ final class CreateStreamedResponseDelta
      */
     public function toArray(): array
     {
-        return array_filter([
-            'role' => $this->role,
-            'content' => $this->content,
-        ]);
+       return array_filter([
+           'role' => $this->role,
+           'content' => $this->content,
+       ], fn ($value): bool => ! is_null($value));
     }
 }

--- a/tests/Fixtures/Chat.php
+++ b/tests/Fixtures/Chat.php
@@ -28,6 +28,44 @@ function chatCompletion(): array
     ];
 }
 
+function chatCompletionStreamFirstChunk(): array
+{
+    return [
+        'id' => 'chatcmpl-6wdIE4DsUtqf1srdMTsfkJp0VWZgz',
+        'object' => 'chat.completion.chunk',
+        'created' => 1679432086,
+        'model' => 'gpt-4-0314',
+        'choices' => [
+            [
+                'index' => 0,
+                'delta' => [
+                    'role' => 'assistant',
+                ],
+                'finish_reason' => null,
+            ],
+        ],
+    ];
+}
+
+function chatCompletionStreamContentChunk(): array
+{
+    return [
+        'id' => 'chatcmpl-6wdIE4DsUtqf1srdMTsfkJp0VWZgz',
+        'object' => 'chat.completion.chunk',
+        'created' => 1679432086,
+        'model' => 'gpt-4-0314',
+        'choices' => [
+            [
+                'index' => 0,
+                'delta' => [
+                    'content' => 'Hello',
+                ],
+                'finish_reason' => null,
+            ],
+        ],
+    ];
+}
+
 /**
  * @return resource
  */

--- a/tests/Responses/Chat/CreateStreamdResponseChoice.php
+++ b/tests/Responses/Chat/CreateStreamdResponseChoice.php
@@ -1,0 +1,20 @@
+<?php
+
+use OpenAI\Responses\Chat\CreateStreamedResponseChoice;
+use OpenAI\Responses\Chat\CreateStreamedResponseDelta;
+
+test('from', function () {
+    $result = CreateStreamedResponseChoice::from(chatCompletionStreamFirstChunk()['choices'][0]);
+
+    expect($result)
+        ->index->toBe(0)
+        ->delta->toBeInstanceOf(CreateStreamedResponseDelta::class)
+        ->finishReason->toBeIn(['stop', null]);
+});
+
+test('to array', function () {
+    $result = CreateStreamedResponseChoice::from(chatCompletionStreamFirstChunk()['choices'][0]);
+
+    expect($result->toArray())
+        ->toBe(chatCompletionStreamFirstChunk()['choices'][0]);
+});

--- a/tests/Responses/Chat/CreateStreamedResponse.php
+++ b/tests/Responses/Chat/CreateStreamedResponse.php
@@ -1,6 +1,34 @@
 <?php
 
 use OpenAI\Responses\Chat\CreateStreamedResponse;
+use OpenAI\Responses\Chat\CreateStreamedResponseChoice;
+
+test('from', function () {
+    $completion = CreateStreamedResponse::from(chatCompletionStreamFirstChunk());
+
+    expect($completion)
+        ->toBeInstanceOf(CreateStreamedResponse::class)
+        ->id->toBe('chatcmpl-6wdIE4DsUtqf1srdMTsfkJp0VWZgz')
+        ->object->toBe('chat.completion.chunk')
+        ->created->toBe(1679432086)
+        ->model->toBe('gpt-4-0314')
+        ->choices->toBeArray()->toHaveCount(1)
+        ->choices->each->toBeInstanceOf(CreateStreamedResponseChoice::class);
+});
+
+test('as array accessible', function () {
+    $completion = CreateStreamedResponse::from(chatCompletionStreamFirstChunk());
+
+    expect($completion['id'])->toBe('chatcmpl-6wdIE4DsUtqf1srdMTsfkJp0VWZgz');
+});
+
+test('to array', function () {
+    $completion = CreateStreamedResponse::from(chatCompletionStreamFirstChunk());
+
+    expect($completion->toArray())
+        ->toBeArray()
+        ->toBe(chatCompletionStreamFirstChunk());
+});
 
 test('fake', function () {
     $response = CreateStreamedResponse::fake();

--- a/tests/Responses/Chat/CreateStreamedResponseDelta.php
+++ b/tests/Responses/Chat/CreateStreamedResponseDelta.php
@@ -1,0 +1,33 @@
+<?php
+
+use OpenAI\Responses\Chat\CreateStreamedResponseDelta;
+
+test('from first chunk', function () {
+    $result = CreateStreamedResponseDelta::from(chatCompletionStreamFirstChunk()['choices'][0]['delta']);
+
+    expect($result)
+        ->role->toBe('assistant')
+        ->content->toBeNull();
+});
+
+test('from content chunk', function () {
+    $result = CreateStreamedResponseDelta::from(chatCompletionStreamContentChunk()['choices'][0]['delta']);
+
+    expect($result)
+        ->role->toBeNull()
+        ->content->toBe('Hello');
+});
+
+test('to array from first chunk', function () {
+    $result = CreateStreamedResponseDelta::from(chatCompletionStreamFirstChunk()['choices'][0]['delta']);
+
+    expect($result->toArray())
+        ->toBe(chatCompletionStreamFirstChunk()['choices'][0]['delta']);
+});
+
+test('to array for a content chunk', function () {
+    $result = CreateStreamedResponseDelta::from(chatCompletionStreamContentChunk()['choices'][0]['delta']);
+
+    expect($result->toArray())
+        ->toBe(chatCompletionStreamContentChunk()['choices'][0]['delta']);
+});

--- a/tests/Responses/FineTunes/ListEventsResponse.php
+++ b/tests/Responses/FineTunes/ListEventsResponse.php
@@ -33,7 +33,7 @@ test('fake', function () {
     expect($response)
         ->object->toBe('list')
         ->and($response['data'][0])
-    ->level->toBe('info');
+        ->level->toBe('info');
 });
 
 test('fake with override', function () {

--- a/tests/Responses/Models/ListResponse.php
+++ b/tests/Responses/Models/ListResponse.php
@@ -31,7 +31,7 @@ test('fake', function () {
     $response = ListResponse::fake();
 
     expect($response)
-    ->object->toBe('list')
+        ->object->toBe('list')
         ->and($response->data[0])
         ->id->toBe('text-babbage:001');
 });

--- a/tests/Responses/Models/RetrieveResponse.php
+++ b/tests/Responses/Models/RetrieveResponse.php
@@ -36,7 +36,7 @@ test('fake', function () {
 
     expect($response)
         ->id->toBe('text-babbage:001')
-    ->and($response->permission[0])
+        ->and($response->permission[0])
         ->allowCreateEngine->toBeFalse();
 });
 


### PR DESCRIPTION
This PR fixes #104

Added some more tests to the chat stream response classes to ensure all the parsing is done properly.