### PR TITLE
Add default system_fingerprint to completion create response fixture

### DIFF
--- a/src/Responses/Completions/CreateResponse.php
+++ b/src/Responses/Completions/CreateResponse.php
@@ -32,6 +32,7 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
         public readonly string $object,
         public readonly int $created,
         public readonly string $model,
+        public readonly ?string $systemFingerprint,
         public readonly array $choices,
         public readonly CreateResponseUsage $usage,
         private readonly MetaInformation $meta,
@@ -41,7 +42,7 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{id: string, object: string, created: int, model: string, choices: array<int, array{text: string, index: int, logprobs: array{tokens: array<int, string>, token_logprobs: array<int, float>, top_logprobs: array<int, string>|null, text_offset: array<int, int>}|null, finish_reason: string}>, usage: array{prompt_tokens: int, completion_tokens: int|null, total_tokens: int}}  $attributes
+     * @param  array{id: string, object: string, created: int, model: string, system_fingerprint?: string, choices: array<int, array{text: string, index: int, logprobs: array{tokens: array<int, string>, token_logprobs: array<int, float>, top_logprobs: array<int, string>|null, text_offset: array<int, int>}|null, finish_reason: string}>, usage: array{prompt_tokens: int, completion_tokens: int|null, total_tokens: int}}  $attributes
      */
     public static function from(array $attributes, MetaInformation $meta): self
     {
@@ -54,6 +55,7 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
             $attributes['object'],
             $attributes['created'],
             $attributes['model'],
+            $attributes['system_fingerprint'] ?? null,
             $choices,
             CreateResponseUsage::from($attributes['usage']),
             $meta,

--- a/src/Testing/Responses/Fixtures/Completions/CreateResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Completions/CreateResponseFixture.php
@@ -9,6 +9,7 @@ final class CreateResponseFixture
         'object' => 'text_completion',
         'created' => 1_589_478_378,
         'model' => 'gpt-3.5-turbo-instruct',
+        'system_fingerprint' => null,
         'choices' => [
             [
                 'text' => "\n\nThis is a fake completion response.",

--- a/tests/Responses/Completions/CreateResponse.php
+++ b/tests/Responses/Completions/CreateResponse.php
@@ -49,10 +49,12 @@ test('fake with override', function () {
                 'text' => 'awesome!',
             ],
         ],
+        'system_fingerprint' => 'fp_44709d6fcb',
     ]);
 
     expect($response)
         ->id->toBe('cmpl-1234')
+        ->systemFingerprint->toBe('fp_44709d6fcb')
         ->and($response->choices[0])
         ->text->toBe('awesome!')
         ->index->toBe(0);


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the OpenAI PHP team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

<!-- describe what your PR is solving -->

This PR continues from #308 by also adding the [`system_fingerprint`](https://platform.openai.com/docs/api-reference/completions/object#completions/object-system_fingerprint) field to the Completions fixture and `CreateResponse` class. This allows the field to be set via the `CreateResponse.fake` method, which has been included in the `"fake with override"` Completion's test.

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->

- https://github.com/openai-php/client/issues/300
- https://github.com/openai-php/client/pull/308
