### PR TITLE
fix: handle `x-request-id` in `MetaInformation`

### DIFF
--- a/src/Responses/Meta/MetaInformation.php
+++ b/src/Responses/Meta/MetaInformation.php
@@ -16,7 +16,7 @@ final class MetaInformation implements MetaInformationContract
     use ArrayAccessible;
 
     private function __construct(
-        public string $requestId,
+        public ?string $requestId,
         public readonly MetaInformationOpenAI $openai,
         public readonly ?MetaInformationRateLimit $requestLimit,
         public readonly ?MetaInformationRateLimit $tokenLimit,
@@ -28,7 +28,7 @@ final class MetaInformation implements MetaInformationContract
      */
     public static function from(array $headers): self
     {
-        $requestId = $headers['x-request-id'][0];
+        $requestId = $headers['x-request-id'][0] ?? null;
 
         $openai = MetaInformationOpenAI::from([
             'model' => $headers['openai-model'][0] ?? null,

--- a/tests/Fixtures/Meta.php
+++ b/tests/Fixtures/Meta.php
@@ -28,6 +28,13 @@ function metaHeadersFromAzure(): array
     ];
 }
 
+function metaHeadersWithoutXRequestId(): array
+{
+    $meta = metaHeaders();
+    unset($meta['x-request-id']);
+    return $meta;
+}
+
 function meta(): MetaInformation
 {
     return MetaInformation::from(metaHeaders());

--- a/tests/Responses/Meta/MetaInformation.php
+++ b/tests/Responses/Meta/MetaInformation.php
@@ -95,3 +95,11 @@ test('to array from azure', function () {
             'x-request-id' => '3813fa4fa3f17bdf0d7654f0f49ebab4',
         ]);
 });
+
+test('from response headers without "x-request-id"', function () {
+    $meta = MetaInformation::from(metaHeadersWithoutXRequestId());
+
+    expect($meta)
+        ->toBeInstanceOf(MetaInformation::class)
+        ->requestId->toBeNull();
+});


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Fix handle of the `x-request-id` header when using models that do not return it:
```php
<?php

namespace App\Service;

use OpenAI;

final class Ai
{
    private $client;

    public function __construct()
    {
        $this->client = OpenAI::factory()
            ->withBaseUri('http://localhost:8888/v1')
            ->make();
    }

    public function getModels()
    {
        return $this->client->models()->list();
    }
}

```
![image](https://github.com/openai-php/client/assets/2184564/732ea514-c70c-4162-850d-40c81683d945)

### Related:

#253
