### PR TITLE
feat: define default model

### DIFF
--- a/src/ValueObjects/Transporter/Payload.php
+++ b/src/ValueObjects/Transporter/Payload.php
@@ -82,6 +82,8 @@ final class Payload
         $contentType = ContentType::JSON;
         $method = Method::POST;
         $uri = ResourceUri::create($resource);
+        
+        $parameters['model'] = $parameters['model'] ?? getenv('OPENAI_MODEL');
 
         return new self($contentType, $method, $uri, $parameters);
     }


### PR DESCRIPTION
Use the specified default model if specified, instead of defining the model on every request