### PR TITLE
allow getting response from StreamResponse object

### DIFF
--- a/src/Responses/StreamResponse.php
+++ b/src/Responses/StreamResponse.php
@@ -69,4 +69,9 @@ final class StreamResponse implements IteratorAggregate
 
         return $buffer;
     }
+
+    public function getResponse(): ResponseInterface
+    {
+        return $this->response;
+    }
 }


### PR DESCRIPTION
It is useful to have access to response object from StreamResponse. In current implementation if API call fails before you actually start iterate over chunks, you haven't any chance to handle this error because you cannot access response code or response body.
This small pull request fixes this problem. 