### PR TITLE
Fix Lint failures.

### DIFF
--- a/src/Responses/Chat/CreateStreamedResponseDelta.php
+++ b/src/Responses/Chat/CreateStreamedResponseDelta.php
@@ -33,7 +33,7 @@ final class CreateStreamedResponseDelta
         $data = array_filter([
             'role' => $this->role,
             'content' => $this->content,
-        ], fn (string|null $value): bool => ! is_null($value));
+        ], fn (?string $value): bool => ! is_null($value));
 
         if ($this->functionCall instanceof CreateStreamedResponseFunctionCall) {
             $data['content'] = null;

--- a/src/Testing/ClientFake.php
+++ b/src/Testing/ClientFake.php
@@ -41,7 +41,7 @@ class ClientFake implements ClientContract
         $this->responses = [...$this->responses, ...$responses];
     }
 
-    public function assertSent(string $resource, callable|int|null $callback = null): void
+    public function assertSent(string $resource, callable|int $callback = null): void
     {
         if (is_int($callback)) {
             $this->assertSentTimes($resource, $callback);

--- a/src/Testing/Resources/Concerns/Testable.php
+++ b/src/Testing/Resources/Concerns/Testable.php
@@ -18,17 +18,17 @@ trait Testable
     /**
      * @param  array<string, mixed>|string|null  $parameters
      */
-    protected function record(string $method, array|string|null $parameters = null): ResponseContract|StreamResponse|string
+    protected function record(string $method, array|string $parameters = null): ResponseContract|StreamResponse|string
     {
         return $this->fake->record(new TestRequest($this->resource(), $method, $parameters));
     }
 
-    public function assertSent(callable|int|null $callback = null): void
+    public function assertSent(callable|int $callback = null): void
     {
         $this->fake->assertSent($this->resource(), $callback);
     }
 
-    public function assertNotSent(callable|int|null $callback = null): void
+    public function assertNotSent(callable|int $callback = null): void
     {
         $this->fake->assertNotSent($this->resource(), $callback);
     }

--- a/src/Testing/Resources/Concerns/Testable.php
+++ b/src/Testing/Resources/Concerns/Testable.php
@@ -16,7 +16,7 @@ trait Testable
     abstract protected function resource(): string;
 
     /**
-     * @param  array<string, mixed>|string|null  $parameters
+     * @param  array<string, mixed>|string  $parameters
      */
     protected function record(string $method, array|string $parameters = null): ResponseContract|StreamResponse|string
     {


### PR DESCRIPTION
While working #178 - my local suite was failing, as well as main [here](https://github.com/openai-php/client/actions/runs/5593233284/job/15150065665). Personally, outside of my knowledge of why since I assume these tools are versions are locked, but there was no package version change on last merge.

Everything passes locally with `composer test` with this.