### PR TITLE
Properly create meta information from azure headers

### DIFF
--- a/src/Responses/Meta/MetaInformation.php
+++ b/src/Responses/Meta/MetaInformation.php
@@ -37,21 +37,21 @@ final class MetaInformation implements MetaInformationContract
             'processingMs' => isset($headers['openai-processing-ms'][0]) ? (int) $headers['openai-processing-ms'][0] : null,
         ]);
 
-        if (isset($headers['x-ratelimit-limit-requests'][0])) {
+        if (isset($headers['x-ratelimit-remaining-requests'][0])) {
             $requestLimit = MetaInformationRateLimit::from([
-                'limit' => (int) $headers['x-ratelimit-limit-requests'][0],
+                'limit' => isset($headers['x-ratelimit-limit-requests'][0]) ? (int) $headers['x-ratelimit-limit-requests'][0] : null,
                 'remaining' => (int) $headers['x-ratelimit-remaining-requests'][0],
-                'reset' => $headers['x-ratelimit-reset-requests'][0],
+                'reset' => $headers['x-ratelimit-reset-requests'][0] ?? null,
             ]);
         } else {
             $requestLimit = null;
         }
 
-        if (isset($headers['x-ratelimit-limit-tokens'][0])) {
+        if (isset($headers['x-ratelimit-remaining-tokens'][0])) {
             $tokenLimit = MetaInformationRateLimit::from([
-                'limit' => (int) $headers['x-ratelimit-limit-tokens'][0],
+                'limit' => isset($headers['x-ratelimit-limit-tokens'][0]) ? (int) $headers['x-ratelimit-limit-tokens'][0] : null,
                 'remaining' => (int) $headers['x-ratelimit-remaining-tokens'][0],
-                'reset' => $headers['x-ratelimit-reset-tokens'][0],
+                'reset' => $headers['x-ratelimit-reset-tokens'][0] ?? null,
             ]);
         } else {
             $tokenLimit = null;

--- a/src/Responses/Meta/MetaInformationRateLimit.php
+++ b/src/Responses/Meta/MetaInformationRateLimit.php
@@ -5,14 +5,14 @@ namespace OpenAI\Responses\Meta;
 final class MetaInformationRateLimit
 {
     private function __construct(
-        public readonly int $limit,
+        public readonly ?int $limit,
         public readonly int $remaining,
-        public readonly string $reset,
+        public readonly ?string $reset,
     ) {
     }
 
     /**
-     * @param  array{limit: int, remaining: int, reset: string}  $attributes
+     * @param  array{limit: ?int, remaining: int, reset: ?string}  $attributes
      */
     public static function from(array $attributes): self
     {

--- a/tests/Fixtures/Meta.php
+++ b/tests/Fixtures/Meta.php
@@ -25,6 +25,8 @@ function metaHeadersFromAzure(): array
         'openai-model' => ['gpt-3.5-turbo-instruct'],
         'openai-processing-ms' => [3482.8264],
         'x-request-id' => ['3813fa4fa3f17bdf0d7654f0f49ebab4'],
+        'x-ratelimit-remaining-requests' => ['119'],
+        'x-ratelimit-remaining-tokens' => ['119968'],
     ];
 }
 

--- a/tests/Responses/Meta/MetaInformation.php
+++ b/tests/Responses/Meta/MetaInformation.php
@@ -47,6 +47,25 @@ test('from azure response headers', function () {
         ->openai->organization->toBeNull()
         ->openai->version->toBeNull()
         ->openai->processingMs->toBe(3482)
+        ->requestLimit->toBeInstanceOf(MetaInformationRateLimit::class)
+        ->requestLimit->limit->toBeNull()
+        ->requestLimit->remaining->toBe(119)
+        ->requestLimit->reset->toBeNull()
+        ->tokenLimit->toBeInstanceOf(MetaInformationRateLimit::class)
+        ->tokenLimit->limit->toBeNull()
+        ->tokenLimit->remaining->toBe(119968)
+        ->tokenLimit->reset->toBeNull();
+});
+
+test('from azure response headers without rate limit headers ', function () {
+    $headers = metaHeadersFromAzure();
+    unset($headers['x-ratelimit-remaining-requests']);
+    unset($headers['x-ratelimit-remaining-tokens']);
+
+    $meta = MetaInformation::from((new \GuzzleHttp\Psr7\Response(headers: $headers))->getHeaders());
+
+    expect($meta)
+        ->toBeInstanceOf(MetaInformation::class)
         ->requestLimit->toBeNull()
         ->tokenLimit->toBeNull();
 });
@@ -59,14 +78,8 @@ test('from azure response headers without processing time', function () {
 
     expect($meta)
         ->toBeInstanceOf(MetaInformation::class)
-        ->requestId->toBe('3813fa4fa3f17bdf0d7654f0f49ebab4')
         ->openai->toBeInstanceOf(MetaInformationOpenAI::class)
-        ->openai->model->toBe('gpt-3.5-turbo-instruct')
-        ->openai->organization->toBeNull()
-        ->openai->version->toBeNull()
-        ->openai->processingMs->toBeNull()
-        ->requestLimit->toBeNull()
-        ->tokenLimit->toBeNull();
+        ->openai->processingMs->toBeNull();
 });
 
 test('as array accessible', function () {
@@ -103,6 +116,8 @@ test('to array from azure', function () {
         ->toBe([
             'openai-model' => 'gpt-3.5-turbo-instruct',
             'openai-processing-ms' => 3482,
+            'x-ratelimit-remaining-requests' => 119,
+            'x-ratelimit-remaining-tokens' => 119968,
             'x-request-id' => '3813fa4fa3f17bdf0d7654f0f49ebab4',
         ]);
 });


### PR DESCRIPTION
Azure only returns a part of the rate limit headers. This PR extracts them properly.