### PR TITLE
OpenAI\Responses\Files\RetrieveResponse::__construct(): Argument #3 ($bytes) must be of type int, null given

### DIFF
--- a/src/Responses/Files/RetrieveResponse.php
+++ b/src/Responses/Files/RetrieveResponse.php
@@ -30,7 +30,7 @@ final class RetrieveResponse implements ResponseContract, ResponseHasMetaInforma
     private function __construct(
         public readonly string $id,
         public readonly string $object,
-        public readonly int $bytes,
+        public readonly int|null $bytes,
         public readonly int $createdAt,
         public readonly string $filename,
         public readonly string $purpose,


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the OpenAI PHP team to understand the PR and also work on it.
-->

### What:

- [X] Bug Fix
- [ ] New Feature

### Description:

in the response from OpenAI, bytes can be null. The construct here only accepts integers leading to an error. See bug report for more details (#323)

### Related:
solves reported bug #323 

