### PR TITLE
Switch to supported size for dall-e-3

### DIFF
--- a/README.md
+++ b/README.md
@@ -870,7 +870,7 @@ $response = $client->images()->create([
     'model' => 'dall-e-3',
     'prompt' => 'A cute baby sea otter',
     'n' => 1,
-    'size' => '256x256',
+    'size' => '1024x1024',
     'response_format' => 'url',
 ]);
 


### PR DESCRIPTION
### Description:

Just a quick readme update. It looks like 256x256 is an invalid size for the dall-e-3 model.

### Related:

See here for supported sizes: https://platform.openai.com/docs/api-reference/images/create#images-create-size
