### PR TITLE
Adds RequestHandled event

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     "require-dev": {
         "guzzlehttp/guzzle": "^7.8.0",
         "guzzlehttp/psr7": "^2.6.1",
+        "illuminate/contracts": "^9.0|^10.0",
         "laravel/pint": "^1.13.6",
         "mockery/mockery": "^1.6.6",
         "nunomaduro/collision": "^7.10.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "psr/http-client": "^1.0.3",
         "psr/http-client-implementation": "^1.0.1",
         "psr/http-factory-implementation": "*",
-        "psr/http-message": "^1.1.0|^2.0.0"
+        "psr/http-message": "^1.1.0|^2.0.0",
+        "psr/event-dispatcher": "^1.0.0"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^7.8.0",

--- a/src/Client.php
+++ b/src/Client.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace OpenAI;
 
 use OpenAI\Contracts\ClientContract;
+use OpenAI\Contracts\DispatcherContract;
 use OpenAI\Contracts\Resources\ThreadsContract;
 use OpenAI\Contracts\TransporterContract;
+use OpenAI\Events\Dispatcher;
 use OpenAI\Resources\Assistants;
 use OpenAI\Resources\Audio;
 use OpenAI\Resources\Chat;
@@ -26,7 +28,10 @@ final class Client implements ClientContract
     /**
      * Creates a Client instance with the given API token.
      */
-    public function __construct(private readonly TransporterContract $transporter)
+    public function __construct(
+        private readonly TransporterContract $transporter,
+        private readonly DispatcherContract $events,
+    )
     {
         // ..
     }
@@ -151,7 +156,7 @@ final class Client implements ClientContract
      */
     public function assistants(): Assistants
     {
-        return new Assistants($this->transporter);
+        return new Assistants($this->transporter, $this->events);
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -8,7 +8,6 @@ use OpenAI\Contracts\ClientContract;
 use OpenAI\Contracts\DispatcherContract;
 use OpenAI\Contracts\Resources\ThreadsContract;
 use OpenAI\Contracts\TransporterContract;
-use OpenAI\Events\Dispatcher;
 use OpenAI\Resources\Assistants;
 use OpenAI\Resources\Audio;
 use OpenAI\Resources\Chat;
@@ -31,8 +30,7 @@ final class Client implements ClientContract
     public function __construct(
         private readonly TransporterContract $transporter,
         private readonly DispatcherContract $events,
-    )
-    {
+    ) {
         // ..
     }
 
@@ -44,7 +42,7 @@ final class Client implements ClientContract
      */
     public function completions(): Completions
     {
-        return new Completions($this->transporter);
+        return new Completions($this->transporter, $this->events);
     }
 
     /**
@@ -54,7 +52,7 @@ final class Client implements ClientContract
      */
     public function chat(): Chat
     {
-        return new Chat($this->transporter);
+        return new Chat($this->transporter, $this->events);
     }
 
     /**
@@ -64,7 +62,7 @@ final class Client implements ClientContract
      */
     public function embeddings(): Embeddings
     {
-        return new Embeddings($this->transporter);
+        return new Embeddings($this->transporter, $this->events);
     }
 
     /**
@@ -74,7 +72,7 @@ final class Client implements ClientContract
      */
     public function audio(): Audio
     {
-        return new Audio($this->transporter);
+        return new Audio($this->transporter, $this->events);
     }
 
     /**
@@ -84,7 +82,7 @@ final class Client implements ClientContract
      */
     public function edits(): Edits
     {
-        return new Edits($this->transporter);
+        return new Edits($this->transporter, $this->events);
     }
 
     /**
@@ -94,7 +92,7 @@ final class Client implements ClientContract
      */
     public function files(): Files
     {
-        return new Files($this->transporter);
+        return new Files($this->transporter, $this->events);
     }
 
     /**
@@ -104,7 +102,7 @@ final class Client implements ClientContract
      */
     public function models(): Models
     {
-        return new Models($this->transporter);
+        return new Models($this->transporter, $this->events);
     }
 
     /**
@@ -114,7 +112,7 @@ final class Client implements ClientContract
      */
     public function fineTuning(): FineTuning
     {
-        return new FineTuning($this->transporter);
+        return new FineTuning($this->transporter, $this->events);
     }
 
     /**
@@ -126,7 +124,7 @@ final class Client implements ClientContract
      */
     public function fineTunes(): FineTunes
     {
-        return new FineTunes($this->transporter);
+        return new FineTunes($this->transporter, $this->events);
     }
 
     /**
@@ -136,7 +134,7 @@ final class Client implements ClientContract
      */
     public function moderations(): Moderations
     {
-        return new Moderations($this->transporter);
+        return new Moderations($this->transporter, $this->events);
     }
 
     /**
@@ -146,7 +144,7 @@ final class Client implements ClientContract
      */
     public function images(): Images
     {
-        return new Images($this->transporter);
+        return new Images($this->transporter, $this->events);
     }
 
     /**
@@ -166,6 +164,6 @@ final class Client implements ClientContract
      */
     public function threads(): ThreadsContract
     {
-        return new Threads($this->transporter);
+        return new Threads($this->transporter, $this->events);
     }
 }

--- a/src/Contracts/DispatcherContract.php
+++ b/src/Contracts/DispatcherContract.php
@@ -4,13 +4,6 @@ declare(strict_types=1);
 
 namespace OpenAI\Contracts;
 
-use OpenAI\Exceptions\ErrorException;
-use OpenAI\Exceptions\TransporterException;
-use OpenAI\Exceptions\UnserializableResponse;
-use OpenAI\ValueObjects\Transporter\Payload;
-use OpenAI\ValueObjects\Transporter\Response;
-use Psr\Http\Message\ResponseInterface;
-
 /**
  * @internal
  */

--- a/src/Contracts/DispatcherContract.php
+++ b/src/Contracts/DispatcherContract.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Contracts;
+
+use OpenAI\Exceptions\ErrorException;
+use OpenAI\Exceptions\TransporterException;
+use OpenAI\Exceptions\UnserializableResponse;
+use OpenAI\ValueObjects\Transporter\Payload;
+use OpenAI\ValueObjects\Transporter\Response;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * @internal
+ */
+interface DispatcherContract
+{
+    /**
+     * Dispatch an event.
+     */
+    public function dispatch(object $event): void;
+}

--- a/src/Events/Dispatcher.php
+++ b/src/Events/Dispatcher.php
@@ -10,8 +10,7 @@ class Dispatcher implements DispatcherContract
 {
     public function __construct(
         private readonly LaravelDispatcher|EventDispatcherInterface|null $events
-    )
-    {
+    ) {
     }
 
     public function dispatch(object $event): void

--- a/src/Events/Dispatcher.php
+++ b/src/Events/Dispatcher.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace OpenAI\Events;
+
+use Illuminate\Contracts\Events\Dispatcher as LaravelDispatcher;
+use OpenAI\Contracts\DispatcherContract;
+use Psr\EventDispatcher\EventDispatcherInterface;
+
+class Dispatcher implements DispatcherContract
+{
+    public function __construct(
+        private readonly LaravelDispatcher|EventDispatcherInterface|null $events
+    )
+    {
+    }
+
+    public function dispatch(object $event): void
+    {
+        $this->events?->dispatch($event);
+    }
+}

--- a/src/Events/RequestHandled.php
+++ b/src/Events/RequestHandled.php
@@ -8,10 +8,10 @@ use OpenAI\ValueObjects\Transporter\Payload;
 
 class RequestHandled
 {
+    // @phpstan-ignore-next-line
     public function __construct(
         public readonly Payload $payload,
         public readonly ResponseContract|ResponseStreamContract|string $response,
-    )
-    {
+    ) {
     }
 }

--- a/src/Events/RequestHandled.php
+++ b/src/Events/RequestHandled.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace OpenAI\Events;
+
+use OpenAI\Contracts\ResponseContract;
+use OpenAI\Contracts\ResponseStreamContract;
+use OpenAI\ValueObjects\Transporter\Payload;
+
+class RequestHandled
+{
+    public function __construct(
+        public readonly Payload $payload,
+        public readonly ResponseContract|ResponseStreamContract|string $response,
+    )
+    {
+    }
+}

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -57,7 +57,7 @@ final class Factory
 
     private ?Closure $streamHandler = null;
 
-    private Dispatcher|EventDispatcherInterface|null $events = null;
+    private LaravelDispatcher|EventDispatcherInterface|null $events = null;
 
     /**
      * Sets the API key for the requests.

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -133,8 +133,6 @@ final class Factory
 
     /**
      * Set the event dispatcher instance.
-     *
-     * @param LaravelDispatcher|EventDispatcherInterface $events
      */
     public function withEventDispatcher(LaravelDispatcher|EventDispatcherInterface $events): self
     {

--- a/src/Resources/Assistants.php
+++ b/src/Resources/Assistants.php
@@ -28,10 +28,10 @@ final class Assistants implements AssistantsContract
     {
         $payload = Payload::create('assistants', $parameters);
 
-        /** @var Response<array{id: string, object: string, created_at: int, name: ?string, description: ?string, model: string, instructions: ?string, tools: array<int, array{type: 'code_interpreter'}|array{type: 'retrieval'}|array{type: 'function', function: array{description: string, name: string, parameters: array<string, mixed>}}>, file_ids: array<int, string>, metadata: array<string, string>}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, created_at: int, name: ?string, description: ?string, model: string, instructions: ?string, tools: array<int, array{type: 'code_interpreter'}|array{type: 'retrieval'}|array{type: 'function', function: array{description: string, name: string, parameters: array<string, mixed>}}>, file_ids: array<int, string>, metadata: array<string, string>}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        $response = AssistantResponse::from($response->data(), $response->meta());
+        $response = AssistantResponse::from($responseRaw->data(), $responseRaw->meta());
 
         $this->event(new RequestHandled($payload, $response));
 
@@ -47,10 +47,14 @@ final class Assistants implements AssistantsContract
     {
         $payload = Payload::retrieve('assistants', $id);
 
-        /** @var Response<array{id: string, object: string, created_at: int, name: ?string, description: ?string, model: string, instructions: ?string, tools: array<int, array{type: 'code_interpreter'}|array{type: 'retrieval'}|array{type: 'function', function: array{description: string, name: string, parameters: array<string, mixed>}}>, file_ids: array<int, string>, metadata: array<string, string>}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, created_at: int, name: ?string, description: ?string, model: string, instructions: ?string, tools: array<int, array{type: 'code_interpreter'}|array{type: 'retrieval'}|array{type: 'function', function: array{description: string, name: string, parameters: array<string, mixed>}}>, file_ids: array<int, string>, metadata: array<string, string>}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return AssistantResponse::from($response->data(), $response->meta());
+        $response = AssistantResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -64,10 +68,14 @@ final class Assistants implements AssistantsContract
     {
         $payload = Payload::modify('assistants', $id, $parameters);
 
-        /** @var Response<array{id: string, object: string, created_at: int, name: ?string, description: ?string, model: string, instructions: ?string, tools: array<int, array{type: 'code_interpreter'}|array{type: 'retrieval'}|array{type: 'function', function: array{description: string, name: string, parameters: array<string, mixed>}}>, file_ids: array<int, string>, metadata: array<string, string>}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, created_at: int, name: ?string, description: ?string, model: string, instructions: ?string, tools: array<int, array{type: 'code_interpreter'}|array{type: 'retrieval'}|array{type: 'function', function: array{description: string, name: string, parameters: array<string, mixed>}}>, file_ids: array<int, string>, metadata: array<string, string>}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return AssistantResponse::from($response->data(), $response->meta());
+        $response = AssistantResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -79,10 +87,14 @@ final class Assistants implements AssistantsContract
     {
         $payload = Payload::delete('assistants', $id);
 
-        /** @var Response<array{id: string, object: string, deleted: bool}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, deleted: bool}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return AssistantDeleteResponse::from($response->data(), $response->meta());
+        $response = AssistantDeleteResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -96,10 +108,14 @@ final class Assistants implements AssistantsContract
     {
         $payload = Payload::list('assistants', $parameters);
 
-        /** @var Response<array{object: string, data: array<int, array{id: string, object: string, created_at: int, name: ?string, description: ?string, model: string, instructions: ?string, tools: array<int, array{type: 'code_interpreter'}|array{type: 'retrieval'}|array{type: 'function', function: array{description: string, name: string, parameters: array<string, mixed>}}>, file_ids: array<int, string>, metadata: array<string, string>}>, first_id: ?string, last_id: ?string, has_more: bool}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{object: string, data: array<int, array{id: string, object: string, created_at: int, name: ?string, description: ?string, model: string, instructions: ?string, tools: array<int, array{type: 'code_interpreter'}|array{type: 'retrieval'}|array{type: 'function', function: array{description: string, name: string, parameters: array<string, mixed>}}>, file_ids: array<int, string>, metadata: array<string, string>}>, first_id: ?string, last_id: ?string, has_more: bool}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return AssistantListResponse::from($response->data(), $response->meta());
+        $response = AssistantListResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -109,6 +125,6 @@ final class Assistants implements AssistantsContract
      */
     public function files(): AssistantsFilesContract
     {
-        return new AssistantsFiles($this->transporter);
+        return new AssistantsFiles($this->transporter, $this->events);
     }
 }

--- a/src/Resources/Assistants.php
+++ b/src/Resources/Assistants.php
@@ -6,6 +6,7 @@ namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\AssistantsContract;
 use OpenAI\Contracts\Resources\AssistantsFilesContract;
+use OpenAI\Events\RequestHandled;
 use OpenAI\Responses\Assistants\AssistantDeleteResponse;
 use OpenAI\Responses\Assistants\AssistantListResponse;
 use OpenAI\Responses\Assistants\AssistantResponse;
@@ -30,7 +31,11 @@ final class Assistants implements AssistantsContract
         /** @var Response<array{id: string, object: string, created_at: int, name: ?string, description: ?string, model: string, instructions: ?string, tools: array<int, array{type: 'code_interpreter'}|array{type: 'retrieval'}|array{type: 'function', function: array{description: string, name: string, parameters: array<string, mixed>}}>, file_ids: array<int, string>, metadata: array<string, string>}> $response */
         $response = $this->transporter->requestObject($payload);
 
-        return AssistantResponse::from($response->data(), $response->meta());
+        $response = AssistantResponse::from($response->data(), $response->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**

--- a/src/Resources/AssistantsFiles.php
+++ b/src/Resources/AssistantsFiles.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\AssistantsFilesContract;
+use OpenAI\Events\RequestHandled;
 use OpenAI\Responses\Assistants\Files\AssistantFileDeleteResponse;
 use OpenAI\Responses\Assistants\Files\AssistantFileListResponse;
 use OpenAI\Responses\Assistants\Files\AssistantFileResponse;
@@ -26,10 +27,14 @@ final class AssistantsFiles implements AssistantsFilesContract
     {
         $payload = Payload::create("assistants/$assistantId/files", $parameters);
 
-        /** @var Response<array{id: string, object: string, created_at: int, assistant_id: string}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, created_at: int, assistant_id: string}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return AssistantFileResponse::from($response->data(), $response->meta());
+        $response = AssistantFileResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -41,10 +46,14 @@ final class AssistantsFiles implements AssistantsFilesContract
     {
         $payload = Payload::retrieve("assistants/$assistantId/files", $fileId);
 
-        /** @var Response<array{id: string, object: string, created_at: int, assistant_id: string}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, created_at: int, assistant_id: string}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return AssistantFileResponse::from($response->data(), $response->meta());
+        $response = AssistantFileResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -56,10 +65,14 @@ final class AssistantsFiles implements AssistantsFilesContract
     {
         $payload = Payload::delete("assistants/$assistantId/files", $fileId);
 
-        /** @var Response<array{id: string, object: string, deleted: bool}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, deleted: bool}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return AssistantFileDeleteResponse::from($response->data(), $response->meta());
+        $response = AssistantFileDeleteResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -73,9 +86,13 @@ final class AssistantsFiles implements AssistantsFilesContract
     {
         $payload = Payload::list("assistants/$assistantId/files", $parameters);
 
-        /** @var Response<array{object: string, data: array<int, array{id: string, object: string, created_at: int, assistant_id: string}>, first_id: ?string, last_id: ?string, has_more: bool}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{object: string, data: array<int, array{id: string, object: string, created_at: int, assistant_id: string}>, first_id: ?string, last_id: ?string, has_more: bool}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return AssistantFileListResponse::from($response->data(), $response->meta());
+        $response = AssistantFileListResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 }

--- a/src/Resources/Audio.php
+++ b/src/Resources/Audio.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\AudioContract;
+use OpenAI\Events\RequestHandled;
 use OpenAI\Responses\Audio\SpeechStreamResponse;
 use OpenAI\Responses\Audio\TranscriptionResponse;
 use OpenAI\Responses\Audio\TranslationResponse;
@@ -26,7 +27,11 @@ final class Audio implements AudioContract
     {
         $payload = Payload::create('audio/speech', $parameters);
 
-        return $this->transporter->requestContent($payload);
+        $response = $this->transporter->requestContent($payload);
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -40,9 +45,13 @@ final class Audio implements AudioContract
     {
         $payload = Payload::create('audio/speech', $parameters);
 
-        $response = $this->transporter->requestStream($payload);
+        $responseRaw = $this->transporter->requestStream($payload);
 
-        return new SpeechStreamResponse($response);
+        $response = new SpeechStreamResponse($responseRaw);
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -56,10 +65,14 @@ final class Audio implements AudioContract
     {
         $payload = Payload::upload('audio/transcriptions', $parameters);
 
-        /** @var Response<array{task: ?string, language: ?string, duration: ?float, segments: array<int, array{id: int, seek: int, start: float, end: float, text: string, tokens: array<int, int>, temperature: float, avg_logprob: float, compression_ratio: float, no_speech_prob: float, transient?: bool}>, text: string}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{task: ?string, language: ?string, duration: ?float, segments: array<int, array{id: int, seek: int, start: float, end: float, text: string, tokens: array<int, int>, temperature: float, avg_logprob: float, compression_ratio: float, no_speech_prob: float, transient?: bool}>, text: string}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return TranscriptionResponse::from($response->data(), $response->meta());
+        $response = TranscriptionResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -73,9 +86,13 @@ final class Audio implements AudioContract
     {
         $payload = Payload::upload('audio/translations', $parameters);
 
-        /** @var Response<array{task: ?string, language: ?string, duration: ?float, segments: array<int, array{id: int, seek: int, start: float, end: float, text: string, tokens: array<int, int>, temperature: float, avg_logprob: float, compression_ratio: float, no_speech_prob: float, transient?: bool}>, text: string}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{task: ?string, language: ?string, duration: ?float, segments: array<int, array{id: int, seek: int, start: float, end: float, text: string, tokens: array<int, int>, temperature: float, avg_logprob: float, compression_ratio: float, no_speech_prob: float, transient?: bool}>, text: string}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return TranslationResponse::from($response->data(), $response->meta());
+        $response = TranslationResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 }

--- a/src/Resources/Concerns/Transportable.php
+++ b/src/Resources/Concerns/Transportable.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenAI\Resources\Concerns;
 
+use OpenAI\Contracts\DispatcherContract;
 use OpenAI\Contracts\TransporterContract;
 
 trait Transportable
@@ -11,8 +12,16 @@ trait Transportable
     /**
      * Creates a Client instance with the given API token.
      */
-    public function __construct(private readonly TransporterContract $transporter)
+    public function __construct(
+        private readonly TransporterContract $transporter,
+        private readonly DispatcherContract $events,
+    )
     {
         // ..
+    }
+
+    public function event(object $event): void
+    {
+        $this->events->dispatch($event);
     }
 }

--- a/src/Resources/Concerns/Transportable.php
+++ b/src/Resources/Concerns/Transportable.php
@@ -15,8 +15,7 @@ trait Transportable
     public function __construct(
         private readonly TransporterContract $transporter,
         private readonly DispatcherContract $events,
-    )
-    {
+    ) {
         // ..
     }
 

--- a/src/Resources/Edits.php
+++ b/src/Resources/Edits.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\EditsContract;
+use OpenAI\Events\RequestHandled;
 use OpenAI\Responses\Edits\CreateResponse;
 use OpenAI\ValueObjects\Transporter\Payload;
 use OpenAI\ValueObjects\Transporter\Response;
@@ -27,9 +28,13 @@ final class Edits implements EditsContract
     {
         $payload = Payload::create('edits', $parameters);
 
-        /** @var Response<array{object: string, created: int, choices: array<int, array{text: string, index: int}>, usage: array{prompt_tokens: int, completion_tokens: int, total_tokens: int}}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{object: string, created: int, choices: array<int, array{text: string, index: int}>, usage: array{prompt_tokens: int, completion_tokens: int, total_tokens: int}}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return CreateResponse::from($response->data(), $response->meta());
+        $response = CreateResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 }

--- a/src/Resources/Files.php
+++ b/src/Resources/Files.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\FilesContract;
+use OpenAI\Events\RequestHandled;
 use OpenAI\Responses\Files\CreateResponse;
 use OpenAI\Responses\Files\DeleteResponse;
 use OpenAI\Responses\Files\ListResponse;
@@ -25,10 +26,14 @@ final class Files implements FilesContract
     {
         $payload = Payload::list('files');
 
-        /** @var Response<array{object: string, data: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{object: string, data: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return ListResponse::from($response->data(), $response->meta());
+        $response = ListResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -40,10 +45,14 @@ final class Files implements FilesContract
     {
         $payload = Payload::retrieve('files', $file);
 
-        /** @var Response<array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return RetrieveResponse::from($response->data(), $response->meta());
+        $response = RetrieveResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -55,7 +64,11 @@ final class Files implements FilesContract
     {
         $payload = Payload::retrieveContent('files', $file);
 
-        return $this->transporter->requestContent($payload);
+        $response = $this->transporter->requestContent($payload);
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -69,10 +82,14 @@ final class Files implements FilesContract
     {
         $payload = Payload::upload('files', $parameters);
 
-        /** @var Response<array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return CreateResponse::from($response->data(), $response->meta());
+        $response = CreateResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -84,9 +101,13 @@ final class Files implements FilesContract
     {
         $payload = Payload::delete('files', $file);
 
-        /** @var Response<array{id: string, object: string, deleted: bool}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, deleted: bool}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return DeleteResponse::from($response->data(), $response->meta());
+        $response = DeleteResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 }

--- a/src/Resources/FineTunes.php
+++ b/src/Resources/FineTunes.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\FineTunesContract;
+use OpenAI\Events\RequestHandled;
 use OpenAI\Responses\FineTunes\ListEventsResponse;
 use OpenAI\Responses\FineTunes\ListResponse;
 use OpenAI\Responses\FineTunes\RetrieveResponse;
@@ -30,10 +31,14 @@ final class FineTunes implements FineTunesContract
     {
         $payload = Payload::create('fine-tunes', $parameters);
 
-        /** @var Response<array{id: string, object: string, model: string, created_at: int, events: array<int, array{object: string, created_at: int, level: string, message: string}>, fine_tuned_model: ?string, hyperparams: array{batch_size: ?int, learning_rate_multiplier: ?float, n_epochs: int, prompt_loss_weight: float}, organization_id: string, result_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, status: string, validation_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, training_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, updated_at: int}>  $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, model: string, created_at: int, events: array<int, array{object: string, created_at: int, level: string, message: string}>, fine_tuned_model: ?string, hyperparams: array{batch_size: ?int, learning_rate_multiplier: ?float, n_epochs: int, prompt_loss_weight: float}, organization_id: string, result_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, status: string, validation_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, training_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, updated_at: int}>  $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return RetrieveResponse::from($response->data(), $response->meta());
+        $response = RetrieveResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -45,10 +50,14 @@ final class FineTunes implements FineTunesContract
     {
         $payload = Payload::list('fine-tunes');
 
-        /** @var Response<array{object: string, data: array<int, array{id: string, object: string, model: string, created_at: int, events: array<int, array{object: string, created_at: int, level: string, message: string}>, fine_tuned_model: ?string, hyperparams: array{batch_size: ?int, learning_rate_multiplier: ?float, n_epochs: int, prompt_loss_weight: float}, organization_id: string, result_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, status: string, validation_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, training_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, updated_at: int}>}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{object: string, data: array<int, array{id: string, object: string, model: string, created_at: int, events: array<int, array{object: string, created_at: int, level: string, message: string}>, fine_tuned_model: ?string, hyperparams: array{batch_size: ?int, learning_rate_multiplier: ?float, n_epochs: int, prompt_loss_weight: float}, organization_id: string, result_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, status: string, validation_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, training_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, updated_at: int}>}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return ListResponse::from($response->data(), $response->meta());
+        $response = ListResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -60,10 +69,14 @@ final class FineTunes implements FineTunesContract
     {
         $payload = Payload::retrieve('fine-tunes', $fineTuneId);
 
-        /** @var Response<array{id: string, object: string, model: string, created_at: int, events: array<int, array{object: string, created_at: int, level: string, message: string}>, fine_tuned_model: ?string, hyperparams: array{batch_size: ?int, learning_rate_multiplier: ?float, n_epochs: int, prompt_loss_weight: float}, organization_id: string, result_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, status: string, validation_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, training_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, updated_at: int}>  $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, model: string, created_at: int, events: array<int, array{object: string, created_at: int, level: string, message: string}>, fine_tuned_model: ?string, hyperparams: array{batch_size: ?int, learning_rate_multiplier: ?float, n_epochs: int, prompt_loss_weight: float}, organization_id: string, result_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, status: string, validation_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, training_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, updated_at: int}>  $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return RetrieveResponse::from($response->data(), $response->meta());
+        $response = RetrieveResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -75,10 +88,14 @@ final class FineTunes implements FineTunesContract
     {
         $payload = Payload::cancel('fine-tunes', $fineTuneId);
 
-        /** @var Response<array{id: string, object: string, model: string, created_at: int, events: array<int, array{object: string, created_at: int, level: string, message: string}>, fine_tuned_model: ?string, hyperparams: array{batch_size: ?int, learning_rate_multiplier: ?float, n_epochs: int, prompt_loss_weight: float}, organization_id: string, result_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, status: string, validation_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, training_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, updated_at: int}>  $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, model: string, created_at: int, events: array<int, array{object: string, created_at: int, level: string, message: string}>, fine_tuned_model: ?string, hyperparams: array{batch_size: ?int, learning_rate_multiplier: ?float, n_epochs: int, prompt_loss_weight: float}, organization_id: string, result_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, status: string, validation_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, training_files: array<int, array{id: string, object: string, created_at: int, bytes: int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>, updated_at: int}>  $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return RetrieveResponse::from($response->data(), $response->meta());
+        $response = RetrieveResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -90,10 +107,14 @@ final class FineTunes implements FineTunesContract
     {
         $payload = Payload::retrieve('fine-tunes', $fineTuneId, '/events');
 
-        /** @var Response<array{object: string, data: array<int, array{object: string, created_at: int, level: string, message: string}>}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{object: string, data: array<int, array{object: string, created_at: int, level: string, message: string}>}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return ListEventsResponse::from($response->data(), $response->meta());
+        $response = ListEventsResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -107,8 +128,12 @@ final class FineTunes implements FineTunesContract
     {
         $payload = Payload::retrieve('fine-tunes', $fineTuneId, '/events?stream=true');
 
-        $response = $this->transporter->requestStream($payload);
+        $responseRaw = $this->transporter->requestStream($payload);
 
-        return new StreamResponse(RetrieveStreamedResponseEvent::class, $response);
+        $response = new StreamResponse(RetrieveStreamedResponseEvent::class, $responseRaw);
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 }

--- a/src/Resources/FineTuning.php
+++ b/src/Resources/FineTuning.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\FineTuningContract;
+use OpenAI\Events\RequestHandled;
 use OpenAI\Responses\FineTuning\ListJobEventsResponse;
 use OpenAI\Responses\FineTuning\ListJobsResponse;
 use OpenAI\Responses\FineTuning\RetrieveJobResponse;
@@ -28,10 +29,14 @@ final class FineTuning implements FineTuningContract
     {
         $payload = Payload::create('fine_tuning/jobs', $parameters);
 
-        /** @var Response<array{id: string, object: string, model: string, created_at: int, finished_at: ?int, fine_tuned_model: ?string, hyperparameters: array{n_epochs: int|string, batch_size: int|string|null, learning_rate_multiplier: float|string|null}, organization_id: string, result_files: array<int, string>, status: string, validation_file: ?string, training_file: string, trained_tokens: ?int, error: ?array{code: string, param: ?string, message: string}}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, model: string, created_at: int, finished_at: ?int, fine_tuned_model: ?string, hyperparameters: array{n_epochs: int|string, batch_size: int|string|null, learning_rate_multiplier: float|string|null}, organization_id: string, result_files: array<int, string>, status: string, validation_file: ?string, training_file: string, trained_tokens: ?int, error: ?array{code: string, param: ?string, message: string}}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return RetrieveJobResponse::from($response->data(), $response->meta());
+        $response = RetrieveJobResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -45,10 +50,14 @@ final class FineTuning implements FineTuningContract
     {
         $payload = Payload::list('fine_tuning/jobs', $parameters);
 
-        /** @var Response<array{object: string, data: array<int, array{id: string, object: string, model: string, created_at: int, finished_at: ?int, fine_tuned_model: ?string, hyperparameters: array{n_epochs: int|string, batch_size: int|string|null, learning_rate_multiplier: float|string|null}, organization_id: string, result_files: array<int, string>, status: string, validation_file: ?string, training_file: string, trained_tokens: ?int, error: ?array{code: string, param: ?string, message: string}}>, has_more: bool}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{object: string, data: array<int, array{id: string, object: string, model: string, created_at: int, finished_at: ?int, fine_tuned_model: ?string, hyperparameters: array{n_epochs: int|string, batch_size: int|string|null, learning_rate_multiplier: float|string|null}, organization_id: string, result_files: array<int, string>, status: string, validation_file: ?string, training_file: string, trained_tokens: ?int, error: ?array{code: string, param: ?string, message: string}}>, has_more: bool}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return ListJobsResponse::from($response->data(), $response->meta());
+        $response = ListJobsResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -60,10 +69,14 @@ final class FineTuning implements FineTuningContract
     {
         $payload = Payload::retrieve('fine_tuning/jobs', $jobId);
 
-        /** @var Response<array{id: string, object: string, model: string, created_at: int, finished_at: ?int, fine_tuned_model: ?string, hyperparameters: array{n_epochs: int|string, batch_size: int|string|null, learning_rate_multiplier: float|string|null}, organization_id: string, result_files: array<int, string>, status: string, validation_file: ?string, training_file: string, trained_tokens: ?int, error: ?array{code: string, param: ?string, message: string}}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, model: string, created_at: int, finished_at: ?int, fine_tuned_model: ?string, hyperparameters: array{n_epochs: int|string, batch_size: int|string|null, learning_rate_multiplier: float|string|null}, organization_id: string, result_files: array<int, string>, status: string, validation_file: ?string, training_file: string, trained_tokens: ?int, error: ?array{code: string, param: ?string, message: string}}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return RetrieveJobResponse::from($response->data(), $response->meta());
+        $response = RetrieveJobResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -75,10 +88,14 @@ final class FineTuning implements FineTuningContract
     {
         $payload = Payload::cancel('fine_tuning/jobs', $jobId);
 
-        /** @var Response<array{id: string, object: string, model: string, created_at: int, finished_at: ?int, fine_tuned_model: ?string, hyperparameters: array{n_epochs: int|string, batch_size: int|string|null, learning_rate_multiplier: float|string|null}, organization_id: string, result_files: array<int, string>, status: string, validation_file: ?string, training_file: string, trained_tokens: ?int, error: ?array{code: string, param: ?string, message: string}}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, model: string, created_at: int, finished_at: ?int, fine_tuned_model: ?string, hyperparameters: array{n_epochs: int|string, batch_size: int|string|null, learning_rate_multiplier: float|string|null}, organization_id: string, result_files: array<int, string>, status: string, validation_file: ?string, training_file: string, trained_tokens: ?int, error: ?array{code: string, param: ?string, message: string}}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return RetrieveJobResponse::from($response->data(), $response->meta());
+        $response = RetrieveJobResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -92,9 +109,13 @@ final class FineTuning implements FineTuningContract
     {
         $payload = Payload::retrieve('fine_tuning/jobs', $jobId, '/events', $parameters);
 
-        /** @var Response<array{object: string, data: array<int, array{object: string, id: string, created_at: int, level: string, message: string, data: array{step: int, train_loss: float, train_mean_token_accuracy: float}|null, type: string}>, has_more: bool}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{object: string, data: array<int, array{object: string, id: string, created_at: int, level: string, message: string, data: array{step: int, train_loss: float, train_mean_token_accuracy: float}|null, type: string}>, has_more: bool}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return ListJobEventsResponse::from($response->data(), $response->meta());
+        $response = ListJobEventsResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 }

--- a/src/Resources/Images.php
+++ b/src/Resources/Images.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\ImagesContract;
+use OpenAI\Events\RequestHandled;
 use OpenAI\Responses\Images\CreateResponse;
 use OpenAI\Responses\Images\EditResponse;
 use OpenAI\Responses\Images\VariationResponse;
@@ -26,10 +27,14 @@ final class Images implements ImagesContract
     {
         $payload = Payload::create('images/generations', $parameters);
 
-        /** @var Response<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return CreateResponse::from($response->data(), $response->meta());
+        $response = CreateResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -43,10 +48,14 @@ final class Images implements ImagesContract
     {
         $payload = Payload::upload('images/edits', $parameters);
 
-        /** @var Response<array{created: int, data: array<int, array{url?: string, b64_json?: string}>}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{created: int, data: array<int, array{url?: string, b64_json?: string}>}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return EditResponse::from($response->data(), $response->meta());
+        $response = EditResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -60,9 +69,13 @@ final class Images implements ImagesContract
     {
         $payload = Payload::upload('images/variations', $parameters);
 
-        /** @var Response<array{created: int, data: array<int, array{url?: string, b64_json?: string}>}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{created: int, data: array<int, array{url?: string, b64_json?: string}>}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return VariationResponse::from($response->data(), $response->meta());
+        $response = VariationResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 }

--- a/src/Resources/Models.php
+++ b/src/Resources/Models.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\ModelsContract;
+use OpenAI\Events\RequestHandled;
 use OpenAI\Responses\Models\DeleteResponse;
 use OpenAI\Responses\Models\ListResponse;
 use OpenAI\Responses\Models\RetrieveResponse;
@@ -24,10 +25,14 @@ final class Models implements ModelsContract
     {
         $payload = Payload::list('models');
 
-        /** @var Response<array{object: string, data: array<int, array{id: string, object: string, created: int, owned_by: string}>}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{object: string, data: array<int, array{id: string, object: string, created: int, owned_by: string}>}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return ListResponse::from($response->data(), $response->meta());
+        $response = ListResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -39,10 +44,14 @@ final class Models implements ModelsContract
     {
         $payload = Payload::retrieve('models', $model);
 
-        /** @var Response<array{id: string, object: string, created: int, owned_by: string}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, created: int, owned_by: string}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return RetrieveResponse::from($response->data(), $response->meta());
+        $response = RetrieveResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -54,9 +63,13 @@ final class Models implements ModelsContract
     {
         $payload = Payload::delete('models', $model);
 
-        /** @var Response<array{id: string, object: string, deleted: bool}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, deleted: bool}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return DeleteResponse::from($response->data(), $response->meta());
+        $response = DeleteResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 }

--- a/src/Resources/Moderations.php
+++ b/src/Resources/Moderations.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\ModerationsContract;
+use OpenAI\Events\RequestHandled;
 use OpenAI\Responses\Moderations\CreateResponse;
 use OpenAI\ValueObjects\Transporter\Payload;
 use OpenAI\ValueObjects\Transporter\Response;
@@ -24,9 +25,13 @@ final class Moderations implements ModerationsContract
     {
         $payload = Payload::create('moderations', $parameters);
 
-        /** @var Response<array{id: string, model: string, results: array<int, array{categories: array<string, bool>, category_scores: array<string, float>, flagged: bool}>}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, model: string, results: array<int, array{categories: array<string, bool>, category_scores: array<string, float>, flagged: bool}>}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return CreateResponse::from($response->data(), $response->meta());
+        $response = CreateResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 }

--- a/src/Resources/Threads.php
+++ b/src/Resources/Threads.php
@@ -7,6 +7,7 @@ namespace OpenAI\Resources;
 use OpenAI\Contracts\Resources\ThreadsContract;
 use OpenAI\Contracts\Resources\ThreadsMessagesContract;
 use OpenAI\Contracts\Resources\ThreadsRunsContract;
+use OpenAI\Events\RequestHandled;
 use OpenAI\Responses\Threads\Runs\ThreadRunResponse;
 use OpenAI\Responses\Threads\ThreadDeleteResponse;
 use OpenAI\Responses\Threads\ThreadResponse;
@@ -28,10 +29,14 @@ final class Threads implements ThreadsContract
     {
         $payload = Payload::create('threads', $parameters);
 
-        /** @var Response<array{id: string, object: string, created_at: int, metadata: array<string, string>}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, created_at: int, metadata: array<string, string>}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return ThreadResponse::from($response->data(), $response->meta());
+        $response = ThreadResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -45,10 +50,14 @@ final class Threads implements ThreadsContract
     {
         $payload = Payload::create('threads/runs', $parameters);
 
-        /** @var Response<array{id: string, object: string, created_at: int, thread_id: string, assistant_id: string, status: string, required_action?: array{type: string, submit_tool_outputs: array{tool_calls: array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}}, last_error: ?array{code: string, message: string}, expires_at: ?int, started_at: ?int, cancelled_at: ?int, failed_at: ?int, completed_at: ?int, model: string, instructions: ?string, tools: array<int, array{type: 'code_interpreter'}|array{type: 'retrieval'}|array{type: 'function', function: array{description: string, name: string, parameters: array<string, mixed>}}>, file_ids: array<int, string>, metadata: array<string, string>}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, created_at: int, thread_id: string, assistant_id: string, status: string, required_action?: array{type: string, submit_tool_outputs: array{tool_calls: array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}}, last_error: ?array{code: string, message: string}, expires_at: ?int, started_at: ?int, cancelled_at: ?int, failed_at: ?int, completed_at: ?int, model: string, instructions: ?string, tools: array<int, array{type: 'code_interpreter'}|array{type: 'retrieval'}|array{type: 'function', function: array{description: string, name: string, parameters: array<string, mixed>}}>, file_ids: array<int, string>, metadata: array<string, string>}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return ThreadRunResponse::from($response->data(), $response->meta());
+        $response = ThreadRunResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -60,10 +69,14 @@ final class Threads implements ThreadsContract
     {
         $payload = Payload::retrieve('threads', $id);
 
-        /** @var Response<array{id: string, object: string, created_at: int, metadata: array<string, string>}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, created_at: int, metadata: array<string, string>}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return ThreadResponse::from($response->data(), $response->meta());
+        $response = ThreadResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -77,10 +90,14 @@ final class Threads implements ThreadsContract
     {
         $payload = Payload::modify('threads', $id, $parameters);
 
-        /** @var Response<array{id: string, object: string, created_at: int, metadata: array<string, string>}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, created_at: int, metadata: array<string, string>}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return ThreadResponse::from($response->data(), $response->meta());
+        $response = ThreadResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -92,10 +109,14 @@ final class Threads implements ThreadsContract
     {
         $payload = Payload::delete('threads', $id);
 
-        /** @var Response<array{id: string, object: string, deleted: bool}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, deleted: bool}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return ThreadDeleteResponse::from($response->data(), $response->meta());
+        $response = ThreadDeleteResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -105,7 +126,7 @@ final class Threads implements ThreadsContract
      */
     public function messages(): ThreadsMessagesContract
     {
-        return new ThreadsMessages($this->transporter);
+        return new ThreadsMessages($this->transporter, $this->events);
     }
 
     /**
@@ -115,6 +136,6 @@ final class Threads implements ThreadsContract
      */
     public function runs(): ThreadsRunsContract
     {
-        return new ThreadsRuns($this->transporter);
+        return new ThreadsRuns($this->transporter, $this->events);
     }
 }

--- a/src/Resources/ThreadsMessages.php
+++ b/src/Resources/ThreadsMessages.php
@@ -6,6 +6,7 @@ namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\ThreadsMessagesContract;
 use OpenAI\Contracts\Resources\ThreadsMessagesFilesContract;
+use OpenAI\Events\RequestHandled;
 use OpenAI\Responses\Threads\Messages\ThreadMessageDeleteResponse;
 use OpenAI\Responses\Threads\Messages\ThreadMessageListResponse;
 use OpenAI\Responses\Threads\Messages\ThreadMessageResponse;
@@ -27,10 +28,14 @@ final class ThreadsMessages implements ThreadsMessagesContract
     {
         $payload = Payload::create("threads/$threadId/messages", $parameters);
 
-        /** @var Response<array{id: string, object: string, created_at: int, thread_id: string, role: string, content: array<int, array{type: 'image_file', image_file: array{file_id: string}}|array{type: 'text', text: array{value: string, annotations: array<int, array{type: 'file_citation', text: string, file_citation: array{file_id: string, quote: string}, start_index: int, end_index: int}|array{type: 'file_path', text: string, file_path: array{file_id: string}, start_index: int, end_index: int}>}}>, assistant_id: ?string, run_id: ?string, file_ids: array<int, string>, metadata: array<string, string>}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, created_at: int, thread_id: string, role: string, content: array<int, array{type: 'image_file', image_file: array{file_id: string}}|array{type: 'text', text: array{value: string, annotations: array<int, array{type: 'file_citation', text: string, file_citation: array{file_id: string, quote: string}, start_index: int, end_index: int}|array{type: 'file_path', text: string, file_path: array{file_id: string}, start_index: int, end_index: int}>}}>, assistant_id: ?string, run_id: ?string, file_ids: array<int, string>, metadata: array<string, string>}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return ThreadMessageResponse::from($response->data(), $response->meta());
+        $response = ThreadMessageResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -42,10 +47,14 @@ final class ThreadsMessages implements ThreadsMessagesContract
     {
         $payload = Payload::retrieve("threads/$threadId/messages", $messageId);
 
-        /** @var Response<array{id: string, object: string, created_at: int, thread_id: string, role: string, content: array<int, array{type: 'image_file', image_file: array{file_id: string}}|array{type: 'text', text: array{value: string, annotations: array<int, array{type: 'file_citation', text: string, file_citation: array{file_id: string, quote: string}, start_index: int, end_index: int}|array{type: 'file_path', text: string, file_path: array{file_id: string}, start_index: int, end_index: int}>}}>, assistant_id: ?string, run_id: ?string, file_ids: array<int, string>, metadata: array<string, string>}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, created_at: int, thread_id: string, role: string, content: array<int, array{type: 'image_file', image_file: array{file_id: string}}|array{type: 'text', text: array{value: string, annotations: array<int, array{type: 'file_citation', text: string, file_citation: array{file_id: string, quote: string}, start_index: int, end_index: int}|array{type: 'file_path', text: string, file_path: array{file_id: string}, start_index: int, end_index: int}>}}>, assistant_id: ?string, run_id: ?string, file_ids: array<int, string>, metadata: array<string, string>}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return ThreadMessageResponse::from($response->data(), $response->meta());
+        $response = ThreadMessageResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -59,10 +68,14 @@ final class ThreadsMessages implements ThreadsMessagesContract
     {
         $payload = Payload::modify("threads/$threadId/messages", $messageId, $parameters);
 
-        /** @var Response<array{id: string, object: string, created_at: int, thread_id: string, role: string, content: array<int, array{type: 'image_file', image_file: array{file_id: string}}|array{type: 'text', text: array{value: string, annotations: array<int, array{type: 'file_citation', text: string, file_citation: array{file_id: string, quote: string}, start_index: int, end_index: int}|array{type: 'file_path', text: string, file_path: array{file_id: string}, start_index: int, end_index: int}>}}>, assistant_id: ?string, run_id: ?string, file_ids: array<int, string>, metadata: array<string, string>}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, created_at: int, thread_id: string, role: string, content: array<int, array{type: 'image_file', image_file: array{file_id: string}}|array{type: 'text', text: array{value: string, annotations: array<int, array{type: 'file_citation', text: string, file_citation: array{file_id: string, quote: string}, start_index: int, end_index: int}|array{type: 'file_path', text: string, file_path: array{file_id: string}, start_index: int, end_index: int}>}}>, assistant_id: ?string, run_id: ?string, file_ids: array<int, string>, metadata: array<string, string>}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return ThreadMessageResponse::from($response->data(), $response->meta());
+        $response = ThreadMessageResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -74,10 +87,14 @@ final class ThreadsMessages implements ThreadsMessagesContract
     {
         $payload = Payload::delete("threads/$threadId/messages", $messageId);
 
-        /** @var Response<array{id: string, object: string, deleted: bool}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, deleted: bool}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return ThreadMessageDeleteResponse::from($response->data(), $response->meta());
+        $response = ThreadMessageDeleteResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -91,10 +108,14 @@ final class ThreadsMessages implements ThreadsMessagesContract
     {
         $payload = Payload::list("threads/$threadId/messages", $parameters);
 
-        /** @var Response<array{object: string, data: array<int, array{id: string, object: string, created_at: int, thread_id: string, role: string, content: array<int, array{type: 'image_file', image_file: array{file_id: string}}|array{type: 'text', text: array{value: string, annotations: array<int, array{type: 'file_citation', text: string, file_citation: array{file_id: string, quote: string}, start_index: int, end_index: int}|array{type: 'file_path', text: string, file_path: array{file_id: string}, start_index: int, end_index: int}>}}>, assistant_id: ?string, run_id: ?string, file_ids: array<int, string>, metadata: array<string, string>}>, first_id: ?string, last_id: ?string, has_more: bool}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{object: string, data: array<int, array{id: string, object: string, created_at: int, thread_id: string, role: string, content: array<int, array{type: 'image_file', image_file: array{file_id: string}}|array{type: 'text', text: array{value: string, annotations: array<int, array{type: 'file_citation', text: string, file_citation: array{file_id: string, quote: string}, start_index: int, end_index: int}|array{type: 'file_path', text: string, file_path: array{file_id: string}, start_index: int, end_index: int}>}}>, assistant_id: ?string, run_id: ?string, file_ids: array<int, string>, metadata: array<string, string>}>, first_id: ?string, last_id: ?string, has_more: bool}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return ThreadMessageListResponse::from($response->data(), $response->meta());
+        $response = ThreadMessageListResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -104,6 +125,6 @@ final class ThreadsMessages implements ThreadsMessagesContract
      */
     public function files(): ThreadsMessagesFilesContract
     {
-        return new ThreadsMessagesFiles($this->transporter);
+        return new ThreadsMessagesFiles($this->transporter, $this->events);
     }
 }

--- a/src/Resources/ThreadsMessagesFiles.php
+++ b/src/Resources/ThreadsMessagesFiles.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\ThreadsMessagesFilesContract;
+use OpenAI\Events\RequestHandled;
 use OpenAI\Responses\Threads\Messages\Files\ThreadMessageFileListResponse;
 use OpenAI\Responses\Threads\Messages\Files\ThreadMessageFileResponse;
 use OpenAI\ValueObjects\Transporter\Payload;
@@ -23,10 +24,14 @@ final class ThreadsMessagesFiles implements ThreadsMessagesFilesContract
     {
         $payload = Payload::retrieve("threads/$threadId/messages/$messageId/files", $fileId);
 
-        /** @var Response<array{id: string, object: string, created_at: int, message_id: string}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, created_at: int, message_id: string}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return ThreadMessageFileResponse::from($response->data(), $response->meta());
+        $response = ThreadMessageFileResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -40,9 +45,13 @@ final class ThreadsMessagesFiles implements ThreadsMessagesFilesContract
     {
         $payload = Payload::list("threads/$threadId/messages/$messageId/files", $parameters);
 
-        /** @var Response<array{object: string, data: array<int, array{id: string, object: string, created_at: int, message_id: string}>, first_id: ?string, last_id: ?string, has_more: bool}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{object: string, data: array<int, array{id: string, object: string, created_at: int, message_id: string}>, first_id: ?string, last_id: ?string, has_more: bool}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return ThreadMessageFileListResponse::from($response->data(), $response->meta());
+        $response = ThreadMessageFileListResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 }

--- a/src/Resources/ThreadsRuns.php
+++ b/src/Resources/ThreadsRuns.php
@@ -6,6 +6,7 @@ namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\ThreadsRunsContract;
 use OpenAI\Contracts\Resources\ThreadsRunsStepsContract;
+use OpenAI\Events\RequestHandled;
 use OpenAI\Responses\Threads\Runs\ThreadRunListResponse;
 use OpenAI\Responses\Threads\Runs\ThreadRunResponse;
 use OpenAI\ValueObjects\Transporter\Payload;
@@ -26,10 +27,14 @@ final class ThreadsRuns implements ThreadsRunsContract
     {
         $payload = Payload::create('threads/'.$threadId.'/runs', $parameters);
 
-        /** @var Response<array{id: string, object: string, created_at: int, thread_id: string, assistant_id: string, status: string, required_action?: array{type: string, submit_tool_outputs: array{tool_calls: array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}}, last_error: ?array{code: string, message: string}, expires_at: ?int, started_at: ?int, cancelled_at: ?int, failed_at: ?int, completed_at: ?int, model: string, instructions: ?string, tools: array<int, array{type: 'code_interpreter'}|array{type: 'retrieval'}|array{type: 'function', function: array{description: string, name: string, parameters: array<string, mixed>}}>, file_ids: array<int, string>, metadata: array<string, string>}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, created_at: int, thread_id: string, assistant_id: string, status: string, required_action?: array{type: string, submit_tool_outputs: array{tool_calls: array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}}, last_error: ?array{code: string, message: string}, expires_at: ?int, started_at: ?int, cancelled_at: ?int, failed_at: ?int, completed_at: ?int, model: string, instructions: ?string, tools: array<int, array{type: 'code_interpreter'}|array{type: 'retrieval'}|array{type: 'function', function: array{description: string, name: string, parameters: array<string, mixed>}}>, file_ids: array<int, string>, metadata: array<string, string>}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return ThreadRunResponse::from($response->data(), $response->meta());
+        $response = ThreadRunResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -41,10 +46,14 @@ final class ThreadsRuns implements ThreadsRunsContract
     {
         $payload = Payload::retrieve('threads/'.$threadId.'/runs', $runId);
 
-        /** @var Response<array{id: string, object: string, created_at: int, thread_id: string, assistant_id: string, status: string, required_action?: array{type: string, submit_tool_outputs: array{tool_calls: array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}}, last_error: ?array{code: string, message: string}, expires_at: ?int, started_at: ?int, cancelled_at: ?int, failed_at: ?int, completed_at: ?int, model: string, instructions: ?string, tools: array<int, array{type: 'code_interpreter'}|array{type: 'retrieval'}|array{type: 'function', function: array{description: string, name: string, parameters: array<string, mixed>}}>, file_ids: array<int, string>, metadata: array<string, string>}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, created_at: int, thread_id: string, assistant_id: string, status: string, required_action?: array{type: string, submit_tool_outputs: array{tool_calls: array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}}, last_error: ?array{code: string, message: string}, expires_at: ?int, started_at: ?int, cancelled_at: ?int, failed_at: ?int, completed_at: ?int, model: string, instructions: ?string, tools: array<int, array{type: 'code_interpreter'}|array{type: 'retrieval'}|array{type: 'function', function: array{description: string, name: string, parameters: array<string, mixed>}}>, file_ids: array<int, string>, metadata: array<string, string>}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return ThreadRunResponse::from($response->data(), $response->meta());
+        $response = ThreadRunResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -58,10 +67,14 @@ final class ThreadsRuns implements ThreadsRunsContract
     {
         $payload = Payload::modify('threads/'.$threadId.'/runs', $runId, $parameters);
 
-        /** @var Response<array{id: string, object: string, created_at: int, thread_id: string, assistant_id: string, status: string, required_action?: array{type: string, submit_tool_outputs: array{tool_calls: array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}}, last_error: ?array{code: string, message: string}, expires_at: ?int, started_at: ?int, cancelled_at: ?int, failed_at: ?int, completed_at: ?int, model: string, instructions: ?string, tools: array<int, array{type: 'code_interpreter'}|array{type: 'retrieval'}|array{type: 'function', function: array{description: string, name: string, parameters: array<string, mixed>}}>, file_ids: array<int, string>, metadata: array<string, string>}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, created_at: int, thread_id: string, assistant_id: string, status: string, required_action?: array{type: string, submit_tool_outputs: array{tool_calls: array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}}, last_error: ?array{code: string, message: string}, expires_at: ?int, started_at: ?int, cancelled_at: ?int, failed_at: ?int, completed_at: ?int, model: string, instructions: ?string, tools: array<int, array{type: 'code_interpreter'}|array{type: 'retrieval'}|array{type: 'function', function: array{description: string, name: string, parameters: array<string, mixed>}}>, file_ids: array<int, string>, metadata: array<string, string>}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return ThreadRunResponse::from($response->data(), $response->meta());
+        $response = ThreadRunResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -75,10 +88,14 @@ final class ThreadsRuns implements ThreadsRunsContract
     {
         $payload = Payload::create('threads/'.$threadId.'/runs/'.$runId.'/submit_tool_outputs', $parameters);
 
-        /** @var Response<array{id: string, object: string, created_at: int, thread_id: string, assistant_id: string, status: string, required_action?: array{type: string, submit_tool_outputs: array{tool_calls: array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}}, last_error: ?array{code: string, message: string}, expires_at: ?int, started_at: ?int, cancelled_at: ?int, failed_at: ?int, completed_at: ?int, model: string, instructions: ?string, tools: array<int, array{type: 'code_interpreter'}|array{type: 'retrieval'}|array{type: 'function', function: array{description: string, name: string, parameters: array<string, mixed>}}>, file_ids: array<int, string>, metadata: array<string, string>}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, created_at: int, thread_id: string, assistant_id: string, status: string, required_action?: array{type: string, submit_tool_outputs: array{tool_calls: array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}}, last_error: ?array{code: string, message: string}, expires_at: ?int, started_at: ?int, cancelled_at: ?int, failed_at: ?int, completed_at: ?int, model: string, instructions: ?string, tools: array<int, array{type: 'code_interpreter'}|array{type: 'retrieval'}|array{type: 'function', function: array{description: string, name: string, parameters: array<string, mixed>}}>, file_ids: array<int, string>, metadata: array<string, string>}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return ThreadRunResponse::from($response->data(), $response->meta());
+        $response = ThreadRunResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -90,10 +107,14 @@ final class ThreadsRuns implements ThreadsRunsContract
     {
         $payload = Payload::cancel('threads/'.$threadId.'/runs', $runId);
 
-        /** @var Response<array{id: string, object: string, created_at: int, thread_id: string, assistant_id: string, status: string, required_action?: array{type: string, submit_tool_outputs: array{tool_calls: array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}}, last_error: ?array{code: string, message: string}, expires_at: ?int, started_at: ?int, cancelled_at: ?int, failed_at: ?int, completed_at: ?int, model: string, instructions: ?string, tools: array<int, array{type: 'code_interpreter'}|array{type: 'retrieval'}|array{type: 'function', function: array{description: string, name: string, parameters: array<string, mixed>}}>, file_ids: array<int, string>, metadata: array<string, string>}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, created_at: int, thread_id: string, assistant_id: string, status: string, required_action?: array{type: string, submit_tool_outputs: array{tool_calls: array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}}, last_error: ?array{code: string, message: string}, expires_at: ?int, started_at: ?int, cancelled_at: ?int, failed_at: ?int, completed_at: ?int, model: string, instructions: ?string, tools: array<int, array{type: 'code_interpreter'}|array{type: 'retrieval'}|array{type: 'function', function: array{description: string, name: string, parameters: array<string, mixed>}}>, file_ids: array<int, string>, metadata: array<string, string>}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return ThreadRunResponse::from($response->data(), $response->meta());
+        $response = ThreadRunResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -107,10 +128,14 @@ final class ThreadsRuns implements ThreadsRunsContract
     {
         $payload = Payload::list('threads/'.$threadId.'/runs', $parameters);
 
-        /** @var Response<array{object: string, data: array<int, array{id: string, object: string, created_at: int, thread_id: string, assistant_id: string, status: string, required_action?: array{type: string, submit_tool_outputs: array{tool_calls: array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}}, last_error: ?array{code: string, message: string}, expires_at: ?int, started_at: ?int, cancelled_at: ?int, failed_at: ?int, completed_at: ?int, model: string, instructions: ?string, tools: array<int, array{type: 'code_interpreter'}|array{type: 'retrieval'}|array{type: 'function', function: array{description: string, name: string, parameters: array<string, mixed>}}>, file_ids: array<int, string>, metadata: array<string, string>}>, first_id: ?string, last_id: ?string, has_more: bool}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{object: string, data: array<int, array{id: string, object: string, created_at: int, thread_id: string, assistant_id: string, status: string, required_action?: array{type: string, submit_tool_outputs: array{tool_calls: array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}}, last_error: ?array{code: string, message: string}, expires_at: ?int, started_at: ?int, cancelled_at: ?int, failed_at: ?int, completed_at: ?int, model: string, instructions: ?string, tools: array<int, array{type: 'code_interpreter'}|array{type: 'retrieval'}|array{type: 'function', function: array{description: string, name: string, parameters: array<string, mixed>}}>, file_ids: array<int, string>, metadata: array<string, string>}>, first_id: ?string, last_id: ?string, has_more: bool}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return ThreadRunListResponse::from($response->data(), $response->meta());
+        $response = ThreadRunListResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -120,6 +145,6 @@ final class ThreadsRuns implements ThreadsRunsContract
      */
     public function steps(): ThreadsRunsStepsContract
     {
-        return new ThreadsRunsSteps($this->transporter);
+        return new ThreadsRunsSteps($this->transporter, $this->events);
     }
 }

--- a/src/Resources/ThreadsRunsSteps.php
+++ b/src/Resources/ThreadsRunsSteps.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\ThreadsRunsStepsContract;
+use OpenAI\Events\RequestHandled;
 use OpenAI\Responses\Threads\Runs\Steps\ThreadRunStepListResponse;
 use OpenAI\Responses\Threads\Runs\Steps\ThreadRunStepResponse;
 use OpenAI\ValueObjects\Transporter\Payload;
@@ -23,10 +24,14 @@ final class ThreadsRunsSteps implements ThreadsRunsStepsContract
     {
         $payload = Payload::retrieve('threads/'.$threadId.'/runs/'.$runId.'/steps', $stepId);
 
-        /** @var Response<array{id: string, object: string, created_at: int, thread_id: string, assistant_id: string, run_id: string, type: string, status: string, step_details: array{type: 'tool_calls', tool_calls: array<int, array{id: string, type: 'code_interpreter', code_interpreter: array{input: string, outputs: array<int, array{type: 'image', image: array{file_id: string}}|array{type: 'logs', logs: string}>}}|array{id: string, type: 'retrieval', retrieval: array<string, string>}|array{id: string, type: 'function', function: array{name: string, arguments: string, output: ?string}}>}|array{type: 'message_creation', message_creation: array{message_id: string}}, last_error: ?array{code: string, message: string}, expires_at: ?int, cancelled_at: ?int, failed_at: ?int, completed_at: ?int, metadata?: array<string, string>}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{id: string, object: string, created_at: int, thread_id: string, assistant_id: string, run_id: string, type: string, status: string, step_details: array{type: 'tool_calls', tool_calls: array<int, array{id: string, type: 'code_interpreter', code_interpreter: array{input: string, outputs: array<int, array{type: 'image', image: array{file_id: string}}|array{type: 'logs', logs: string}>}}|array{id: string, type: 'retrieval', retrieval: array<string, string>}|array{id: string, type: 'function', function: array{name: string, arguments: string, output: ?string}}>}|array{type: 'message_creation', message_creation: array{message_id: string}}, last_error: ?array{code: string, message: string}, expires_at: ?int, cancelled_at: ?int, failed_at: ?int, completed_at: ?int, metadata?: array<string, string>}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return ThreadRunStepResponse::from($response->data(), $response->meta());
+        $response = ThreadRunStepResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 
     /**
@@ -40,9 +45,13 @@ final class ThreadsRunsSteps implements ThreadsRunsStepsContract
     {
         $payload = Payload::list('threads/'.$threadId.'/runs/'.$runId.'/steps', $parameters);
 
-        /** @var Response<array{object: string, data: array<int, array{id: string, object: string, created_at: int, thread_id: string, assistant_id: string, run_id: string, type: string, status: string, step_details: array{type: 'tool_calls', tool_calls: array<int, array{id: string, type: 'code_interpreter', code_interpreter: array{input: string, outputs: array<int, array{type: 'image', image: array{file_id: string}}|array{type: 'logs', logs: string}>}}|array{id: string, type: 'retrieval', retrieval: array<string, string>}|array{id: string, type: 'function', function: array{name: string, arguments: string, output: ?string}}>}|array{type: 'message_creation', message_creation: array{message_id: string}}, last_error: ?array{code: string, message: string}, expires_at: ?int, cancelled_at: ?int, failed_at: ?int, completed_at: ?int, metadata?: array<string, string>}>, first_id: ?string, last_id: ?string, has_more: bool}> $response */
-        $response = $this->transporter->requestObject($payload);
+        /** @var Response<array{object: string, data: array<int, array{id: string, object: string, created_at: int, thread_id: string, assistant_id: string, run_id: string, type: string, status: string, step_details: array{type: 'tool_calls', tool_calls: array<int, array{id: string, type: 'code_interpreter', code_interpreter: array{input: string, outputs: array<int, array{type: 'image', image: array{file_id: string}}|array{type: 'logs', logs: string}>}}|array{id: string, type: 'retrieval', retrieval: array<string, string>}|array{id: string, type: 'function', function: array{name: string, arguments: string, output: ?string}}>}|array{type: 'message_creation', message_creation: array{message_id: string}}, last_error: ?array{code: string, message: string}, expires_at: ?int, cancelled_at: ?int, failed_at: ?int, completed_at: ?int, metadata?: array<string, string>}>, first_id: ?string, last_id: ?string, has_more: bool}> $responseRaw */
+        $responseRaw = $this->transporter->requestObject($payload);
 
-        return ThreadRunStepListResponse::from($response->data(), $response->meta());
+        $response = ThreadRunStepListResponse::from($responseRaw->data(), $responseRaw->meta());
+
+        $this->event(new RequestHandled($payload, $response));
+
+        return $response;
     }
 }

--- a/src/ValueObjects/Transporter/Payload.php
+++ b/src/ValueObjects/Transporter/Payload.php
@@ -24,10 +24,10 @@ final class Payload
      * @param  array<string, mixed>  $parameters
      */
     private function __construct(
-        private readonly ContentType $contentType,
-        private readonly Method $method,
-        private readonly ResourceUri $uri,
-        private readonly array $parameters = [],
+        public readonly ContentType $contentType,
+        public readonly Method $method,
+        public readonly ResourceUri $uri,
+        public readonly array $parameters = [],
     ) {
         // ..
     }

--- a/tests/Arch.php
+++ b/tests/Arch.php
@@ -23,6 +23,7 @@ test('exceptions')
 
 test('resources')->expect('OpenAI\Resources')->toOnlyUse([
     'OpenAI\Contracts',
+    'OpenAI\Events',
     'OpenAI\ValueObjects',
     'OpenAI\Exceptions',
     'OpenAI\Responses',
@@ -31,6 +32,7 @@ test('resources')->expect('OpenAI\Resources')->toOnlyUse([
 test('responses')->expect('OpenAI\Responses')->toOnlyUse([
     'Http\Discovery\Psr17Factory',
     'OpenAI\Enums',
+    'OpenAI\Events',
     'OpenAI\Exceptions\ErrorException',
     'OpenAI\Contracts',
     'OpenAI\Testing\Responses\Concerns',
@@ -49,6 +51,7 @@ test('value objects')->expect('OpenAI\ValueObjects')->toOnlyUse([
 ]);
 
 test('client')->expect('OpenAI\Client')->toOnlyUse([
+    'OpenAI\Events',
     'OpenAI\Resources',
     'OpenAI\Contracts',
 ]);
@@ -59,8 +62,10 @@ test('openai')->expect('OpenAI')->toOnlyUse([
     'Http\Discovery\Psr17Factory',
     'Http\Discovery\Psr18ClientDiscovery',
     'Http\Message\MultipartStream\MultipartStreamBuilder',
+    'Illuminate\Contracts\Events\Dispatcher',
     'OpenAI\Contracts',
     'OpenAI\Resources',
+    'Psr\EventDispatcher\EventDispatcherInterface',
     'Psr\Http\Client',
     'Psr\Http\Message\RequestInterface',
     'Psr\Http\Message\ResponseInterface',

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,6 +1,7 @@
 <?php
 
 use OpenAI\Client;
+use OpenAI\Contracts\DispatcherContract;
 use OpenAI\Contracts\TransporterContract;
 use OpenAI\ValueObjects\ApiKey;
 use OpenAI\ValueObjects\Transporter\BaseUri;
@@ -40,7 +41,13 @@ function mockClient(string $method, string $resource, array $params, Response|Re
                 && $request->getUri()->getPath() === "/v1/$resource";
         })->andReturn($response);
 
-    return new Client($transporter);
+    $dispatcher = Mockery::mock(DispatcherContract::class);
+
+    $dispatcher
+        ->shouldReceive('dispatch')
+        ->once();
+
+    return new Client($transporter, $dispatcher);
 }
 
 function mockContentClient(string $method, string $resource, array $params, string $response, bool $validateParams = true)


### PR DESCRIPTION
This PR adds the ability register an event dispatcher.

When a request has been handled successfully and an event dispatcher is registered, a `RequestHandled` event will be dispatched.
The event contains the initial `Payload` of the request and the `Response`.

This feature is required to create a `Recorder` for Laravel Pulse in the openai/laravel repository.

Todos:
- [ ] Find a better name for the `Transportable` contract
- [ ] Add events docs
- [ ] Add missing factory tests