### PR TITLE
fix: Make object and created in StreamedResponse optional

### DIFF
--- a/src/Responses/Chat/CreateStreamedResponse.php
+++ b/src/Responses/Chat/CreateStreamedResponse.php
@@ -45,8 +45,8 @@ final class CreateStreamedResponse implements ResponseContract
 
         return new self(
             $attributes['id'],
-            $attributes['object'],
-            $attributes['created'],
+            $attributes['object'] ?? '',
+            $attributes['created'] ?? time(),
             $attributes['model'],
             $choices,
         );


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the OpenAI PHP team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

If the endpoint does not return an `object` or `created`, an error no longer occurs.

