### PR TITLE
Update TranslationResponseSegment.php

### DIFF
--- a/src/Responses/Audio/TranslationResponseSegment.php
+++ b/src/Responses/Audio/TranslationResponseSegment.php
@@ -38,7 +38,7 @@ final class TranslationResponseSegment implements ResponseContract
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{id: int, seek: int, start: float, end: float, text: string, tokens: array<int, int>, temperature: float, avg_logprob: float, compression_ratio: float, no_speech_prob: float, transient: bool}  $attributes
+     * @param  array{id: int, seek: int, start: float, end: float, text: string, tokens: array<int, int>, temperature: float, avg_logprob: float, compression_ratio: float, no_speech_prob: float, transient?: bool}  $attributes
      */
     public static function from(array $attributes): self
     {
@@ -53,7 +53,7 @@ final class TranslationResponseSegment implements ResponseContract
             $attributes['avg_logprob'],
             $attributes['compression_ratio'],
             $attributes['no_speech_prob'],
-            $attributes['transient'],
+            $attributes['transient'] ?? false,
         );
     }
 


### PR DESCRIPTION
Same fix as #160 but for translations instead of transcriptions

See https://github.com/openai-php/client/issues/158

Fixes this exception:
![image](https://github.com/openai-php/client/assets/9074391/144e5e5e-bed7-4261-9d3c-03e3eb64a295)
