### PR TITLE
fix: exception handling for server errors with different content type header - fixes #132

### DIFF
--- a/src/Enums/Transporter/ContentType.php
+++ b/src/Enums/Transporter/ContentType.php
@@ -11,4 +11,5 @@ enum ContentType: string
 {
     case JSON = 'application/json';
     case MULTIPART = 'multipart/form-data';
+    case TEXT_PLAIN = 'text/plain';
 }

--- a/src/Transporters/HttpTransporter.php
+++ b/src/Transporters/HttpTransporter.php
@@ -8,6 +8,7 @@ use Closure;
 use GuzzleHttp\Exception\ClientException;
 use JsonException;
 use OpenAI\Contracts\TransporterContract;
+use OpenAI\Enums\Transporter\ContentType;
 use OpenAI\Exceptions\ErrorException;
 use OpenAI\Exceptions\TransporterException;
 use OpenAI\Exceptions\UnserializableResponse;
@@ -48,7 +49,7 @@ final class HttpTransporter implements TransporterContract
 
         $contents = $response->getBody()->getContents();
 
-        if ($response->getHeader('Content-Type')[0] === 'text/plain; charset=utf-8') {
+        if (str_contains($response->getHeaderLine('Content-Type'), ContentType::TEXT_PLAIN->value)) {
             return $contents;
         }
 
@@ -113,7 +114,7 @@ final class HttpTransporter implements TransporterContract
             return;
         }
 
-        if ($response->getheader('Content-Type')[0] !== 'application/json; charset=utf-8') {
+        if (! str_contains($response->getHeaderLine('Content-Type'), ContentType::JSON->value)) {
             return;
         }
 


### PR DESCRIPTION
This PR fixes exception handling for errors with a. content type header of `application/json` instead of `application/json; charset=utf-8`

fixes #132 