### PR TITLE
fix: Use method that seeks stream

### DIFF
--- a/src/Transporters/HttpTransporter.php
+++ b/src/Transporters/HttpTransporter.php
@@ -48,7 +48,7 @@ final class HttpTransporter implements TransporterContract
 
         $response = $this->sendRequest(fn (): \Psr\Http\Message\ResponseInterface => $this->client->sendRequest($request));
 
-        $contents = $response->getBody()->getContents();
+        $contents = (string)$response->getBody();
 
         if (str_contains($response->getHeaderLine('Content-Type'), ContentType::TEXT_PLAIN->value)) {
             return Response::from($contents, $response->getHeaders());
@@ -75,7 +75,7 @@ final class HttpTransporter implements TransporterContract
 
         $response = $this->sendRequest(fn (): \Psr\Http\Message\ResponseInterface => $this->client->sendRequest($request));
 
-        $contents = $response->getBody()->getContents();
+        $contents = (string)$response->getBody();
 
         $this->throwIfJsonError($response, $contents);
 
@@ -102,7 +102,7 @@ final class HttpTransporter implements TransporterContract
             return $callable();
         } catch (ClientExceptionInterface $clientException) {
             if ($clientException instanceof ClientException) {
-                $this->throwIfJsonError($clientException->getResponse(), $clientException->getResponse()->getBody()->getContents());
+                $this->throwIfJsonError($clientException->getResponse(), (string)$clientException->getResponse()->getBody());
             }
 
             throw new TransporterException($clientException);


### PR DESCRIPTION
Right now if you are using a guzzle middleware that reads content (or something else that also reads content), you will get empty string when you call getBody()->getContents() and as a consequence a json decode error, because the stream has already been read

Sample code that reads the body before returning the response:
```php  
$stack = HandlerStack::create();

$stack->push(
    Middleware::log(
        $this->logger,
        new MessageFormatter(MessageFormatter::DEBUG)
    )
);

$this->client = (new Factory())->withApiKey($this->apiKey)
    ->withOrganization($this->organization)
    ->withHttpClient(new Client(['handler' => $stack]))
    ->make();
```  

Solution:  
Use StreamInterface::_toString(), because it must attempt to seek to the beginning of the stream