### PR TITLE
Fix function call responses from Azure throwing errors

### DIFF
--- a/src/Responses/Chat/CreateResponseMessage.php
+++ b/src/Responses/Chat/CreateResponseMessage.php
@@ -20,7 +20,7 @@ final class CreateResponseMessage
     {
         return new self(
             $attributes['role'],
-            $attributes['content'],
+            $attributes['content'] ?? null,
             isset($attributes['function_call']) ? CreateResponseFunctionCall::from($attributes['function_call']) : null,
         );
     }

--- a/tests/Fixtures/Chat.php
+++ b/tests/Fixtures/Chat.php
@@ -60,6 +60,37 @@ function chatCompletionWithFunction(): array
     ];
 }
 
+/**
+ * @return array<string, mixed>
+ */
+function chatCompletionWithFunctionAndNoContent(): array
+{
+    return [
+        'id' => 'chatcmpl-123',
+        'object' => 'chat.completion',
+        'created' => 1686689333,
+        'model' => 'gpt-3.5-turbo-0613',
+        'choices' => [
+            [
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'function_call' => [
+                        'name' => 'get_current_weather',
+                        'arguments' => "{\n  \"location\": \"Boston, MA\"\n}",
+                    ],
+                ],
+                'finish_reason' => 'function_call',
+            ],
+        ],
+        'usage' => [
+            'prompt_tokens' => 82,
+            'completion_tokens' => 18,
+            'total_tokens' => 100,
+        ],
+    ];
+}
+
 function chatCompletionStreamFirstChunk(): array
 {
     return [

--- a/tests/Responses/Chat/CreateResponse.php
+++ b/tests/Responses/Chat/CreateResponse.php
@@ -32,6 +32,20 @@ test('from function response', function () {
         ->usage->toBeInstanceOf(CreateResponseUsage::class);
 });
 
+test('from function response without content', function () {
+    $completion = CreateResponse::from(chatCompletionWithFunctionAndNoContent());
+
+    expect($completion)
+        ->toBeInstanceOf(CreateResponse::class)
+        ->id->toBe('chatcmpl-123')
+        ->object->toBe('chat.completion')
+        ->created->toBe(1686689333)
+        ->model->toBe('gpt-3.5-turbo-0613')
+        ->choices->toBeArray()->toHaveCount(1)
+        ->choices->each->toBeInstanceOf(CreateResponseChoice::class)
+        ->usage->toBeInstanceOf(CreateResponseUsage::class);
+});
+
 test('as array accessible', function () {
     $completion = CreateResponse::from(chatCompletion());
 


### PR DESCRIPTION
The responses from Azure for gpt-35-turbo-16k don't seem to have the content attribute (with OpenAI it's set to null).

This PR fixes the _ErrorException: Undefined array key "content"_ error.