### PR TITLE
Update CreateResponseFixture.php

### DIFF
--- a/src/Testing/Responses/Fixtures/Chat/CreateResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Chat/CreateResponseFixture.php
@@ -15,6 +15,7 @@ final class CreateResponseFixture
                 'message' => [
                     'role' => 'assistant',
                     'content' => "\n\nHello there, this is a fake chat response.",
+                    'function_call' => null,
                 ],
                 'finish_reason' => 'stop',
             ],


### PR DESCRIPTION
Thanks so much for getting the new function stuff added so quickly! 

Found this minor issue while trying to write some tests using CreateResponse::fake. Without the function_call key in the fixture the content of functionCall in the faked response will always be null.

Tested with:
```php
    $client = new ClientFake([
        CreateResponse::fake([
            'choices' => [
                [
                    'message' => [
                        'function_call' => [
                            'name' => 'get_current_weather',
                            'arguments' => "{\n  \"location\": \"Boston, MA\"\n}",
                        ],
                    ],
                    'finish_reason' => 'function_call'
                ],
            ],
        ]),
    ]);
```