### PR TITLE
Add test case for function call with output not submitted yet

### DIFF
--- a/src/Responses/Threads/Runs/Steps/ThreadRunStepResponseFunction.php
+++ b/src/Responses/Threads/Runs/Steps/ThreadRunStepResponseFunction.php
@@ -37,7 +37,7 @@ final class ThreadRunStepResponseFunction implements ResponseContract
         return new self(
             $attributes['name'],
             $attributes['arguments'],
-            $attributes['output'],
+            $attributes['output'] ?? null,
         );
     }
 

--- a/tests/Fixtures/ThreadRunSteps.php
+++ b/tests/Fixtures/ThreadRunSteps.php
@@ -92,6 +92,42 @@ function threadRunStepWithCodeInterpreterOutputResource(): array
 /**
  * @return array<string, mixed>
  */
+function threadRunStepWithFunctionCallPendingOutputResource(): array
+{
+    return [
+        'id' => 'step_1spQXgbAabXFm1YXrwiGIMUz',
+        'object' => 'thread.run.step',
+        'created_at' => 1699564106,
+        'run_id' => 'run_fYijubpOJsKDnvtACWBS8C8r',
+        'assistant_id' => 'asst_EopvUEMh90bxkNRYEYM81Orc',
+        'thread_id' => 'thread_3WdOgtVuhD8aUIEx774Whkvo',
+        'type' => 'tool_calls',
+        'status' => 'in_progress',
+        'cancelled_at' => null,
+        'completed_at' => 1699564119,
+        'expires_at' => null,
+        'failed_at' => null,
+        'last_error' => null,
+        'step_details' => [
+            'type' => 'tool_calls',
+            'tool_calls' => [
+                [
+                    'id' => 'call_Fbg14X7kZF2WDzlPhpQ167De',
+                    'type' => 'function',
+                    'function' => [
+                        'name' => 'add',
+                        'arguments' => '{ "a": 5, "b": 7 }',
+                    ],
+                ],
+            ],
+        ],
+        'metadata' => ['name' => 'the step name'],
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
 function threadRunStepListResource(): array
 {
     return [

--- a/tests/Responses/Threads/Runs/Steps/ThreadRunStepResponseFunction.php
+++ b/tests/Responses/Threads/Runs/Steps/ThreadRunStepResponseFunction.php
@@ -10,6 +10,14 @@ test('from', function () {
         ->output->toBe('12');
 });
 
+test('from function call with output not submitted', function () {
+    $result = ThreadRunStepResponseFunction::from(threadRunStepWithFunctionCallPendingOutputResource()['step_details']['tool_calls'][0]['function']);
+    expect($result)
+        ->name->toBe('add')
+        ->arguments->toBe('{ "a": 5, "b": 7 }')
+        ->output->toBeEmpty();
+});
+
 test('as array accessible', function () {
     $result = ThreadRunStepResponseFunction::from(threadRunStepWithCodeInterpreterOutputResource()['step_details']['tool_calls'][1]['function']);
 


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

When a retrieving the list of run step where their results have not submitted yet, it will trigger an error because `output` is missing from the `$attribute` array.


