### PR TITLE
Add @throws annotation

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,5 +5,14 @@ parameters:
     excludePaths:
             analyse:
                 - src/Testing
+    exceptions:
+        check:
+            missingCheckedExceptionInThrows: true
+            tooWideThrowType: true
+        implicitThrows: false
+        uncheckedExceptionClasses:
+            - Http\Discovery\Exception\NotFoundException
+            - LogicException
+            - JsonException
 
     reportUnmatchedIgnoredErrors: true

--- a/src/Contracts/Resources/AssistantsContract.php
+++ b/src/Contracts/Resources/AssistantsContract.php
@@ -2,6 +2,7 @@
 
 namespace OpenAI\Contracts\Resources;
 
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\Assistants\AssistantDeleteResponse;
 use OpenAI\Responses\Assistants\AssistantListResponse;
 use OpenAI\Responses\Assistants\AssistantResponse;
@@ -14,6 +15,8 @@ interface AssistantsContract
      * @see https://platform.openai.com/docs/api-reference/assistants/createAssistant
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function create(array $parameters): AssistantResponse;
 
@@ -21,6 +24,8 @@ interface AssistantsContract
      * Retrieves an assistant.
      *
      * @see https://platform.openai.com/docs/api-reference/assistants/getAssistant
+     *
+     * @throws OpenAIThrowable
      */
     public function retrieve(string $id): AssistantResponse;
 
@@ -30,6 +35,8 @@ interface AssistantsContract
      * @see https://platform.openai.com/docs/api-reference/assistants/modifyAssistant
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function modify(string $id, array $parameters): AssistantResponse;
 
@@ -37,6 +44,8 @@ interface AssistantsContract
      * Delete an assistant.
      *
      * @see https://platform.openai.com/docs/api-reference/assistants/deleteAssistant
+     *
+     * @throws OpenAIThrowable
      */
     public function delete(string $id): AssistantDeleteResponse;
 
@@ -46,6 +55,8 @@ interface AssistantsContract
      * @see https://platform.openai.com/docs/api-reference/assistants/listAssistants
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function list(array $parameters = []): AssistantListResponse;
 }

--- a/src/Contracts/Resources/AudioContract.php
+++ b/src/Contracts/Resources/AudioContract.php
@@ -2,6 +2,7 @@
 
 namespace OpenAI\Contracts\Resources;
 
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\Audio\SpeechStreamResponse;
 use OpenAI\Responses\Audio\TranscriptionResponse;
 use OpenAI\Responses\Audio\TranslationResponse;
@@ -14,6 +15,8 @@ interface AudioContract
      * @see https://platform.openai.com/docs/api-reference/audio/createSpeech
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function speech(array $parameters): string;
 
@@ -23,6 +26,8 @@ interface AudioContract
      * @see https://platform.openai.com/docs/api-reference/audio/createSpeech
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function speechStreamed(array $parameters): SpeechStreamResponse;
 
@@ -32,6 +37,8 @@ interface AudioContract
      * @see https://platform.openai.com/docs/api-reference/audio/createTranscription
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function transcribe(array $parameters): TranscriptionResponse;
 
@@ -41,6 +48,8 @@ interface AudioContract
      * @see https://platform.openai.com/docs/api-reference/audio/createTranslation
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function translate(array $parameters): TranslationResponse;
 }

--- a/src/Contracts/Resources/ChatContract.php
+++ b/src/Contracts/Resources/ChatContract.php
@@ -2,6 +2,7 @@
 
 namespace OpenAI\Contracts\Resources;
 
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\Chat\CreateResponse;
 use OpenAI\Responses\Chat\CreateStreamedResponse;
 use OpenAI\Responses\StreamResponse;
@@ -14,6 +15,8 @@ interface ChatContract
      * @see https://platform.openai.com/docs/api-reference/chat/create
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function create(array $parameters): CreateResponse;
 
@@ -24,6 +27,8 @@ interface ChatContract
      *
      * @param  array<string, mixed>  $parameters
      * @return StreamResponse<CreateStreamedResponse>
+     *
+     * @throws OpenAIThrowable
      */
     public function createStreamed(array $parameters): StreamResponse;
 }

--- a/src/Contracts/Resources/CompletionsContract.php
+++ b/src/Contracts/Resources/CompletionsContract.php
@@ -2,6 +2,7 @@
 
 namespace OpenAI\Contracts\Resources;
 
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\Completions\CreateResponse;
 use OpenAI\Responses\Completions\CreateStreamedResponse;
 use OpenAI\Responses\StreamResponse;
@@ -14,6 +15,8 @@ interface CompletionsContract
      * @see https://platform.openai.com/docs/api-reference/completions/create-completion
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function create(array $parameters): CreateResponse;
 
@@ -24,6 +27,8 @@ interface CompletionsContract
      *
      * @param  array<string, mixed>  $parameters
      * @return StreamResponse<CreateStreamedResponse>
+     *
+     * @throws OpenAIThrowable
      */
     public function createStreamed(array $parameters): StreamResponse;
 }

--- a/src/Contracts/Resources/EditsContract.php
+++ b/src/Contracts/Resources/EditsContract.php
@@ -2,6 +2,7 @@
 
 namespace OpenAI\Contracts\Resources;
 
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\Edits\CreateResponse;
 
 interface EditsContract
@@ -12,6 +13,8 @@ interface EditsContract
      * @see https://platform.openai.com/docs/api-reference/edits/create
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      *
      * @deprecated OpenAI has deprecated this endpoint and will stop working by January 4, 2024.
      * https://openai.com/blog/gpt-4-api-general-availability#deprecation-of-the-edits-api

--- a/src/Contracts/Resources/EmbeddingsContract.php
+++ b/src/Contracts/Resources/EmbeddingsContract.php
@@ -2,6 +2,7 @@
 
 namespace OpenAI\Contracts\Resources;
 
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\Embeddings\CreateResponse;
 
 interface EmbeddingsContract
@@ -12,6 +13,8 @@ interface EmbeddingsContract
      * @see https://platform.openai.com/docs/api-reference/embeddings/create
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function create(array $parameters): CreateResponse;
 }

--- a/src/Contracts/Resources/FilesContract.php
+++ b/src/Contracts/Resources/FilesContract.php
@@ -2,6 +2,7 @@
 
 namespace OpenAI\Contracts\Resources;
 
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\Files\CreateResponse;
 use OpenAI\Responses\Files\DeleteResponse;
 use OpenAI\Responses\Files\ListResponse;
@@ -13,6 +14,8 @@ interface FilesContract
      * Returns a list of files that belong to the user's organization.
      *
      * @see https://platform.openai.com/docs/api-reference/files/list
+     *
+     * @throws OpenAIThrowable
      */
     public function list(): ListResponse;
 
@@ -20,6 +23,8 @@ interface FilesContract
      * Returns information about a specific file.
      *
      * @see https://platform.openai.com/docs/api-reference/files/retrieve
+     *
+     * @throws OpenAIThrowable
      */
     public function retrieve(string $file): RetrieveResponse;
 
@@ -27,6 +32,8 @@ interface FilesContract
      * Returns the contents of the specified file.
      *
      * @see https://platform.openai.com/docs/api-reference/files/retrieve-content
+     *
+     * @throws OpenAIThrowable
      */
     public function download(string $file): string;
 
@@ -36,6 +43,8 @@ interface FilesContract
      * @see https://platform.openai.com/docs/api-reference/files/upload
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function upload(array $parameters): CreateResponse;
 
@@ -43,6 +52,8 @@ interface FilesContract
      * Delete a file.
      *
      * @see https://platform.openai.com/docs/api-reference/files/delete
+     *
+     * @throws OpenAIThrowable
      */
     public function delete(string $file): DeleteResponse;
 }

--- a/src/Contracts/Resources/FineTunesContract.php
+++ b/src/Contracts/Resources/FineTunesContract.php
@@ -2,6 +2,7 @@
 
 namespace OpenAI\Contracts\Resources;
 
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\FineTunes\ListEventsResponse;
 use OpenAI\Responses\FineTunes\ListResponse;
 use OpenAI\Responses\FineTunes\RetrieveResponse;
@@ -18,6 +19,8 @@ interface FineTunesContract
      * @see https://platform.openai.com/docs/api-reference/fine-tunes/create
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function create(array $parameters): RetrieveResponse;
 
@@ -25,6 +28,8 @@ interface FineTunesContract
      * List your organization's fine-tuning jobs.
      *
      * @see https://platform.openai.com/docs/api-reference/fine-tunes/list
+     *
+     * @throws OpenAIThrowable
      */
     public function list(): ListResponse;
 
@@ -32,6 +37,8 @@ interface FineTunesContract
      * Gets info about the fine-tune job.
      *
      * @see https://platform.openai.com/docs/api-reference/fine-tunes/list
+     *
+     * @throws OpenAIThrowable
      */
     public function retrieve(string $fineTuneId): RetrieveResponse;
 
@@ -39,6 +46,8 @@ interface FineTunesContract
      * Immediately cancel a fine-tune job.
      *
      * @see https://platform.openai.com/docs/api-reference/fine-tunes/cancel
+     *
+     * @throws OpenAIThrowable
      */
     public function cancel(string $fineTuneId): RetrieveResponse;
 
@@ -46,6 +55,8 @@ interface FineTunesContract
      * Get fine-grained status updates for a fine-tune job.
      *
      * @see https://platform.openai.com/docs/api-reference/fine-tunes/events
+     *
+     * @throws OpenAIThrowable
      */
     public function listEvents(string $fineTuneId): ListEventsResponse;
 
@@ -55,6 +66,8 @@ interface FineTunesContract
      * @see https://platform.openai.com/docs/api-reference/fine-tunes/events
      *
      * @return StreamResponse<RetrieveStreamedResponseEvent>
+     *
+     * @throws OpenAIThrowable
      */
     public function listEventsStreamed(string $fineTuneId): StreamResponse;
 }

--- a/src/Contracts/Resources/FineTuningContract.php
+++ b/src/Contracts/Resources/FineTuningContract.php
@@ -2,6 +2,7 @@
 
 namespace OpenAI\Contracts\Resources;
 
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\FineTuning\ListJobEventsResponse;
 use OpenAI\Responses\FineTuning\ListJobsResponse;
 use OpenAI\Responses\FineTuning\RetrieveJobResponse;
@@ -16,6 +17,8 @@ interface FineTuningContract
      * @see https://platform.openai.com/docs/api-reference/fine-tuning/create
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function createJob(array $parameters): RetrieveJobResponse;
 
@@ -25,6 +28,8 @@ interface FineTuningContract
      * @see https://platform.openai.com/docs/api-reference/fine-tuning/undefined
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function listJobs(array $parameters = []): ListJobsResponse;
 
@@ -32,6 +37,8 @@ interface FineTuningContract
      * Get info about a fine-tuning job.
      *
      * @see https://platform.openai.com/docs/api-reference/fine-tuning/retrieve
+     *
+     * @throws OpenAIThrowable
      */
     public function retrieveJob(string $jobId): RetrieveJobResponse;
 
@@ -39,6 +46,8 @@ interface FineTuningContract
      * Immediately cancel a fine-tune job.
      *
      * @see https://platform.openai.com/docs/api-reference/fine-tuning/cancel
+     *
+     * @throws OpenAIThrowable
      */
     public function cancelJob(string $jobId): RetrieveJobResponse;
 
@@ -48,6 +57,8 @@ interface FineTuningContract
      * @see https://platform.openai.com/docs/api-reference/fine-tuning/list-events
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function listJobEvents(string $jobId, array $parameters = []): ListJobEventsResponse;
 }

--- a/src/Contracts/Resources/ImagesContract.php
+++ b/src/Contracts/Resources/ImagesContract.php
@@ -2,6 +2,7 @@
 
 namespace OpenAI\Contracts\Resources;
 
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\Images\CreateResponse;
 use OpenAI\Responses\Images\EditResponse;
 use OpenAI\Responses\Images\VariationResponse;
@@ -14,6 +15,8 @@ interface ImagesContract
      * @see https://platform.openai.com/docs/api-reference/images/create
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function create(array $parameters): CreateResponse;
 
@@ -23,6 +26,8 @@ interface ImagesContract
      * @see https://platform.openai.com/docs/api-reference/images/create-edit
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function edit(array $parameters): EditResponse;
 
@@ -32,6 +37,8 @@ interface ImagesContract
      * @see https://platform.openai.com/docs/api-reference/images/create-variation
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function variation(array $parameters): VariationResponse;
 }

--- a/src/Contracts/Resources/ModelsContract.php
+++ b/src/Contracts/Resources/ModelsContract.php
@@ -2,6 +2,7 @@
 
 namespace OpenAI\Contracts\Resources;
 
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\Models\DeleteResponse;
 use OpenAI\Responses\Models\ListResponse;
 use OpenAI\Responses\Models\RetrieveResponse;
@@ -12,6 +13,8 @@ interface ModelsContract
      * Lists the currently available models, and provides basic information about each one such as the owner and availability.
      *
      * @see https://platform.openai.com/docs/api-reference/models/list
+     *
+     * @throws OpenAIThrowable
      */
     public function list(): ListResponse;
 
@@ -19,6 +22,8 @@ interface ModelsContract
      * Retrieves a model instance, providing basic information about the model such as the owner and permissioning.
      *
      * @see https://platform.openai.com/docs/api-reference/models/retrieve
+     *
+     * @throws OpenAIThrowable
      */
     public function retrieve(string $model): RetrieveResponse;
 
@@ -26,6 +31,8 @@ interface ModelsContract
      * Delete a fine-tuned model. You must have the Owner role in your organization.
      *
      * @see https://platform.openai.com/docs/api-reference/fine-tunes/delete-model
+     *
+     * @throws OpenAIThrowable
      */
     public function delete(string $model): DeleteResponse;
 }

--- a/src/Contracts/Resources/ModerationsContract.php
+++ b/src/Contracts/Resources/ModerationsContract.php
@@ -2,6 +2,7 @@
 
 namespace OpenAI\Contracts\Resources;
 
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\Moderations\CreateResponse;
 
 interface ModerationsContract
@@ -12,6 +13,8 @@ interface ModerationsContract
      * @see https://platform.openai.com/docs/api-reference/moderations/create
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function create(array $parameters): CreateResponse;
 }

--- a/src/Contracts/Resources/ThreadsContract.php
+++ b/src/Contracts/Resources/ThreadsContract.php
@@ -2,6 +2,7 @@
 
 namespace OpenAI\Contracts\Resources;
 
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\StreamResponse;
 use OpenAI\Responses\Threads\Runs\ThreadRunResponse;
 use OpenAI\Responses\Threads\Runs\ThreadRunStreamResponse;
@@ -16,6 +17,8 @@ interface ThreadsContract
      * @see https://platform.openai.com/docs/api-reference/threads/createThread
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function create(array $parameters): ThreadResponse;
 
@@ -25,6 +28,8 @@ interface ThreadsContract
      * @see https://platform.openai.com/docs/api-reference/runs/createThreadAndRun
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function createAndRun(array $parameters): ThreadRunResponse;
 
@@ -42,6 +47,8 @@ interface ThreadsContract
      * Retrieves a thread.
      *
      * @see https://platform.openai.com/docs/api-reference/threads/getThread
+     *
+     * @throws OpenAIThrowable
      */
     public function retrieve(string $id): ThreadResponse;
 
@@ -51,6 +58,8 @@ interface ThreadsContract
      * @see https://platform.openai.com/docs/api-reference/threads/modifyThread
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function modify(string $id, array $parameters): ThreadResponse;
 
@@ -58,6 +67,8 @@ interface ThreadsContract
      * Delete an thread.
      *
      * @see https://platform.openai.com/docs/api-reference/threads/deleteThread
+     *
+     * @throws OpenAIThrowable
      */
     public function delete(string $id): ThreadDeleteResponse;
 

--- a/src/Contracts/Resources/ThreadsMessagesContract.php
+++ b/src/Contracts/Resources/ThreadsMessagesContract.php
@@ -2,6 +2,7 @@
 
 namespace OpenAI\Contracts\Resources;
 
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\Threads\Messages\ThreadMessageDeleteResponse;
 use OpenAI\Responses\Threads\Messages\ThreadMessageListResponse;
 use OpenAI\Responses\Threads\Messages\ThreadMessageResponse;
@@ -14,6 +15,8 @@ interface ThreadsMessagesContract
      * @see https://platform.openai.com/docs/api-reference/messages/createMessage
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function create(string $threadId, array $parameters): ThreadMessageResponse;
 
@@ -21,6 +24,8 @@ interface ThreadsMessagesContract
      * Retrieve a message.
      *
      * @see https://platform.openai.com/docs/api-reference/messages/getMessage
+     *
+     * @throws OpenAIThrowable
      */
     public function retrieve(string $threadId, string $messageId): ThreadMessageResponse;
 
@@ -30,6 +35,8 @@ interface ThreadsMessagesContract
      * @see https://platform.openai.com/docs/api-reference/messages/modifyMessage
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function modify(string $threadId, string $messageId, array $parameters): ThreadMessageResponse;
 
@@ -46,6 +53,8 @@ interface ThreadsMessagesContract
      * @see https://platform.openai.com/docs/api-reference/messages/listMessages
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function list(string $threadId, array $parameters = []): ThreadMessageListResponse;
 }

--- a/src/Contracts/Resources/ThreadsRunsContract.php
+++ b/src/Contracts/Resources/ThreadsRunsContract.php
@@ -2,6 +2,7 @@
 
 namespace OpenAI\Contracts\Resources;
 
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\StreamResponse;
 use OpenAI\Responses\Threads\Runs\ThreadRunListResponse;
 use OpenAI\Responses\Threads\Runs\ThreadRunResponse;
@@ -15,6 +16,8 @@ interface ThreadsRunsContract
      * @see https://platform.openai.com/docs/api-reference/runs/createRun
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function create(string $threadId, array $parameters): ThreadRunResponse;
 

--- a/src/Contracts/Resources/ThreadsRunsStepsContract.php
+++ b/src/Contracts/Resources/ThreadsRunsStepsContract.php
@@ -2,6 +2,7 @@
 
 namespace OpenAI\Contracts\Resources;
 
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\Threads\Runs\Steps\ThreadRunStepListResponse;
 use OpenAI\Responses\Threads\Runs\Steps\ThreadRunStepResponse;
 
@@ -11,6 +12,8 @@ interface ThreadsRunsStepsContract
      * Retrieves a run step.
      *
      * @see https://platform.openai.com/docs/api-reference/runs/getRunStep
+     *
+     * @throws OpenAIThrowable
      */
     public function retrieve(string $threadId, string $runId, string $stepId): ThreadRunStepResponse;
 
@@ -20,6 +23,8 @@ interface ThreadsRunsStepsContract
      * @see https://platform.openai.com/docs/api-reference/runs/listRunSteps
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function list(string $threadId, string $runId, array $parameters = []): ThreadRunStepListResponse;
 }

--- a/src/Contracts/TransporterContract.php
+++ b/src/Contracts/TransporterContract.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace OpenAI\Contracts;
 
-use OpenAI\Exceptions\ErrorException;
-use OpenAI\Exceptions\TransporterException;
-use OpenAI\Exceptions\UnserializableResponse;
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\ValueObjects\Transporter\Payload;
 use OpenAI\ValueObjects\Transporter\Response;
 use Psr\Http\Message\ResponseInterface;
@@ -21,21 +19,21 @@ interface TransporterContract
      *
      * @return Response<array<array-key, mixed>|string>
      *
-     * @throws ErrorException|UnserializableResponse|TransporterException
+     * @throws OpenAIThrowable
      */
     public function requestObject(Payload $payload): Response;
 
     /**
      * Sends a content request to a server.
      *
-     * @throws ErrorException|TransporterException
+     * @throws OpenAIThrowable
      */
     public function requestContent(Payload $payload): string;
 
     /**
      * Sends a stream request to a server.
      **
-     * @throws ErrorException
+     * @throws OpenAIThrowable
      */
     public function requestStream(Payload $payload): ResponseInterface;
 }

--- a/src/Exceptions/ErrorException.php
+++ b/src/Exceptions/ErrorException.php
@@ -6,7 +6,7 @@ namespace OpenAI\Exceptions;
 
 use Exception;
 
-final class ErrorException extends Exception
+final class ErrorException extends Exception implements OpenAIThrowable
 {
     /**
      * Creates a new Exception instance.

--- a/src/Exceptions/InvalidArgumentException.php
+++ b/src/Exceptions/InvalidArgumentException.php
@@ -6,6 +6,6 @@ namespace OpenAI\Exceptions;
 
 use Exception;
 
-final class InvalidArgumentException extends Exception
+final class InvalidArgumentException extends Exception implements OpenAIThrowable
 {
 }

--- a/src/Exceptions/OpenAIThrowable.php
+++ b/src/Exceptions/OpenAIThrowable.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace OpenAI\Exceptions;
+
+use Throwable;
+
+interface OpenAIThrowable extends Throwable
+{
+}

--- a/src/Exceptions/TransporterException.php
+++ b/src/Exceptions/TransporterException.php
@@ -7,7 +7,7 @@ namespace OpenAI\Exceptions;
 use Exception;
 use Psr\Http\Client\ClientExceptionInterface;
 
-final class TransporterException extends Exception
+final class TransporterException extends Exception implements OpenAIThrowable
 {
     /**
      * Creates a new Exception instance.

--- a/src/Exceptions/UnreadableResponse.php
+++ b/src/Exceptions/UnreadableResponse.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace OpenAI\Exceptions;
 
 use Exception;
-use JsonException;
+use RuntimeException;
 
-final class UnserializableResponse extends Exception implements OpenAIThrowable
+final class UnreadableResponse extends Exception implements OpenAIThrowable
 {
     /**
      * Creates a new Exception instance.
      */
-    public function __construct(JsonException $exception)
+    public function __construct(RuntimeException $exception)
     {
         parent::__construct($exception->getMessage(), 0, $exception);
     }

--- a/src/Resources/Assistants.php
+++ b/src/Resources/Assistants.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\AssistantsContract;
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\Assistants\AssistantDeleteResponse;
 use OpenAI\Responses\Assistants\AssistantListResponse;
 use OpenAI\Responses\Assistants\AssistantResponse;
@@ -21,6 +22,8 @@ final class Assistants implements AssistantsContract
      * @see https://platform.openai.com/docs/api-reference/assistants/createAssistant
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function create(array $parameters): AssistantResponse
     {
@@ -36,6 +39,8 @@ final class Assistants implements AssistantsContract
      * Retrieves an assistant.
      *
      * @see https://platform.openai.com/docs/api-reference/assistants/getAssistant
+     *
+     * @throws OpenAIThrowable
      */
     public function retrieve(string $id): AssistantResponse
     {
@@ -53,6 +58,8 @@ final class Assistants implements AssistantsContract
      * @see https://platform.openai.com/docs/api-reference/assistants/modifyAssistant
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function modify(string $id, array $parameters): AssistantResponse
     {
@@ -68,6 +75,8 @@ final class Assistants implements AssistantsContract
      * Delete an assistant.
      *
      * @see https://platform.openai.com/docs/api-reference/assistants/deleteAssistant
+     *
+     * @throws OpenAIThrowable
      */
     public function delete(string $id): AssistantDeleteResponse
     {
@@ -85,6 +94,8 @@ final class Assistants implements AssistantsContract
      * @see https://platform.openai.com/docs/api-reference/assistants/listAssistants
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function list(array $parameters = []): AssistantListResponse
     {

--- a/src/Resources/Audio.php
+++ b/src/Resources/Audio.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\AudioContract;
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\Audio\SpeechStreamResponse;
 use OpenAI\Responses\Audio\TranscriptionResponse;
 use OpenAI\Responses\Audio\TranslationResponse;
@@ -21,6 +22,8 @@ final class Audio implements AudioContract
      * @see https://platform.openai.com/docs/api-reference/audio/createSpeech
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function speech(array $parameters): string
     {
@@ -35,6 +38,8 @@ final class Audio implements AudioContract
      * @see https://platform.openai.com/docs/api-reference/audio/createSpeech
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function speechStreamed(array $parameters): SpeechStreamResponse
     {
@@ -51,6 +56,8 @@ final class Audio implements AudioContract
      * @see https://platform.openai.com/docs/api-reference/audio/createTranscription
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function transcribe(array $parameters): TranscriptionResponse
     {
@@ -68,6 +75,8 @@ final class Audio implements AudioContract
      * @see https://platform.openai.com/docs/api-reference/audio/createTranslation
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function translate(array $parameters): TranslationResponse
     {

--- a/src/Resources/Chat.php
+++ b/src/Resources/Chat.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\ChatContract;
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\Chat\CreateResponse;
 use OpenAI\Responses\Chat\CreateStreamedResponse;
 use OpenAI\Responses\StreamResponse;
@@ -22,6 +23,8 @@ final class Chat implements ChatContract
      * @see https://platform.openai.com/docs/api-reference/chat/create
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function create(array $parameters): CreateResponse
     {
@@ -42,6 +45,8 @@ final class Chat implements ChatContract
      *
      * @param  array<string, mixed>  $parameters
      * @return StreamResponse<CreateStreamedResponse>
+     *
+     * @throws OpenAIThrowable
      */
     public function createStreamed(array $parameters): StreamResponse
     {

--- a/src/Resources/Completions.php
+++ b/src/Resources/Completions.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\CompletionsContract;
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\Completions\CreateResponse;
 use OpenAI\Responses\Completions\CreateStreamedResponse;
 use OpenAI\Responses\StreamResponse;
@@ -22,6 +23,8 @@ final class Completions implements CompletionsContract
      * @see https://platform.openai.com/docs/api-reference/completions/create-completion
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function create(array $parameters): CreateResponse
     {
@@ -42,6 +45,8 @@ final class Completions implements CompletionsContract
      *
      * @param  array<string, mixed>  $parameters
      * @return StreamResponse<CreateStreamedResponse>
+     *
+     * @throws OpenAIThrowable
      */
     public function createStreamed(array $parameters): StreamResponse
     {

--- a/src/Resources/Concerns/Streamable.php
+++ b/src/Resources/Concerns/Streamable.php
@@ -8,6 +8,8 @@ trait Streamable
 {
     /**
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws InvalidArgumentException
      */
     private function ensureNotStreamed(array $parameters): void
     {

--- a/src/Resources/Edits.php
+++ b/src/Resources/Edits.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\EditsContract;
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\Edits\CreateResponse;
 use OpenAI\ValueObjects\Transporter\Payload;
 use OpenAI\ValueObjects\Transporter\Response;
@@ -19,6 +20,8 @@ final class Edits implements EditsContract
      * @see https://platform.openai.com/docs/api-reference/edits/create
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      *
      * @deprecated OpenAI has deprecated this endpoint and will stop working by January 4, 2024.
      * https://openai.com/blog/gpt-4-api-general-availability#deprecation-of-the-edits-api

--- a/src/Resources/Embeddings.php
+++ b/src/Resources/Embeddings.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\EmbeddingsContract;
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\Embeddings\CreateResponse;
 use OpenAI\ValueObjects\Transporter\Payload;
 use OpenAI\ValueObjects\Transporter\Response;
@@ -19,6 +20,8 @@ final class Embeddings implements EmbeddingsContract
      * @see https://platform.openai.com/docs/api-reference/embeddings/create
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function create(array $parameters): CreateResponse
     {

--- a/src/Resources/Files.php
+++ b/src/Resources/Files.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\FilesContract;
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\Files\CreateResponse;
 use OpenAI\Responses\Files\DeleteResponse;
 use OpenAI\Responses\Files\ListResponse;
@@ -20,6 +21,8 @@ final class Files implements FilesContract
      * Returns a list of files that belong to the user's organization.
      *
      * @see https://platform.openai.com/docs/api-reference/files/list
+     *
+     * @throws OpenAIThrowable
      */
     public function list(): ListResponse
     {
@@ -35,6 +38,8 @@ final class Files implements FilesContract
      * Returns information about a specific file.
      *
      * @see https://platform.openai.com/docs/api-reference/files/retrieve
+     *
+     * @throws OpenAIThrowable
      */
     public function retrieve(string $file): RetrieveResponse
     {
@@ -50,6 +55,8 @@ final class Files implements FilesContract
      * Returns the contents of the specified file.
      *
      * @see https://platform.openai.com/docs/api-reference/files/retrieve-content
+     *
+     * @throws OpenAIThrowable
      */
     public function download(string $file): string
     {
@@ -64,6 +71,8 @@ final class Files implements FilesContract
      * @see https://platform.openai.com/docs/api-reference/files/upload
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function upload(array $parameters): CreateResponse
     {
@@ -79,6 +88,8 @@ final class Files implements FilesContract
      * Delete a file.
      *
      * @see https://platform.openai.com/docs/api-reference/files/delete
+     *
+     * @throws OpenAIThrowable
      */
     public function delete(string $file): DeleteResponse
     {

--- a/src/Resources/FineTunes.php
+++ b/src/Resources/FineTunes.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\FineTunesContract;
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\FineTunes\ListEventsResponse;
 use OpenAI\Responses\FineTunes\ListResponse;
 use OpenAI\Responses\FineTunes\RetrieveResponse;
@@ -25,6 +26,8 @@ final class FineTunes implements FineTunesContract
      * @see https://platform.openai.com/docs/api-reference/fine-tunes/create
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function create(array $parameters): RetrieveResponse
     {
@@ -40,6 +43,8 @@ final class FineTunes implements FineTunesContract
      * List your organization's fine-tuning jobs.
      *
      * @see https://platform.openai.com/docs/api-reference/fine-tunes/list
+     *
+     * @throws OpenAIThrowable
      */
     public function list(): ListResponse
     {
@@ -55,6 +60,8 @@ final class FineTunes implements FineTunesContract
      * Gets info about the fine-tune job.
      *
      * @see https://platform.openai.com/docs/api-reference/fine-tunes/list
+     *
+     * @throws OpenAIThrowable
      */
     public function retrieve(string $fineTuneId): RetrieveResponse
     {
@@ -70,6 +77,8 @@ final class FineTunes implements FineTunesContract
      * Immediately cancel a fine-tune job.
      *
      * @see https://platform.openai.com/docs/api-reference/fine-tunes/cancel
+     *
+     * @throws OpenAIThrowable
      */
     public function cancel(string $fineTuneId): RetrieveResponse
     {
@@ -85,6 +94,8 @@ final class FineTunes implements FineTunesContract
      * Get fine-grained status updates for a fine-tune job.
      *
      * @see https://platform.openai.com/docs/api-reference/fine-tunes/events
+     *
+     * @throws OpenAIThrowable
      */
     public function listEvents(string $fineTuneId): ListEventsResponse
     {
@@ -102,6 +113,8 @@ final class FineTunes implements FineTunesContract
      * @see https://platform.openai.com/docs/api-reference/fine-tunes/events
      *
      * @return StreamResponse<RetrieveStreamedResponseEvent>
+     *
+     * @throws OpenAIThrowable
      */
     public function listEventsStreamed(string $fineTuneId): StreamResponse
     {

--- a/src/Resources/FineTuning.php
+++ b/src/Resources/FineTuning.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\FineTuningContract;
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\FineTuning\ListJobEventsResponse;
 use OpenAI\Responses\FineTuning\ListJobsResponse;
 use OpenAI\Responses\FineTuning\RetrieveJobResponse;
@@ -23,6 +24,8 @@ final class FineTuning implements FineTuningContract
      * @see https://platform.openai.com/docs/api-reference/fine-tuning/create
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function createJob(array $parameters): RetrieveJobResponse
     {
@@ -40,6 +43,8 @@ final class FineTuning implements FineTuningContract
      * @see https://platform.openai.com/docs/api-reference/fine-tuning/undefined
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function listJobs(array $parameters = []): ListJobsResponse
     {
@@ -55,6 +60,8 @@ final class FineTuning implements FineTuningContract
      * Gets info about the fine-tune job.
      *
      * @see https://platform.openai.com/docs/api-reference/fine-tuning/retrieve
+     *
+     * @throws OpenAIThrowable
      */
     public function retrieveJob(string $jobId): RetrieveJobResponse
     {
@@ -70,6 +77,8 @@ final class FineTuning implements FineTuningContract
      * Immediately cancel a fine-tune job.
      *
      * @see https://platform.openai.com/docs/api-reference/fine-tuning/cancel
+     *
+     * @throws OpenAIThrowable
      */
     public function cancelJob(string $jobId): RetrieveJobResponse
     {
@@ -87,6 +96,8 @@ final class FineTuning implements FineTuningContract
      * @see https://platform.openai.com/docs/api-reference/fine-tuning/list-events
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function listJobEvents(string $jobId, array $parameters = []): ListJobEventsResponse
     {

--- a/src/Resources/Images.php
+++ b/src/Resources/Images.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\ImagesContract;
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\Images\CreateResponse;
 use OpenAI\Responses\Images\EditResponse;
 use OpenAI\Responses\Images\VariationResponse;
@@ -21,6 +22,8 @@ final class Images implements ImagesContract
      * @see https://platform.openai.com/docs/api-reference/images/create
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function create(array $parameters): CreateResponse
     {
@@ -38,6 +41,8 @@ final class Images implements ImagesContract
      * @see https://platform.openai.com/docs/api-reference/images/create-edit
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function edit(array $parameters): EditResponse
     {
@@ -55,6 +60,8 @@ final class Images implements ImagesContract
      * @see https://platform.openai.com/docs/api-reference/images/create-variation
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function variation(array $parameters): VariationResponse
     {

--- a/src/Resources/Models.php
+++ b/src/Resources/Models.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\ModelsContract;
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\Models\DeleteResponse;
 use OpenAI\Responses\Models\ListResponse;
 use OpenAI\Responses\Models\RetrieveResponse;
@@ -19,6 +20,8 @@ final class Models implements ModelsContract
      * Lists the currently available models, and provides basic information about each one such as the owner and availability.
      *
      * @see https://platform.openai.com/docs/api-reference/models/list
+     *
+     * @throws OpenAIThrowable
      */
     public function list(): ListResponse
     {
@@ -34,6 +37,8 @@ final class Models implements ModelsContract
      * Retrieves a model instance, providing basic information about the model such as the owner and permissioning.
      *
      * @see https://platform.openai.com/docs/api-reference/models/retrieve
+     *
+     * @throws OpenAIThrowable
      */
     public function retrieve(string $model): RetrieveResponse
     {
@@ -49,6 +54,8 @@ final class Models implements ModelsContract
      * Delete a fine-tuned model. You must have the Owner role in your organization.
      *
      * @see https://platform.openai.com/docs/api-reference/fine-tunes/delete-model
+     *
+     * @throws OpenAIThrowable
      */
     public function delete(string $model): DeleteResponse
     {

--- a/src/Resources/Moderations.php
+++ b/src/Resources/Moderations.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\ModerationsContract;
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\Moderations\CreateResponse;
 use OpenAI\ValueObjects\Transporter\Payload;
 use OpenAI\ValueObjects\Transporter\Response;
@@ -19,6 +20,8 @@ final class Moderations implements ModerationsContract
      * @see https://platform.openai.com/docs/api-reference/moderations/create
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function create(array $parameters): CreateResponse
     {

--- a/src/Resources/Threads.php
+++ b/src/Resources/Threads.php
@@ -7,6 +7,7 @@ namespace OpenAI\Resources;
 use OpenAI\Contracts\Resources\ThreadsContract;
 use OpenAI\Contracts\Resources\ThreadsMessagesContract;
 use OpenAI\Contracts\Resources\ThreadsRunsContract;
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\StreamResponse;
 use OpenAI\Responses\Threads\Runs\ThreadRunResponse;
 use OpenAI\Responses\Threads\Runs\ThreadRunStreamResponse;
@@ -26,6 +27,8 @@ final class Threads implements ThreadsContract
      * @see https://platform.openai.com/docs/api-reference/threads/createThread
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function create(array $parameters): ThreadResponse
     {
@@ -43,6 +46,8 @@ final class Threads implements ThreadsContract
      * @see https://platform.openai.com/docs/api-reference/runs/createThreadAndRun
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function createAndRun(array $parameters): ThreadRunResponse
     {
@@ -77,6 +82,8 @@ final class Threads implements ThreadsContract
      * Retrieves a thread.
      *
      * @see https://platform.openai.com/docs/api-reference/threads/getThread
+     *
+     * @throws OpenAIThrowable
      */
     public function retrieve(string $id): ThreadResponse
     {
@@ -94,6 +101,8 @@ final class Threads implements ThreadsContract
      * @see https://platform.openai.com/docs/api-reference/threads/modifyThread
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function modify(string $id, array $parameters): ThreadResponse
     {
@@ -109,6 +118,8 @@ final class Threads implements ThreadsContract
      * Delete an thread.
      *
      * @see https://platform.openai.com/docs/api-reference/threads/deleteThread
+     *
+     * @throws OpenAIThrowable
      */
     public function delete(string $id): ThreadDeleteResponse
     {

--- a/src/Resources/ThreadsMessages.php
+++ b/src/Resources/ThreadsMessages.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\ThreadsMessagesContract;
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\Threads\Messages\ThreadMessageDeleteResponse;
 use OpenAI\Responses\Threads\Messages\ThreadMessageListResponse;
 use OpenAI\Responses\Threads\Messages\ThreadMessageResponse;
@@ -21,6 +22,8 @@ final class ThreadsMessages implements ThreadsMessagesContract
      * @see https://platform.openai.com/docs/api-reference/messages/createMessage
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function create(string $threadId, array $parameters): ThreadMessageResponse
     {
@@ -36,6 +39,8 @@ final class ThreadsMessages implements ThreadsMessagesContract
      * Retrieve a message.
      *
      * @see https://platform.openai.com/docs/api-reference/messages/getMessage
+     *
+     * @throws OpenAIThrowable
      */
     public function retrieve(string $threadId, string $messageId): ThreadMessageResponse
     {
@@ -53,6 +58,8 @@ final class ThreadsMessages implements ThreadsMessagesContract
      * @see https://platform.openai.com/docs/api-reference/messages/modifyMessage
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function modify(string $threadId, string $messageId, array $parameters): ThreadMessageResponse
     {
@@ -85,6 +92,8 @@ final class ThreadsMessages implements ThreadsMessagesContract
      * @see https://platform.openai.com/docs/api-reference/messages/listMessages
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function list(string $threadId, array $parameters = []): ThreadMessageListResponse
     {

--- a/src/Resources/ThreadsRuns.php
+++ b/src/Resources/ThreadsRuns.php
@@ -6,6 +6,7 @@ namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\ThreadsRunsContract;
 use OpenAI\Contracts\Resources\ThreadsRunsStepsContract;
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\StreamResponse;
 use OpenAI\Responses\Threads\Runs\ThreadRunListResponse;
 use OpenAI\Responses\Threads\Runs\ThreadRunResponse;
@@ -24,6 +25,8 @@ final class ThreadsRuns implements ThreadsRunsContract
      * @see https://platform.openai.com/docs/api-reference/runs/createRun
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function create(string $threadId, array $parameters): ThreadRunResponse
     {
@@ -58,6 +61,8 @@ final class ThreadsRuns implements ThreadsRunsContract
      * Retrieves a run.
      *
      * @see https://platform.openai.com/docs/api-reference/runs/getRun
+     *
+     * @throws OpenAIThrowable
      */
     public function retrieve(string $threadId, string $runId): ThreadRunResponse
     {
@@ -75,6 +80,8 @@ final class ThreadsRuns implements ThreadsRunsContract
      * @see https://platform.openai.com/docs/api-reference/runs/modifyRun
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function modify(string $threadId, string $runId, array $parameters): ThreadRunResponse
     {
@@ -92,6 +99,8 @@ final class ThreadsRuns implements ThreadsRunsContract
      * @see https://platform.openai.com/docs/api-reference/runs/submitToolOutputs
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function submitToolOutputs(string $threadId, string $runId, array $parameters): ThreadRunResponse
     {
@@ -127,6 +136,8 @@ final class ThreadsRuns implements ThreadsRunsContract
      * Cancels a run that is `in_progress`.
      *
      * @see https://platform.openai.com/docs/api-reference/runs/cancelRun
+     *
+     * @throws OpenAIThrowable
      */
     public function cancel(string $threadId, string $runId): ThreadRunResponse
     {
@@ -144,6 +155,8 @@ final class ThreadsRuns implements ThreadsRunsContract
      * @see https://platform.openai.com/docs/api-reference/runs/listRuns
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function list(string $threadId, array $parameters = []): ThreadRunListResponse
     {

--- a/src/Resources/ThreadsRunsSteps.php
+++ b/src/Resources/ThreadsRunsSteps.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\ThreadsRunsStepsContract;
+use OpenAI\Exceptions\OpenAIThrowable;
 use OpenAI\Responses\Threads\Runs\Steps\ThreadRunStepListResponse;
 use OpenAI\Responses\Threads\Runs\Steps\ThreadRunStepResponse;
 use OpenAI\ValueObjects\Transporter\Payload;
@@ -18,6 +19,8 @@ final class ThreadsRunsSteps implements ThreadsRunsStepsContract
      * Retrieves a run step.
      *
      * @see https://platform.openai.com/docs/api-reference/runs/getRunStep
+     *
+     * @throws OpenAIThrowable
      */
     public function retrieve(string $threadId, string $runId, string $stepId): ThreadRunStepResponse
     {
@@ -35,6 +38,8 @@ final class ThreadsRunsSteps implements ThreadsRunsStepsContract
      * @see https://platform.openai.com/docs/api-reference/runs/listRunSteps
      *
      * @param  array<string, mixed>  $parameters
+     *
+     * @throws OpenAIThrowable
      */
     public function list(string $threadId, string $runId, array $parameters = []): ThreadRunStepListResponse
     {

--- a/src/Responses/Audio/SpeechStreamResponse.php
+++ b/src/Responses/Audio/SpeechStreamResponse.php
@@ -8,6 +8,7 @@ use OpenAI\Contracts\ResponseHasMetaInformationContract;
 use OpenAI\Contracts\ResponseStreamContract;
 use OpenAI\Responses\Meta\MetaInformation;
 use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
 
 /**
  * @implements ResponseStreamContract<string>
@@ -22,6 +23,8 @@ final class SpeechStreamResponse implements ResponseHasMetaInformationContract, 
 
     /**
      * {@inheritDoc}
+     *
+     * @throws RuntimeException
      */
     public function getIterator(): Generator
     {

--- a/src/Responses/StreamResponse.php
+++ b/src/Responses/StreamResponse.php
@@ -9,6 +9,7 @@ use OpenAI\Exceptions\ErrorException;
 use OpenAI\Responses\Meta\MetaInformation;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
+use RuntimeException;
 
 /**
  * @template TResponse
@@ -31,6 +32,8 @@ final class StreamResponse implements ResponseHasMetaInformationContract, Respon
 
     /**
      * {@inheritDoc}
+     *
+     * @throws ErrorException|RuntimeException
      */
     public function getIterator(): Generator
     {
@@ -71,6 +74,8 @@ final class StreamResponse implements ResponseHasMetaInformationContract, Respon
 
     /**
      * Read a line from the stream.
+     *
+     * @throws RuntimeException
      */
     private function readLine(StreamInterface $stream): string
     {


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature (?)

### Description:

HI @gehrisandro @nunomaduro, I recently used this library and got an API exception in production. Currently there is no `@throws` phpdoc above method to help the developer to be aware exception are thrown and which can be caught. 
`@throws` annotation allow tools like PHPStorm or PHPStan to report not caught exception. I tried to improve the documentation then.

- Since there are multiple exception in this library I introduced a `OpenAIThrowable` interface which allow to catch all of them.
- Then, I added `@throws OpenAIThrowable` to every method throwing an exception
- To be sure the documentation is up to date, I updated the phpstan config to check `@throws` tag: https://phpstan.org/blog/bring-your-exceptions-under-control
- Since `$response->getBody()->getContents();` throw a RuntimeException, I introduced a `UnreadableResponse` exception to encapsulate the default exception (and implements `OpenAIThrowable`).

Thanks.

### Related:

