### PR TITLE
fix: change invalid return type of exception

### DIFF
--- a/src/Exceptions/ErrorException.php
+++ b/src/Exceptions/ErrorException.php
@@ -11,7 +11,7 @@ final class ErrorException extends Exception
     /**
      * Creates a new Exception instance.
      *
-     * @param  array{message: string|array<int, string>, type: ?string, code: ?string}  $contents
+     * @param array{message: string|array<int, string>, type: ?string, code: ?string} $contents
      */
     public function __construct(private readonly array $contents)
     {
@@ -43,7 +43,7 @@ final class ErrorException extends Exception
     /**
      * Returns the error type.
      */
-    public function getErrorCode(): ?string
+    public function getErrorCode(): string|int|null
     {
         return $this->contents['code'];
     }


### PR DESCRIPTION
Fix invalid return type of OpenAI\\Exceptions\\ErrorException::getErrorCode()

Exception:
TypeError
OpenAI\\Exceptions\\ErrorException::getErrorCode(): Return value must be of type ?string, int returned