### PR TITLE
[0.5]: unify exception handling

### DIFF
--- a/tests/Arch.php
+++ b/tests/Arch.php
@@ -43,6 +43,7 @@ test('client')->expect('OpenAI\Client')->toOnlyUse([
 
 test('openai')->expect('OpenAI')->toOnlyUse([
     'GuzzleHttp\Client',
+    'GuzzleHttp\Exception\ClientException',
     'Http\Discovery\Psr17Factory',
     'Http\Discovery\Psr18ClientDiscovery',
     'Http\Message\MultipartStream\MultipartStreamBuilder',


### PR DESCRIPTION
This PR unifies the exception handling between the different request types and HTTP client implementations:
- stream requests are now checked for a json response error and throws the corresponding `ErrorException` like object or content requests already do.
- Guzzle `ClientException`s are checked for json errors before throwing the `TransporterException` and throw a `ErrorException` instead.
Background: For client errors (4xx) the API returns a json error but this wasn't handled with the Guzzle Client yet because Guzzle throws an exception instead of returning the response like the other HTTP clients do.

This change from `TransporterException` to `ErrorException` for 4xx responses with the Guzzle Client is a (minor) breaking change!

This resolves https://github.com/openai-php/client/pull/90