### PR TITLE
[Audio::transcribe] Add support for timestamp_granularities

### DIFF
--- a/src/Resources/Audio.php
+++ b/src/Resources/Audio.php
@@ -56,7 +56,7 @@ final class Audio implements AudioContract
     {
         $payload = Payload::upload('audio/transcriptions', $parameters);
 
-        /** @var Response<array{task: ?string, language: ?string, duration: ?float, segments: array<int, array{id: int, seek: int, start: float, end: float, text: string, tokens: array<int, int>, temperature: float, avg_logprob: float, compression_ratio: float, no_speech_prob: float, transient?: bool}>, text: string}> $response */
+        /** @var Response<array{task: ?string, language: ?string, duration: ?float, segments: array<int, array{id: int, seek: int, start: float, end: float, text: string, tokens: array<int, int>, temperature: float, avg_logprob: float, compression_ratio: float, no_speech_prob: float, transient?: bool}>, words: array<int, array{word: string, start: float, end: float}>, text: string}> $response */
         $response = $this->transporter->requestObject($payload);
 
         return TranscriptionResponse::from($response->data(), $response->meta());

--- a/src/Responses/Audio/TranscriptionResponse.php
+++ b/src/Responses/Audio/TranscriptionResponse.php
@@ -12,12 +12,12 @@ use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
- * @implements ResponseContract<array{task: ?string, language: ?string, duration: ?float, segments: array<int, array{id: int, seek: int, start: float, end: float, text: string, tokens: array<int, int>, temperature: float, avg_logprob: float, compression_ratio: float, no_speech_prob: float, transient?: bool}>, text: string}>
+ * @implements ResponseContract<array{task: ?string, language: ?string, duration: ?float, segments: array<int, array{id: int, seek: int, start: float, end: float, text: string, tokens: array<int, int>, temperature: float, avg_logprob: float, compression_ratio: float, no_speech_prob: float, transient?: bool}>, words: array<int, array{word: string, start: float, end: float}>, text: string}>
  */
 final class TranscriptionResponse implements ResponseContract, ResponseHasMetaInformationContract
 {
     /**
-     * @use ArrayAccessible<array{task: ?string, language: ?string, duration: ?float, segments: array<int, array{id: int, seek: int, start: float, end: float, text: string, tokens: array<int, int>, temperature: float, avg_logprob: float, compression_ratio: float, no_speech_prob: float, transient?: bool}>, text: string}>
+     * @use ArrayAccessible<array{task: ?string, language: ?string, duration: ?float, segments: array<int, array{id: int, seek: int, start: float, end: float, text: string, tokens: array<int, int>, temperature: float, avg_logprob: float, compression_ratio: float, no_speech_prob: float, transient?: bool}>, words: array<int, array{word: string, start: float, end: float}>, text: string}>
      */
     use ArrayAccessible;
 
@@ -26,12 +26,14 @@ final class TranscriptionResponse implements ResponseContract, ResponseHasMetaIn
 
     /**
      * @param  array<int, TranscriptionResponseSegment>  $segments
+     * @param  array<int, TranscriptionResponseWord>  $words
      */
     private function __construct(
         public readonly ?string $task,
         public readonly ?string $language,
         public readonly ?float $duration,
         public readonly array $segments,
+        public readonly array $words,
         public readonly string $text,
         private readonly MetaInformation $meta,
     ) {
@@ -40,7 +42,7 @@ final class TranscriptionResponse implements ResponseContract, ResponseHasMetaIn
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{task: ?string, language: ?string, duration: ?float, segments: array<int, array{id: int, seek: int, start: float, end: float, text: string, tokens: array<int, int>, temperature: float, avg_logprob: float, compression_ratio: float, no_speech_prob: float, transient?: bool}>, text: string}|string  $attributes
+     * @param  array{task: ?string, language: ?string, duration: ?float, segments: array<int, array{id: int, seek: int, start: float, end: float, text: string, tokens: array<int, int>, temperature: float, avg_logprob: float, compression_ratio: float, no_speech_prob: float, transient?: bool}>, words: array<int, array{word: string, start: float, end: float}>, text: string}|string  $attributes
      */
     public static function from(array|string $attributes, MetaInformation $meta): self
     {
@@ -52,11 +54,16 @@ final class TranscriptionResponse implements ResponseContract, ResponseHasMetaIn
             $result
         ), $attributes['segments']) : [];
 
+        $words = isset($attributes['words']) ? array_map(fn (array $result): TranscriptionResponseWord => TranscriptionResponseWord::from(
+            $result
+        ), $attributes['words']) : [];
+
         return new self(
             $attributes['task'] ?? null,
             $attributes['language'] ?? null,
             $attributes['duration'] ?? null,
             $segments,
+            $words,
             $attributes['text'],
             $meta,
         );
@@ -74,6 +81,10 @@ final class TranscriptionResponse implements ResponseContract, ResponseHasMetaIn
             'segments' => array_map(
                 static fn (TranscriptionResponseSegment $result): array => $result->toArray(),
                 $this->segments,
+            ),
+            'words' => array_map(
+                static fn (TranscriptionResponseWord $result): array => $result->toArray(),
+                $this->words,
             ),
             'text' => $this->text,
         ];

--- a/src/Responses/Audio/TranscriptionResponseWord.php
+++ b/src/Responses/Audio/TranscriptionResponseWord.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Responses\Audio;
+
+use OpenAI\Contracts\ResponseContract;
+use OpenAI\Responses\Concerns\ArrayAccessible;
+
+/**
+ * @implements ResponseContract<array{word: string, start: float, end: float}>
+ */
+final class TranscriptionResponseWord implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<array{word: string, start: float, end: float}>
+     */
+    use ArrayAccessible;
+
+    private function __construct(
+        public readonly string $word,
+        public readonly float $start,
+        public readonly float $end,
+    ) {
+    }
+
+    /**
+     * Acts as static factory, and returns a new Response instance.
+     *
+     * @param  array{word: string, start: float, end: float}  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            $attributes['word'],
+            $attributes['start'],
+            $attributes['end'],
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'word' => $this->word,
+            'start' => $this->start,
+            'end' => $this->end,
+        ];
+    }
+}

--- a/src/ValueObjects/Transporter/Payload.php
+++ b/src/ValueObjects/Transporter/Payload.php
@@ -164,7 +164,7 @@ final class Payload
             if ($this->contentType === ContentType::MULTIPART) {
                 $streamBuilder = new MultipartStreamBuilder($psr17Factory);
 
-                /** @var array<string, StreamInterface|string|int|float|bool> $parameters */
+                /** @var array<string, StreamInterface|string|int|float|bool|array<int, string>> $parameters */
                 $parameters = $this->parameters;
 
                 foreach ($parameters as $key => $value) {
@@ -172,7 +172,15 @@ final class Payload
                         $value = (string) $value;
                     }
 
-                    $streamBuilder->addResource($key, $value);
+                    // Support only one level of nested arrays
+                    if (is_array($value)) {
+                        foreach ($value as $nestedKey => $nestedValue) {
+                            $streamBuilder->addResource($key.'['.$nestedKey.']', $nestedValue);
+                        }
+                    } else {
+                        $streamBuilder->addResource($key, $value);
+                    }
+
                 }
 
                 $body = $streamBuilder->build();

--- a/tests/Fixtures/Audio.php
+++ b/tests/Fixtures/Audio.php
@@ -33,6 +33,81 @@ function audioTranscriptionVerboseJson(): array
                 'transient' => false,
             ],
         ],
+        'words' => [],
+        'text' => 'Hello, how are you?',
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function audioTranscriptionGranularitySegment(): array
+{
+    return [
+        'task' => 'transcribe',
+        'language' => 'english',
+        'duration' => 2.95,
+        'segments' => [
+            [
+                'id' => 0,
+                'seek' => 0,
+                'start' => 0.0,
+                'end' => 4.0,
+                'text' => ' Hello, how are you?',
+                'tokens' => [
+                    50364,
+                    2425,
+                    11,
+                    577,
+                    366,
+                    291,
+                    30,
+                    50564,
+                ],
+                'temperature' => 0.0,
+                'avg_logprob' => -0.45045216878255206,
+                'compression_ratio' => 0.7037037037037037,
+                'no_speech_prob' => 0.1076972484588623,
+                'transient' => false,
+            ],
+        ],
+        'words' => [],
+        'text' => 'Hello, how are you?',
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function audioTranscriptionGranularityWord(): array
+{
+    return [
+        'task' => 'transcribe',
+        'language' => 'english',
+        'duration' => 2.95,
+        'segments' => [],
+        'words' => [
+            [
+                'word' => 'Hello',
+                'start' => 0.31,
+                'end' => 0.92,
+            ],
+            [
+                'word' => 'how',
+                'start' => 1.0,
+                'end' => 1.55,
+            ],
+            [
+                'word' => 'are',
+                'start' => 1.56,
+                'end' => 1.88,
+            ],
+            [
+                'word' => 'you',
+                'start' => 1.88,
+                'end' => 2.16,
+            ],
+        ],
         'text' => 'Hello, how are you?',
     ];
 }


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the OpenAI PHP team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

This PR adds support for the new [`timestamp_granularities[]` property](https://platform.openai.com/docs/api-reference/audio/createTranscription) in Audio Transcriptions.

- Adds the ability to describe the granularity level of the transcription
- Processes the response to include `words`
- Adjusts the HTTPTransporter `Payload` class to support sending array-based data

Currently, attempting to pass in a granularity level array results in an error:

```php
$response = OpenAI::audio()->transcribe([
  'model' => 'whisper-1',
  'file' => $file
  'response_format' => 'verbose_json',
  'timestamp_granularities' => ['word'],
]);
```

Exception:

```
First argument to "Http\Message\MultipartStream\MultipartStreamBuilder::createStream()" must be a string, resource or StreamInterface.
```

My solution is to parse one level of array data. I'm not sure if this is the best solution, or if we ought to support recursive array parsing.
