### PR TITLE
Add "has_more" to the fine tuning list responses, add pagination parameters to list jobs request

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,15 @@ foreach ($response->data as $result) {
 $response->toArray(); // ['object' => 'list', 'data' => [...]]
 ```
 
+You can pass additional parameters to the `listJobs` method to narrow down the results.
+
+```php
+$response = $client->fineTuning()->listJobs([
+    'limit' => 3, // Number of jobs to retrieve (Default: 20)
+    'after' => 'ft-AF1WoRqd3aJAHsqc9NY7iL8F', // Identifier for the last job from the previous pagination request.
+]);
+```
+
 #### `retrieve job`
 
 Get info about a fine-tuning job.

--- a/src/Contracts/Resources/FineTuningContract.php
+++ b/src/Contracts/Resources/FineTuningContract.php
@@ -22,9 +22,11 @@ interface FineTuningContract
     /**
      * List your organization's fine-tuning jobs.
      *
-     * @see TODO: There is no official documentation yet
+     * @see https://platform.openai.com/docs/api-reference/fine-tuning/undefined
+     *
+     * @param  array<string, mixed>  $parameters
      */
-    public function listJobs(): ListJobsResponse;
+    public function listJobs(array $parameters = []): ListJobsResponse;
 
     /**
      * Get info about a fine-tuning job.

--- a/src/Resources/FineTuning.php
+++ b/src/Resources/FineTuning.php
@@ -37,13 +37,15 @@ final class FineTuning implements FineTuningContract
     /**
      * List your organization's fine-tuning jobs.
      *
-     * @see TODO: There is no official documentation yet
+     * @see https://platform.openai.com/docs/api-reference/fine-tuning/undefined
+     *
+     * @param  array<string, mixed>  $parameters
      */
-    public function listJobs(): ListJobsResponse
+    public function listJobs(array $parameters = []): ListJobsResponse
     {
-        $payload = Payload::list('fine_tuning/jobs');
+        $payload = Payload::list('fine_tuning/jobs', $parameters);
 
-        /** @var Response<array{object: string, data: array<int, array{id: string, object: string, model: string, created_at: int, finished_at: ?int, fine_tuned_model: ?string, hyperparameters: array{n_epochs: int}, organization_id: string, result_files: array<int, string>, status: string, validation_file: ?string, training_file: string, trained_tokens: ?int}>}> $response */
+        /** @var Response<array{object: string, data: array<int, array{id: string, object: string, model: string, created_at: int, finished_at: ?int, fine_tuned_model: ?string, hyperparameters: array{n_epochs: int}, organization_id: string, result_files: array<int, string>, status: string, validation_file: ?string, training_file: string, trained_tokens: ?int}>, has_more: bool}> $response */
         $response = $this->transporter->requestObject($payload);
 
         return ListJobsResponse::from($response->data(), $response->meta());
@@ -52,7 +54,7 @@ final class FineTuning implements FineTuningContract
     /**
      * Gets info about the fine-tune job.
      *
-     * @see https://platform.openai.com/docs/api-reference/fine-tunes/list
+     * @see https://platform.openai.com/docs/api-reference/fine-tuning/retrieve
      */
     public function retrieveJob(string $jobId): RetrieveJobResponse
     {
@@ -90,7 +92,7 @@ final class FineTuning implements FineTuningContract
     {
         $payload = Payload::retrieve('fine_tuning/jobs', $jobId, '/events', $parameters);
 
-        /** @var Response<array{object: string, data: array<int, array{object: string, id: string, created_at: int, level: string, message: string, data: array{step: int, train_loss: float, train_mean_token_accuracy: float}|null, type: string}>}> $response */
+        /** @var Response<array{object: string, data: array<int, array{object: string, id: string, created_at: int, level: string, message: string, data: array{step: int, train_loss: float, train_mean_token_accuracy: float}|null, type: string}>, has_more: bool}> $response */
         $response = $this->transporter->requestObject($payload);
 
         return ListJobEventsResponse::from($response->data(), $response->meta());

--- a/src/Responses/FineTuning/ListJobEventsResponse.php
+++ b/src/Responses/FineTuning/ListJobEventsResponse.php
@@ -12,12 +12,12 @@ use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
- * @implements ResponseContract<array{object: string, data: array<int, array{object: string, id: string, created_at: int, level: string, message: string, data: array{step: int, train_loss: float, train_mean_token_accuracy: float}|null, type: string}>}>
+ * @implements ResponseContract<array{object: string, data: array<int, array{object: string, id: string, created_at: int, level: string, message: string, data: array{step: int, train_loss: float, train_mean_token_accuracy: float}|null, type: string}>, has_more: bool}>
  */
 final class ListJobEventsResponse implements ResponseContract, ResponseHasMetaInformationContract
 {
     /**
-     * @use ArrayAccessible<array{object: string, data: array<int, array{object: string, id: string, created_at: int, level: string, message: string, data: array{step: int, train_loss: float, train_mean_token_accuracy: float}|null, type: string}>}>
+     * @use ArrayAccessible<array{object: string, data: array<int, array{object: string, id: string, created_at: int, level: string, message: string, data: array{step: int, train_loss: float, train_mean_token_accuracy: float}|null, type: string}>, has_more: bool}>
      */
     use ArrayAccessible;
 
@@ -30,6 +30,7 @@ final class ListJobEventsResponse implements ResponseContract, ResponseHasMetaIn
     private function __construct(
         public readonly string $object,
         public readonly array $data,
+        public readonly bool $hasMore,
         private readonly MetaInformation $meta,
     ) {
     }
@@ -37,7 +38,7 @@ final class ListJobEventsResponse implements ResponseContract, ResponseHasMetaIn
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{object: string, data: array<int, array{object: string, id: string, created_at: int, level: string, message: string, data: array{step: int, train_loss: float, train_mean_token_accuracy: float}|null, type: string}>}  $attributes
+     * @param  array{object: string, data: array<int, array{object: string, id: string, created_at: int, level: string, message: string, data: array{step: int, train_loss: float, train_mean_token_accuracy: float}|null, type: string}>, has_more: bool}  $attributes
      */
     public static function from(array $attributes, MetaInformation $meta): self
     {
@@ -48,6 +49,7 @@ final class ListJobEventsResponse implements ResponseContract, ResponseHasMetaIn
         return new self(
             $attributes['object'],
             $data,
+            $attributes['has_more'],
             $meta,
         );
     }
@@ -63,6 +65,7 @@ final class ListJobEventsResponse implements ResponseContract, ResponseHasMetaIn
                 static fn (ListJobEventsResponseEvent $response): array => $response->toArray(),
                 $this->data,
             ),
+            'has_more' => $this->hasMore,
         ];
     }
 }

--- a/src/Responses/FineTuning/ListJobsResponse.php
+++ b/src/Responses/FineTuning/ListJobsResponse.php
@@ -12,12 +12,12 @@ use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
- * @implements ResponseContract<array{object: string, data: array<int, array{id: string, object: string, model: string, created_at: int, finished_at: ?int, fine_tuned_model: ?string, hyperparameters: array{n_epochs: int}, organization_id: string, result_files: array<int, string>, status: string, validation_file: ?string, training_file: string, trained_tokens: ?int}>}>
+ * @implements ResponseContract<array{object: string, data: array<int, array{id: string, object: string, model: string, created_at: int, finished_at: ?int, fine_tuned_model: ?string, hyperparameters: array{n_epochs: int}, organization_id: string, result_files: array<int, string>, status: string, validation_file: ?string, training_file: string, trained_tokens: ?int}>, has_more: bool}>
  */
 final class ListJobsResponse implements ResponseContract, ResponseHasMetaInformationContract
 {
     /**
-     * @use ArrayAccessible<array{object: string, data: array<int, array{id: string, object: string, model: string, created_at: int, finished_at: ?int, fine_tuned_model: ?string, hyperparameters: array{n_epochs: int}, organization_id: string, result_files: array<int, string>, status: string, validation_file: ?string, training_file: string, trained_tokens: ?int}>}>
+     * @use ArrayAccessible<array{object: string, data: array<int, array{id: string, object: string, model: string, created_at: int, finished_at: ?int, fine_tuned_model: ?string, hyperparameters: array{n_epochs: int}, organization_id: string, result_files: array<int, string>, status: string, validation_file: ?string, training_file: string, trained_tokens: ?int}>, has_more: bool}>
      */
     use ArrayAccessible;
 
@@ -30,6 +30,7 @@ final class ListJobsResponse implements ResponseContract, ResponseHasMetaInforma
     private function __construct(
         public readonly string $object,
         public readonly array $data,
+        public readonly bool $hasMore,
         private readonly MetaInformation $meta,
     ) {
     }
@@ -37,7 +38,7 @@ final class ListJobsResponse implements ResponseContract, ResponseHasMetaInforma
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{object: string, data: array<int, array{id: string, object: string, model: string, created_at: int, finished_at: ?int, fine_tuned_model: ?string, hyperparameters: array{n_epochs: int}, organization_id: string, result_files: array<int, string>, status: string, validation_file: ?string, training_file: string, trained_tokens: ?int}>}  $attributes
+     * @param  array{object: string, data: array<int, array{id: string, object: string, model: string, created_at: int, finished_at: ?int, fine_tuned_model: ?string, hyperparameters: array{n_epochs: int}, organization_id: string, result_files: array<int, string>, status: string, validation_file: ?string, training_file: string, trained_tokens: ?int}>, has_more: bool}  $attributes
      */
     public static function from(array $attributes, MetaInformation $meta): self
     {
@@ -49,6 +50,7 @@ final class ListJobsResponse implements ResponseContract, ResponseHasMetaInforma
         return new self(
             $attributes['object'],
             $data,
+            $attributes['has_more'],
             $meta,
         );
     }
@@ -64,6 +66,7 @@ final class ListJobsResponse implements ResponseContract, ResponseHasMetaInforma
                 static fn (RetrieveJobResponse $response): array => $response->toArray(),
                 $this->data,
             ),
+            'has_more' => $this->hasMore,
         ];
     }
 }

--- a/src/Testing/Resources/FineTuningTestResource.php
+++ b/src/Testing/Resources/FineTuningTestResource.php
@@ -23,7 +23,7 @@ final class FineTuningTestResource implements FineTuningContract
         return $this->record(__FUNCTION__, $parameters);
     }
 
-    public function listJobs(): ListJobsResponse
+    public function listJobs(array $parameters = []): ListJobsResponse
     {
         return $this->record(__FUNCTION__);
     }

--- a/src/Testing/Responses/Fixtures/FineTuning/ListJobEventsResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/FineTuning/ListJobEventsResponseFixture.php
@@ -17,5 +17,6 @@ final class ListJobEventsResponseFixture
                 'type' => 'message',
             ],
         ],
+        'has_more' => false,
     ];
 }

--- a/src/Testing/Responses/Fixtures/FineTuning/ListJobsResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/FineTuning/ListJobsResponseFixture.php
@@ -9,5 +9,6 @@ final class ListJobsResponseFixture
         'data' => [
             RetrieveJobResponseFixture::ATTRIBUTES,
         ],
+        'has_more' => false,
     ];
 }

--- a/src/ValueObjects/Transporter/Payload.php
+++ b/src/ValueObjects/Transporter/Payload.php
@@ -34,14 +34,16 @@ final class Payload
 
     /**
      * Creates a new Payload value object from the given parameters.
+     *
+     * @param  array<string, mixed>  $parameters
      */
-    public static function list(string $resource): self
+    public static function list(string $resource, array $parameters = []): self
     {
         $contentType = ContentType::JSON;
         $method = Method::GET;
         $uri = ResourceUri::list($resource);
 
-        return new self($contentType, $method, $uri);
+        return new self($contentType, $method, $uri, $parameters);
     }
 
     /**

--- a/tests/Fixtures/FineTuning.php
+++ b/tests/Fixtures/FineTuning.php
@@ -61,6 +61,7 @@ function fineTuningJobListResource(): array
             fineTuningJobRetrieveResource(),
             fineTuningJobRetrieveResource(),
         ],
+        'has_more' => false,
     ];
 }
 
@@ -111,5 +112,6 @@ function fineTuningJobListEventsResource(): array
             fineTuningJobMessageEventResource(),
             fineTuningJobMetricsEventResource(),
         ],
+        'has_more' => true,
     ];
 }

--- a/tests/Resources/FineTuning.php
+++ b/tests/Resources/FineTuning.php
@@ -63,6 +63,17 @@ test('list jobs', function () {
         ->toBeInstanceOf(MetaInformation::class);
 });
 
+test('list jobs with params', function () {
+    $client = mockClient('GET', 'fine_tuning/jobs', [], \OpenAI\ValueObjects\Transporter\Response::from(fineTuningJobListResource(), metaHeaders()));
+
+    $result = $client->fineTuning()->listJobs(['limit' => 3]);
+
+    expect($result)
+        ->toBeInstanceOf(ListJobsResponse::class)
+        ->data->toBeArray()->toHaveCount(2)
+        ->data->each->toBeInstanceOf(RetrieveJobResponse::class);
+});
+
 test('retrieve job', function () {
     $client = mockClient('GET', 'fine_tuning/jobs/ft-AF1WoRqd3aJAHsqc9NY7iL8F', [], \OpenAI\ValueObjects\Transporter\Response::from(fineTuningJobRetrieveResource(), metaHeaders()));
 

--- a/tests/Responses/FineTuning/ListJobEventsResponse.php
+++ b/tests/Responses/FineTuning/ListJobEventsResponse.php
@@ -12,6 +12,7 @@ test('from', function () {
         ->object->toBe('list')
         ->data->toBeArray()->toHaveCount(2)
         ->data->each->toBeInstanceOf(ListJobEventsResponseEvent::class)
+        ->hasMore->toBeTrue()
         ->meta()->toBeInstanceOf(MetaInformation::class);
 });
 

--- a/tests/Responses/FineTuning/ListJobsResponse.php
+++ b/tests/Responses/FineTuning/ListJobsResponse.php
@@ -12,6 +12,7 @@ test('from', function () {
         ->object->toBe('list')
         ->data->toBeArray()->toHaveCount(2)
         ->data->each->toBeInstanceOf(RetrieveJobResponse::class)
+        ->hasMore->toBeFalse()
         ->meta()->toBeInstanceOf(MetaInformation::class);
 });
 


### PR DESCRIPTION
This PR adds the missing "has_more" to the fine tuning jobs and events list responses.

Additionally it adds the missing parameters to filter the jobs list.