### PR TITLE
Set default index of 0 if not defined by API server (e.g. OpenRouter)

### DIFF
--- a/src/Resources/Images.php
+++ b/src/Resources/Images.php
@@ -26,7 +26,7 @@ final class Images implements ImagesContract
     {
         $payload = Payload::create('images/generations', $parameters);
 
-        /** @var Response<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>}> $response */
+        /** @var Response<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}> $response */
         $response = $this->transporter->requestObject($payload);
 
         return CreateResponse::from($response->data(), $response->meta());
@@ -43,7 +43,7 @@ final class Images implements ImagesContract
     {
         $payload = Payload::upload('images/edits', $parameters);
 
-        /** @var Response<array{created: int, data: array<int, array{url?: string, b64_json?: string}>}> $response */
+        /** @var Response<array{created: int, data: array<int, array{url?: string, b64_json?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}> $response */
         $response = $this->transporter->requestObject($payload);
 
         return EditResponse::from($response->data(), $response->meta());
@@ -60,7 +60,7 @@ final class Images implements ImagesContract
     {
         $payload = Payload::upload('images/variations', $parameters);
 
-        /** @var Response<array{created: int, data: array<int, array{url?: string, b64_json?: string}>}> $response */
+        /** @var Response<array{created: int, data: array<int, array{url?: string, b64_json?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}> $response */
         $response = $this->transporter->requestObject($payload);
 
         return VariationResponse::from($response->data(), $response->meta());

--- a/src/Responses/Chat/CreateResponseChoice.php
+++ b/src/Responses/Chat/CreateResponseChoice.php
@@ -19,7 +19,7 @@ final class CreateResponseChoice
     public static function from(array $attributes): self
     {
         return new self(
-            $attributes['index'],
+            $attributes['index'] ?? 0,
             CreateResponseMessage::from($attributes['message']),
             $attributes['finish_reason'] ?? null,
         );

--- a/src/Responses/Chat/CreateResponseUsageCompletionTokensDetails.php
+++ b/src/Responses/Chat/CreateResponseUsageCompletionTokensDetails.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Responses\Chat;
+
+final class CreateResponseUsageCompletionTokensDetails
+{
+    private function __construct(
+        public readonly ?int $audioTokens,
+        public readonly ?int $reasoningTokens,
+        public readonly ?int $acceptedPredictionTokens,
+        public readonly ?int $rejectedPredictionTokens,
+    ) {
+    }
+
+    /**
+     * @param array{audio_tokens?:int|null, reasoning_tokens?:int|null, accepted_prediction_tokens?:int|null, rejected_prediction_tokens?:int|null} $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            $attributes['audio_tokens'] ?? null,
+            $attributes['reasoning_tokens'] ?? null,
+            $attributes['accepted_prediction_tokens'] ?? null,
+            $attributes['rejected_prediction_tokens'] ?? null,
+        );
+    }
+
+    /**
+     * @return array{audio_tokens?:int, reasoning_tokens?:int, accepted_prediction_tokens?:int, rejected_prediction_tokens?:int}
+     */
+    public function toArray(): array
+    {
+        $result = [];
+
+        if (! is_null($this->audioTokens)) {
+            $result['audio_tokens'] = $this->audioTokens;
+        }
+
+        if (! is_null($this->reasoningTokens)) {
+            $result['reasoning_tokens'] = $this->reasoningTokens;
+        }
+
+        if (! is_null($this->acceptedPredictionTokens)) {
+            $result['accepted_prediction_tokens'] = $this->acceptedPredictionTokens;
+        }
+
+        if (! is_null($this->rejectedPredictionTokens)) {
+            $result['rejected_prediction_tokens'] = $this->rejectedPredictionTokens;
+        }
+
+        return $result;
+    }
+} 

--- a/src/Responses/Chat/CreateResponseUsagePromptTokensDetails.php
+++ b/src/Responses/Chat/CreateResponseUsagePromptTokensDetails.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Responses\Chat;
+
+final class CreateResponseUsagePromptTokensDetails
+{
+    private function __construct(
+        public readonly ?int $audioTokens,
+        public readonly ?int $imageTokens,
+        public readonly ?int $textTokens,
+    ) {
+    }
+
+    /**
+     * @param array{audio_tokens?:int|null, image_tokens?:int|null, text_tokens?:int|null} $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            $attributes['audio_tokens'] ?? null,
+            $attributes['image_tokens'] ?? null,
+            $attributes['text_tokens'] ?? null,
+        );
+    }
+
+    /**
+     * @return array{audio_tokens?:int, image_tokens?:int, text_tokens?:int}
+     */
+    public function toArray(): array
+    {
+        $result = [];
+
+        if (! is_null($this->audioTokens)) {
+            $result['audio_tokens'] = $this->audioTokens;
+        }
+
+        if (! is_null($this->imageTokens)) {
+            $result['image_tokens'] = $this->imageTokens;
+        }
+
+        if (! is_null($this->textTokens)) {
+            $result['text_tokens'] = $this->textTokens;
+        }
+
+        return $result;
+    }
+} 

--- a/src/Responses/Chat/CreateStreamedResponseChoice.php
+++ b/src/Responses/Chat/CreateStreamedResponseChoice.php
@@ -19,7 +19,7 @@ final class CreateStreamedResponseChoice
     public static function from(array $attributes): self
     {
         return new self(
-            $attributes['index'],
+            $attributes['index'] ?? 0,
             CreateStreamedResponseDelta::from($attributes['delta']),
             $attributes['finish_reason'] ?? null,
         );

--- a/src/Responses/Completions/CreateResponseChoice.php
+++ b/src/Responses/Completions/CreateResponseChoice.php
@@ -21,7 +21,7 @@ final class CreateResponseChoice
     {
         return new self(
             $attributes['text'],
-            $attributes['index'],
+            $attributes['index'] ?? 0,
             $attributes['logprobs'] ? CreateResponseChoiceLogprobs::from($attributes['logprobs']) : null,
             $attributes['finish_reason'],
         );

--- a/src/Responses/Images/CreateResponse.php
+++ b/src/Responses/Images/CreateResponse.php
@@ -10,14 +10,15 @@ use OpenAI\Responses\Concerns\ArrayAccessible;
 use OpenAI\Responses\Concerns\HasMetaInformation;
 use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
+use OpenAI\Responses\Images\ImageResponseUsage;
 
 /**
- * @implements ResponseContract<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>}>
+ * @implements ResponseContract<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}>
  */
 final class CreateResponse implements ResponseContract, ResponseHasMetaInformationContract
 {
     /**
-     * @use ArrayAccessible<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>}>
+     * @use ArrayAccessible<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}>
      */
     use ArrayAccessible;
 
@@ -31,13 +32,15 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
         public readonly int $created,
         public readonly array $data,
         private readonly MetaInformation $meta,
+        public readonly ?ImageResponseUsage $usage,
     ) {
     }
 
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>}  $attributes
+     * @param  array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}  $attributes
+     * @param  MetaInformation  $meta
      */
     public static function from(array $attributes, MetaInformation $meta): self
     {
@@ -45,10 +48,13 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
             $result
         ), $attributes['data']);
 
+        $usage = isset($attributes['usage']) ? ImageResponseUsage::from($attributes['usage']) : null;
+
         return new self(
             $attributes['created'],
             $results,
             $meta,
+            $usage,
         );
     }
 
@@ -57,12 +63,28 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
      */
     public function toArray(): array
     {
-        return [
+        $data = array_map(
+            static fn (CreateResponseData $result): array => $result->toArray(),
+            $this->data,
+        );
+
+        $result = [
             'created' => $this->created,
-            'data' => array_map(
-                static fn (CreateResponseData $result): array => $result->toArray(),
-                $this->data,
-            ),
+            'data' => $data,
         ];
+
+        if ($this->usage !== null) {
+            $result['usage'] = $this->usage->toArray();
+        }
+
+        return $result;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function meta(): MetaInformation
+    {
+        return $this->meta;
     }
 }

--- a/src/Responses/Images/EditResponse.php
+++ b/src/Responses/Images/EditResponse.php
@@ -10,14 +10,15 @@ use OpenAI\Responses\Concerns\ArrayAccessible;
 use OpenAI\Responses\Concerns\HasMetaInformation;
 use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
+use OpenAI\Responses\Images\ImageResponseUsage;
 
 /**
- * @implements ResponseContract<array{created: int, data: array<int, array{url?: string, b64_json?: string}>}>
+ * @implements ResponseContract<array{created: int, data: array<int, array{url?: string, b64_json?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}>
  */
 final class EditResponse implements ResponseContract, ResponseHasMetaInformationContract
 {
     /**
-     * @use ArrayAccessible<array{created: int, data: array<int, array{url?: string, b64_json?: string}>}>
+     * @use ArrayAccessible<array{created: int, data: array<int, array{url?: string, b64_json?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}>
      */
     use ArrayAccessible;
 
@@ -31,13 +32,14 @@ final class EditResponse implements ResponseContract, ResponseHasMetaInformation
         public readonly int $created,
         public readonly array $data,
         private readonly MetaInformation $meta,
+        public readonly ?ImageResponseUsage $usage,
     ) {
     }
 
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{created: int, data: array<int, array{url?: string, b64_json?: string}>}  $attributes
+     * @param  array{created: int, data: array<int, array{url?: string, b64_json?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}  $attributes
      */
     public static function from(array $attributes, MetaInformation $meta): self
     {
@@ -45,10 +47,13 @@ final class EditResponse implements ResponseContract, ResponseHasMetaInformation
             $result
         ), $attributes['data']);
 
+        $usage = isset($attributes['usage']) ? ImageResponseUsage::from($attributes['usage']) : null;
+
         return new self(
             $attributes['created'],
             $results,
             $meta,
+            $usage,
         );
     }
 
@@ -57,12 +62,20 @@ final class EditResponse implements ResponseContract, ResponseHasMetaInformation
      */
     public function toArray(): array
     {
-        return [
+        $data = array_map(
+            static fn (EditResponseData $result): array => $result->toArray(),
+            $this->data,
+        );
+
+        $result = [
             'created' => $this->created,
-            'data' => array_map(
-                static fn (EditResponseData $result): array => $result->toArray(),
-                $this->data,
-            ),
+            'data' => $data,
         ];
+
+        if ($this->usage !== null) {
+            $result['usage'] = $this->usage->toArray();
+        }
+
+        return $result;
     }
 }

--- a/src/Responses/Images/ImageResponseUsage.php
+++ b/src/Responses/Images/ImageResponseUsage.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Responses\Images;
+
+use OpenAI\Contracts\ResponseContract;
+use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
+use OpenAI\Responses\Images\ImageResponseUsageInputTokensDetails;
+
+/**
+ * @implements ResponseContract<array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}>
+ */
+final class ImageResponseUsage implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}>
+     */
+    use ArrayAccessible;
+    use Fakeable;
+
+    private function __construct(
+        public readonly int $totalTokens,
+        public readonly int $inputTokens,
+        public readonly int $outputTokens,
+        public readonly ImageResponseUsageInputTokensDetails $inputTokensDetails,
+    ) {
+    }
+
+    /**
+     * Acts as static factory, and returns a new Response instance.
+     *
+     * @param  array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        $inputTokensDetails = ImageResponseUsageInputTokensDetails::from($attributes['input_tokens_details']);
+
+        return new self(
+            $attributes['total_tokens'],
+            $attributes['input_tokens'],
+            $attributes['output_tokens'],
+            $inputTokensDetails,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'total_tokens' => $this->totalTokens,
+            'input_tokens' => $this->inputTokens,
+            'output_tokens' => $this->outputTokens,
+            'input_tokens_details' => $this->inputTokensDetails->toArray(),
+        ];
+    }
+} 

--- a/src/Responses/Images/ImageResponseUsageInputTokensDetails.php
+++ b/src/Responses/Images/ImageResponseUsageInputTokensDetails.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Responses\Images;
+
+use OpenAI\Contracts\ResponseContract;
+use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * @implements ResponseContract<array{text_tokens: int, image_tokens: int}>
+ */
+final class ImageResponseUsageInputTokensDetails implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<array{text_tokens: int, image_tokens: int}>
+     */
+    use ArrayAccessible;
+    use Fakeable;
+
+    private function __construct(
+        public readonly int $textTokens,
+        public readonly int $imageTokens,
+    ) {
+    }
+
+    /**
+     * Acts as static factory, and returns a new Response instance.
+     *
+     * @param  array{text_tokens: int, image_tokens: int}  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            $attributes['text_tokens'],
+            $attributes['image_tokens'],
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'text_tokens' => $this->textTokens,
+            'image_tokens' => $this->imageTokens,
+        ];
+    }
+} 

--- a/src/Responses/Images/VariationResponse.php
+++ b/src/Responses/Images/VariationResponse.php
@@ -10,14 +10,15 @@ use OpenAI\Responses\Concerns\ArrayAccessible;
 use OpenAI\Responses\Concerns\HasMetaInformation;
 use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
+use OpenAI\Responses\Images\ImageResponseUsage;
 
 /**
- * @implements ResponseContract<array{created: int, data: array<int, array{url?: string, b64_json?: string}>}>
+ * @implements ResponseContract<array{created: int, data: array<int, array{url?: string, b64_json?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}>
  */
 final class VariationResponse implements ResponseContract, ResponseHasMetaInformationContract
 {
     /**
-     * @use ArrayAccessible<array{created: int, data: array<int, array{url?: string, b64_json?: string}>}>
+     * @use ArrayAccessible<array{created: int, data: array<int, array{url?: string, b64_json?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}>
      */
     use ArrayAccessible;
 
@@ -31,13 +32,14 @@ final class VariationResponse implements ResponseContract, ResponseHasMetaInform
         public readonly int $created,
         public readonly array $data,
         private readonly MetaInformation $meta,
+        public readonly ?ImageResponseUsage $usage,
     ) {
     }
 
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{created: int, data: array<int, array{url?: string, b64_json?: string}>}  $attributes
+     * @param  array{created: int, data: array<int, array{url?: string, b64_json?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}  $attributes
      */
     public static function from(array $attributes, MetaInformation $meta): self
     {
@@ -45,10 +47,13 @@ final class VariationResponse implements ResponseContract, ResponseHasMetaInform
             $result
         ), $attributes['data']);
 
+        $usage = isset($attributes['usage']) ? ImageResponseUsage::from($attributes['usage']) : null;
+
         return new self(
             $attributes['created'],
             $results,
             $meta,
+            $usage,
         );
     }
 
@@ -57,12 +62,20 @@ final class VariationResponse implements ResponseContract, ResponseHasMetaInform
      */
     public function toArray(): array
     {
-        return [
+        $data = array_map(
+            static fn (VariationResponseData $result): array => $result->toArray(),
+            $this->data,
+        );
+
+        $result = [
             'created' => $this->created,
-            'data' => array_map(
-                static fn (VariationResponseData $result): array => $result->toArray(),
-                $this->data,
-            ),
+            'data' => $data,
         ];
+
+        if ($this->usage !== null) {
+            $result['usage'] = $this->usage->toArray();
+        }
+
+        return $result;
     }
 }

--- a/tests/Fixtures/Chat.php
+++ b/tests/Fixtures/Chat.php
@@ -290,3 +290,211 @@ function chatCompletionStreamError()
 {
     return fopen(__DIR__.'/Streams/ChatCompletionCreateError.txt', 'r');
 }
+
+/**
+ * @return array<string, mixed>
+ */
+function chatCompletionWithLogProbs(): array
+{
+    return [
+        'id' => 'chatcmpl-123',
+        'object' => 'chat.completion',
+        'created' => 1677652288,
+        'model' => 'gpt-3.5-turbo',
+        'choices' => [
+            [
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => "\n\nHello there, how may I assist you today?",
+                ],
+                'logprobs' => [
+                    'content' => [
+                        [
+                            'token' => 'Hello',
+                            'logprob' => -0.0001,
+                            'bytes' => [72, 101, 108, 108, 111],
+                            'top_logprobs' => [
+                                [
+                                    'token' => 'Hello',
+                                    'logprob' => -0.0001,
+                                    'bytes' => [72, 101, 108, 108, 111],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'finish_reason' => 'stop',
+            ],
+        ],
+        'usage' => [
+            'prompt_tokens' => 9,
+            'completion_tokens' => 12,
+            'total_tokens' => 21,
+        ],
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function chatCompletionWithUsageDetails(): array
+{
+    return [
+        'id' => 'chatcmpl-123',
+        'object' => 'chat.completion',
+        'created' => 1677652288,
+        'model' => 'gpt-3.5-turbo',
+        'choices' => [
+            [
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => "\n\nHello there, how may I assist you today?",
+                ],
+                'logprobs' => null,
+                'finish_reason' => 'stop',
+            ],
+        ],
+        'usage' => [
+            'prompt_tokens' => 9,
+            'prompt_tokens_details' => [
+                'audio_tokens' => 0,
+                'image_tokens' => 0,
+                'text_tokens' => 9,
+            ],
+            'completion_tokens' => 12,
+            'completion_tokens_details' => [
+                'audio_tokens' => 0,
+                'reasoning_tokens' => 0,
+                'accepted_prediction_tokens' => 12,
+                'rejected_prediction_tokens' => 0,
+            ],
+            'total_tokens' => 21,
+        ],
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function chatCompletionOpenRouter(): array
+{
+    return [
+        'id' => 'gen-hPV4VUD2Jc8f59N2QPpK5n4834mR',
+        'model' => 'google/gemma-7b-it:free',
+        'choices' => [
+            [
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => 'Hello! How can I help you today?',
+                ],
+                'finish_reason' => 'stop',
+            ],
+        ],
+        'usage' => [
+            'prompt_tokens' => 13,
+            'completion_tokens' => 20,
+            'total_tokens' => 33,
+        ],
+        'created' => 1708000000,
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function chatCompletionOpenRouterOpenAI(): array
+{
+    return [
+        'id' => 'gen-hPV4VUD2Jc8f59N2QPpK5n4834mR',
+        'model' => 'openai/gpt-4-turbo-preview',
+        'choices' => [
+            [
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => 'Hello! How can I help you today?',
+                ],
+                'finish_reason' => 'stop',
+            ],
+        ],
+        'usage' => [
+            'prompt_tokens' => 21,
+            'prompt_tokens_details' => [
+                'text_tokens' => 21,
+            ],
+            'completion_tokens' => 21,
+            'completion_tokens_details' => [
+                'reasoning_tokens' => 0,
+                'accepted_prediction_tokens' => 21,
+                'rejected_prediction_tokens' => 0,
+            ],
+            'total_tokens' => 42,
+        ],
+        'created' => 1708000000,
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function chatCompletionOpenRouterGoogle(): array
+{
+    return [
+        'id' => 'gen-hPV4VUD2Jc8f59N2QPpK5n4834mR',
+        'model' => 'google/gemini-pro',
+        'choices' => [
+            [
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => 'Hello! How can I help you today?',
+                ],
+                'finish_reason' => 'stop',
+            ],
+        ],
+        'usage' => [
+            'prompt_tokens' => 10,
+            'completion_tokens' => 138,
+            'total_tokens' => 148,
+        ],
+        'created' => 1708000000,
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function chatCompletionOpenRouterXAI(): array
+{
+    return [
+        'id' => 'gen-hPV4VUD2Jc8f59N2QPpK5n4834mR',
+        'model' => 'xai/grok-1',
+        'choices' => [
+            [
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => 'Hello! How can I help you today?',
+                ],
+                'finish_reason' => 'stop',
+            ],
+        ],
+        'usage' => [
+            'prompt_tokens' => 21,
+            'prompt_tokens_details' => [
+                'text_tokens' => 21,
+            ],
+            'completion_tokens' => 36,
+            'completion_tokens_details' => [
+                'reasoning_tokens' => 0,
+                'accepted_prediction_tokens' => 36,
+                'rejected_prediction_tokens' => 0,
+            ],
+            'total_tokens' => 392, // xAI returns strange total_tokens
+        ],
+        'created' => 1708000000,
+    ];
+}

--- a/tests/Fixtures/Image.php
+++ b/tests/Fixtures/Image.php
@@ -105,3 +105,91 @@ function imageVariationWithB46Json(): array
         ],
     ];
 }
+
+/**
+ * @return array<string, mixed>
+ */
+function imageCreateWithUsage(): array
+{
+    return [
+        'created' => 1664136088,
+        'data' => [
+            [
+                'url' => 'https://openai.com/image.png',
+            ],
+        ],
+        'usage' => [
+            'total_tokens' => 100,
+            'input_tokens' => 50,
+            'output_tokens' => 50,
+            'input_tokens_details' => [
+                'text_tokens' => 10,
+                'image_tokens' => 40,
+            ],
+        ],
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function imageEditWithUsage(): array
+{
+    return [
+        'created' => 1664136088,
+        'data' => [
+            [
+                'url' => 'https://openai.com/image.png',
+            ],
+        ],
+        'usage' => [
+            'total_tokens' => 100,
+            'input_tokens' => 50,
+            'output_tokens' => 50,
+            'input_tokens_details' => [
+                'text_tokens' => 10,
+                'image_tokens' => 40,
+            ],
+        ],
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function imageVariationWithUsage(): array
+{
+    return [
+        'created' => 1664136088,
+        'data' => [
+            [
+                'url' => 'https://openai.com/image.png',
+            ],
+        ],
+        'usage' => [
+            'total_tokens' => 100,
+            'input_tokens' => 50,
+            'output_tokens' => 50,
+            'input_tokens_details' => [
+                'text_tokens' => 10,
+                'image_tokens' => 40,
+            ],
+        ],
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function imageCreateWithRevisedPrompt(): array
+{
+    return [
+        'created' => 1664136088,
+        'data' => [
+            [
+                'url' => 'https://openai.com/image.png',
+                'revised_prompt' => 'A cute baby sea otter with a pearl earring',
+            ],
+        ],
+    ];
+}

--- a/tests/Resources/Images.php
+++ b/tests/Resources/Images.php
@@ -7,6 +7,8 @@ use OpenAI\Responses\Images\EditResponseData;
 use OpenAI\Responses\Images\VariationResponse;
 use OpenAI\Responses\Images\VariationResponseData;
 use OpenAI\Responses\Meta\MetaInformation;
+use OpenAI\Responses\Images\ImageResponseUsage;
+use OpenAI\Responses\Images\ImageResponseUsageInputTokensDetails;
 
 test('create', function () {
     $client = mockClient('POST', 'images/generations', [
@@ -91,6 +93,215 @@ test('variation', function () {
 
     expect($result->data[0])
         ->url->toBe('https://openai.com/image.png');
+
+    expect($result->meta())
+        ->toBeInstanceOf(MetaInformation::class);
+});
+
+test('create with b64_json', function () {
+    $client = mockClient('POST', 'images/generations', [
+        'prompt' => 'A cute baby sea otter',
+        'n' => 1,
+        'size' => '256x256',
+        'response_format' => 'b64_json',
+    ], \OpenAI\ValueObjects\Transporter\Response::from(imageCreateWithB64Json(), metaHeaders()));
+
+    $result = $client->images()->create([
+        'prompt' => 'A cute baby sea otter',
+        'n' => 1,
+        'size' => '256x256',
+        'response_format' => 'b64_json',
+    ]);
+
+    expect($result)
+        ->toBeInstanceOf(CreateResponse::class)
+        ->created->toBe(1664136088)
+        ->data->toBeArray()->toHaveCount(1)
+        ->data->each->toBeInstanceOf(CreateResponseData::class);
+
+    expect($result->data[0])
+        ->b64_json->toBe('image_in_base64_format');
+
+    expect($result->meta())
+        ->toBeInstanceOf(MetaInformation::class);
+});
+
+test('create with usage', function () {
+    $this->fake->response(imageCreateWithUsage(), metaHeaders());
+
+    $client = mockClient('POST', 'images/generations', [
+        'prompt' => 'A cute baby sea otter',
+        'n' => 1,
+        'size' => '256x256',
+        'response_format' => 'url',
+    ], \OpenAI\ValueObjects\Transporter\Response::from(imageCreateWithUsage(), metaHeaders()));
+
+    $result = $client->images()->create([
+        'prompt' => 'A cute baby sea otter',
+        'n' => 1,
+        'size' => '256x256',
+        'response_format' => 'url',
+    ]);
+
+    expect($result)
+        ->toBeInstanceOf(CreateResponse::class)
+        ->created->toBe(1664136088)
+        ->data->toBeArray()->toHaveCount(1)
+        ->data->each->toBeInstanceOf(CreateResponseData::class);
+
+    expect($result->data[0])
+        ->url->toBe('https://openai.com/image.png');
+
+    expect($result->usage)
+        ->toBeInstanceOf(ImageResponseUsage::class)
+        ->usage->totalTokens->toBe(100)
+        ->usage->inputTokens->toBe(50)
+        ->usage->outputTokens->toBe(50)
+        ->usage->inputTokensDetails->toBeInstanceOf(ImageResponseUsageInputTokensDetails::class)
+        ->usage->inputTokensDetails->textTokens->toBe(10)
+        ->usage->inputTokensDetails->imageTokens->toBe(40);
+
+    expect($result->meta())
+        ->toBeInstanceOf(MetaInformation::class);
+});
+
+test('edit with b64_json', function () {
+    $client = mockClient('POST', 'images/edits', [
+        'image' => fileResourceResource(),
+        'mask' => fileResourceResource(),
+        'prompt' => 'A sunlit indoor lounge area with a pool containing a flamingo',
+        'n' => 1,
+        'size' => '256x256',
+        'response_format' => 'b64_json',
+    ], \OpenAI\ValueObjects\Transporter\Response::from(imageEditWithB64Json(), metaHeaders()), validateParams: false);
+
+    $result = $client->images()->edit([
+        'image' => fileResourceResource(),
+        'mask' => fileResourceResource(),
+        'prompt' => 'A sunlit indoor lounge area with a pool containing a flamingo',
+        'n' => 1,
+        'size' => '256x256',
+        'response_format' => 'b64_json',
+    ]);
+
+    expect($result)
+        ->toBeInstanceOf(EditResponse::class)
+        ->created->toBe(1664136088)
+        ->data->toBeArray()->toHaveCount(1)
+        ->data->each->toBeInstanceOf(EditResponseData::class);
+
+    expect($result->data[0])
+        ->b64_json->toBe('image_in_base64_format');
+
+    expect($result->meta())
+        ->toBeInstanceOf(MetaInformation::class);
+});
+
+test('edit with usage', function () {
+    $this->fake->response(imageEditWithUsage(), metaHeaders());
+
+    $client = mockClient('POST', 'images/edits', [
+        'image' => fileResourceResource(),
+        'mask' => fileResourceResource(),
+        'prompt' => 'A sunlit indoor lounge area with a pool containing a flamingo',
+        'n' => 1,
+        'size' => '256x256',
+        'response_format' => 'url',
+    ], \OpenAI\ValueObjects\Transporter\Response::from(imageEditWithUsage(), metaHeaders()), validateParams: false);
+
+    $result = $client->images()->edit([
+        'image' => fileResourceResource(),
+        'mask' => fileResourceResource(),
+        'prompt' => 'A sunlit indoor lounge area with a pool containing a flamingo',
+        'n' => 1,
+        'size' => '256x256',
+        'response_format' => 'url',
+    ]);
+
+    expect($result)
+        ->toBeInstanceOf(EditResponse::class)
+        ->created->toBe(1664136088)
+        ->data->toBeArray()->toHaveCount(1)
+        ->data->each->toBeInstanceOf(EditResponseData::class);
+
+    expect($result->data[0])
+        ->url->toBe('https://openai.com/image.png');
+
+    expect($result->usage)
+        ->toBeInstanceOf(ImageResponseUsage::class)
+        ->usage->totalTokens->toBe(100)
+        ->usage->inputTokens->toBe(50)
+        ->usage->outputTokens->toBe(50)
+        ->usage->inputTokensDetails->toBeInstanceOf(ImageResponseUsageInputTokensDetails::class)
+        ->usage->inputTokensDetails->textTokens->toBe(10)
+        ->usage->inputTokensDetails->imageTokens->toBe(40);
+
+    expect($result->meta())
+        ->toBeInstanceOf(MetaInformation::class);
+});
+
+test('variation with b64_json', function () {
+    $client = mockClient('POST', 'images/variations', [
+        'image' => fileResourceResource(),
+        'n' => 1,
+        'size' => '256x256',
+        'response_format' => 'b64_json',
+    ], \OpenAI\ValueObjects\Transporter\Response::from(imageVariationWithB64Json(), metaHeaders()), validateParams: false);
+
+    $result = $client->images()->variation([
+        'image' => fileResourceResource(),
+        'n' => 1,
+        'size' => '256x256',
+        'response_format' => 'b64_json',
+    ]);
+
+    expect($result)
+        ->toBeInstanceOf(VariationResponse::class)
+        ->created->toBe(1664136088)
+        ->data->toBeArray()->toHaveCount(1)
+        ->data->each->toBeInstanceOf(VariationResponseData::class);
+
+    expect($result->data[0])
+        ->b64_json->toBe('image_in_base64_format');
+
+    expect($result->meta())
+        ->toBeInstanceOf(MetaInformation::class);
+});
+
+test('variation with usage', function () {
+    $this->fake->response(imageVariationWithUsage(), metaHeaders());
+
+    $client = mockClient('POST', 'images/variations', [
+        'image' => fileResourceResource(),
+        'n' => 1,
+        'size' => '256x256',
+        'response_format' => 'url',
+    ], \OpenAI\ValueObjects\Transporter\Response::from(imageVariationWithUsage(), metaHeaders()));
+
+    $result = $client->images()->variation([
+        'image' => fileResourceResource(),
+        'n' => 1,
+        'size' => '256x256',
+        'response_format' => 'url',
+    ]);
+
+    expect($result)
+        ->toBeInstanceOf(VariationResponse::class)
+        ->created->toBe(1664136088)
+        ->data->toBeArray()->toHaveCount(1)
+        ->data->each->toBeInstanceOf(VariationResponseData::class);
+
+    expect($result->data[0])
+        ->url->toBe('https://openai.com/image.png');
+
+    expect($result->usage)
+        ->toBeInstanceOf(ImageResponseUsage::class)
+        ->usage->totalTokens->toBe(100)
+        ->usage->inputTokens->toBe(50)
+        ->usage->outputTokens->toBe(50)
+        ->usage->inputTokensDetails->toBeInstanceOf(ImageResponseUsageInputTokensDetails::class)
+        ->usage->inputTokensDetails->textTokens->toBe(10)
+        ->usage->inputTokensDetails->imageTokens->toBe(40);
 
     expect($result->meta())
         ->toBeInstanceOf(MetaInformation::class);

--- a/tests/Responses/Chat/CreateResponse.php
+++ b/tests/Responses/Chat/CreateResponse.php
@@ -3,6 +3,8 @@
 use OpenAI\Responses\Chat\CreateResponse;
 use OpenAI\Responses\Chat\CreateResponseChoice;
 use OpenAI\Responses\Chat\CreateResponseUsage;
+use OpenAI\Responses\Chat\CreateResponseUsageCompletionTokensDetails;
+use OpenAI\Responses\Chat\CreateResponseUsagePromptTokensDetails;
 use OpenAI\Responses\Meta\MetaInformation;
 
 test('from', function () {
@@ -69,6 +71,109 @@ test('from tool calls response', function () {
         ->choices->each->toBeInstanceOf(CreateResponseChoice::class)
         ->usage->toBeInstanceOf(CreateResponseUsage::class)
         ->meta()->toBeInstanceOf(MetaInformation::class);
+});
+
+test('from usage details response', function () {
+    $response = CreateResponse::from(chatCompletionWithUsageDetails(), meta());
+
+    expect($response->usage->promptTokensDetails)
+        ->toBeInstanceOf(CreateResponseUsagePromptTokensDetails::class)
+        ->audioTokens->toBe(0)
+        ->imageTokens->toBe(0)
+        ->textTokens->toBe(9);
+
+    expect($response->usage->completionTokensDetails)
+        ->toBeInstanceOf(CreateResponseUsageCompletionTokensDetails::class)
+        ->audioTokens->toBe(0)
+        ->reasoningTokens->toBe(0)
+        ->acceptedPredictionTokens->toBe(12)
+        ->rejectedPredictionTokens->toBe(0);
+});
+
+test('from OpenRouter response', function () {
+    $response = CreateResponse::from(chatCompletionOpenRouter(), meta());
+
+    expect($response)
+        ->toBeInstanceOf(CreateResponse::class)
+        ->id->toBe('gen-hPV4VUD2Jc8f59N2QPpK5n4834mR')
+        ->object->toBe('chat.completion')
+        ->created->toBe(1708000000)
+        ->model->toBe('google/gemma-7b-it:free')
+        ->choices->toBeArray()->toHaveCount(1)
+        ->choices->{0}->toBeInstanceOf(CreateResponseChoice::class)
+        ->usage->toBeInstanceOf(CreateResponseUsage::class)
+        ->meta()->toBeInstanceOf(MetaInformation::class);
+});
+
+test('from OpenRouter OpenAI response', function () {
+    $response = CreateResponse::from(chatCompletionOpenRouterOpenAI(), meta());
+
+    expect($response)
+        ->toBeInstanceOf(CreateResponse::class)
+        ->id->toBe('gen-hPV4VUD2Jc8f59N2QPpK5n4834mR')
+        ->object->toBe('chat.completion')
+        ->created->toBe(1708000000)
+        ->model->toBe('openai/gpt-4-turbo-preview')
+        ->choices->toBeArray()->toHaveCount(1)
+        ->choices->{0}->toBeInstanceOf(CreateResponseChoice::class)
+        ->usage->toBeInstanceOf(CreateResponseUsage::class)
+        ->meta()->toBeInstanceOf(MetaInformation::class);
+
+    expect($response->usage->promptTokensDetails)
+        ->toBeInstanceOf(CreateResponseUsagePromptTokensDetails::class)
+        ->audioTokens->toBeNull()
+        ->imageTokens->toBeNull()
+        ->textTokens->toBe(21);
+
+    expect($response->usage->completionTokensDetails)
+        ->toBeInstanceOf(CreateResponseUsageCompletionTokensDetails::class)
+        ->audioTokens->toBeNull()
+        ->reasoningTokens->toBe(0)
+        ->acceptedPredictionTokens->toBe(21)
+        ->rejectedPredictionTokens->toBe(0);
+});
+
+test('from OpenRouter Google response', function () {
+    $response = CreateResponse::from(chatCompletionOpenRouterGoogle(), meta());
+
+    expect($response)
+        ->toBeInstanceOf(CreateResponse::class)
+        ->id->toBe('gen-hPV4VUD2Jc8f59N2QPpK5n4834mR')
+        ->object->toBe('chat.completion')
+        ->created->toBe(1708000000)
+        ->model->toBe('google/gemini-pro')
+        ->choices->toBeArray()->toHaveCount(1)
+        ->choices->{0}->toBeInstanceOf(CreateResponseChoice::class)
+        ->usage->toBeInstanceOf(CreateResponseUsage::class)
+        ->meta()->toBeInstanceOf(MetaInformation::class);
+});
+
+test('from OpenRouter xAI response', function () {
+    $response = CreateResponse::from(chatCompletionOpenRouterXAI(), meta());
+
+    expect($response)
+        ->toBeInstanceOf(CreateResponse::class)
+        ->id->toBe('gen-hPV4VUD2Jc8f59N2QPpK5n4834mR')
+        ->object->toBe('chat.completion')
+        ->created->toBe(1708000000)
+        ->model->toBe('xai/grok-1')
+        ->choices->toBeArray()->toHaveCount(1)
+        ->choices->{0}->toBeInstanceOf(CreateResponseChoice::class)
+        ->usage->toBeInstanceOf(CreateResponseUsage::class)
+        ->meta()->toBeInstanceOf(MetaInformation::class);
+
+    expect($response->usage->promptTokensDetails)
+        ->toBeInstanceOf(CreateResponseUsagePromptTokensDetails::class)
+        ->audioTokens->toBeNull()
+        ->imageTokens->toBeNull()
+        ->textTokens->toBe(21);
+
+    expect($response->usage->completionTokensDetails)
+        ->toBeInstanceOf(CreateResponseUsageCompletionTokensDetails::class)
+        ->audioTokens->toBeNull()
+        ->reasoningTokens->toBe(0)
+        ->acceptedPredictionTokens->toBe(36)
+        ->rejectedPredictionTokens->toBe(0);
 });
 
 test('as array accessible', function () {

--- a/tests/Responses/Chat/CreateResponseChoice.php
+++ b/tests/Responses/Chat/CreateResponseChoice.php
@@ -21,6 +21,36 @@ test('from vision response', function () {
         ->finishReason->toBeNull();
 });
 
+test('from OpenRouter OpenAI response', function () {
+    $result = CreateResponseChoice::from(chatCompletionOpenRouterOpenAI()['choices'][0]);
+
+    expect($result)
+        ->index->toBe(0)
+        ->message->toBeInstanceOf(CreateResponseMessage::class)
+        ->logprobs->toBeNull()
+        ->finishReason->toBe('stop');
+});
+
+test('from OpenRouter Google response', function () {
+    $result = CreateResponseChoice::from(chatCompletionOpenRouterGoogle()['choices'][0]);
+
+    expect($result)
+        ->index->toBe(0)
+        ->message->toBeInstanceOf(CreateResponseMessage::class)
+        ->logprobs->toBeNull()
+        ->finishReason->toBe('stop');
+});
+
+test('from OpenRouter xAI response', function () {
+    $result = CreateResponseChoice::from(chatCompletionOpenRouterXAI()['choices'][0]);
+
+    expect($result)
+        ->index->toBe(0)
+        ->message->toBeInstanceOf(CreateResponseMessage::class)
+        ->logprobs->toBeNull()
+        ->finishReason->toBe('stop');
+});
+
 test('to array', function () {
     $result = CreateResponseChoice::from(chatCompletion()['choices'][0]);
 

--- a/tests/Responses/Images/CreateResponse.php
+++ b/tests/Responses/Images/CreateResponse.php
@@ -2,6 +2,8 @@
 
 use OpenAI\Responses\Images\CreateResponse;
 use OpenAI\Responses\Images\CreateResponseData;
+use OpenAI\Responses\Images\ImageResponseUsage;
+use OpenAI\Responses\Images\ImageResponseUsageInputTokensDetails;
 use OpenAI\Responses\Meta\MetaInformation;
 
 test('from with url', function () {
@@ -38,6 +40,13 @@ test('from with b64_json', function () {
         ->data->toBeArray()->toHaveCount(1)
         ->data->each->toBeInstanceOf(CreateResponseData::class)
         ->meta()->toBeInstanceOf(MetaInformation::class);
+
+    expect($response->data[0])
+        ->toBeInstanceOf(CreateResponseData::class)
+        ->url->toBeNull()
+        ->b64_json->toBe('image_in_base64_format');
+
+    expect($response->usage)->toBeNull();
 });
 
 test('as array accessible with b64_json', function () {
@@ -72,4 +81,62 @@ test('fake with override', function () {
 
     expect($response['data'][0])
         ->url->toBe('https://openai.com/new-image.png');
+});
+
+test('from with revised prompt', function () {
+    $response = CreateResponse::from(imageCreateWithRevisedPrompt(), meta());
+
+    expect($response)
+        ->toBeInstanceOf(CreateResponse::class)
+        ->created->toBe(1664136088)
+        ->data->toBeArray()->toHaveCount(1)
+        ->data->each->toBeInstanceOf(CreateResponseData::class)
+        ->data[0]->revised_prompt->toBe('A cute baby sea otter with a pearl earring')
+        ->meta()->toBeInstanceOf(MetaInformation::class);
+
+    expect($response->usage)->toBeNull();
+});
+
+test('from with usage', function () {
+    $response = CreateResponse::from(imageCreateWithUsage(), meta());
+
+    expect($response)
+        ->toBeInstanceOf(CreateResponse::class)
+        ->created->toBe(1664136088)
+        ->data->toBeArray()->toHaveCount(1);
+
+    expect($response->data[0])
+        ->toBeInstanceOf(CreateResponseData::class)
+        ->url->toBe('https://openai.com/image.png')
+        ->b64_json->toBeNull();
+
+    expect($response->usage)->toBeInstanceOf(ImageResponseUsage::class)
+        ->usage->totalTokens->toBe(100)
+        ->usage->inputTokens->toBe(50)
+        ->usage->outputTokens->toBe(50)
+        ->usage->inputTokensDetails->toBeInstanceOf(ImageResponseUsageInputTokensDetails::class)
+        ->usage->inputTokensDetails->textTokens->toBe(10)
+        ->usage->inputTokensDetails->imageTokens->toBe(40);
+});
+
+test('as array accessible', function () {
+    $response = CreateResponse::from(imageCreateWithUrl(), meta());
+
+    expect($response['created'])->toBe(1664136088);
+});
+
+test('to array', function () {
+    $response = CreateResponse::from(imageCreateWithUrl(), meta());
+
+    expect($response->toArray())
+        ->toBeArray()
+        ->toBe(imageCreateWithUrl());
+});
+
+test('to array with usage', function () {
+    $response = CreateResponse::from(imageCreateWithUsage(), meta());
+
+    expect($response->toArray())
+        ->toBeArray()
+        ->toBe(imageCreateWithUsage());
 });

--- a/tests/Responses/Images/EditResponse.php
+++ b/tests/Responses/Images/EditResponse.php
@@ -2,6 +2,8 @@
 
 use OpenAI\Responses\Images\EditResponse;
 use OpenAI\Responses\Images\EditResponseData;
+use OpenAI\Responses\Images\ImageResponseUsage;
+use OpenAI\Responses\Images\ImageResponseUsageInputTokensDetails;
 use OpenAI\Responses\Meta\MetaInformation;
 
 test('from with url', function () {
@@ -38,6 +40,13 @@ test('from with b64_json', function () {
         ->data->toBeArray()->toHaveCount(1)
         ->data->each->toBeInstanceOf(EditResponseData::class)
         ->meta()->toBeInstanceOf(MetaInformation::class);
+
+    expect($response->data[0])
+        ->toBeInstanceOf(EditResponseData::class)
+        ->url->toBeNull()
+        ->b64_json->toBe('image_in_base64_format');
+
+    expect($response->usage)->toBeNull();
 });
 
 test('as array accessible with b64_json', function () {
@@ -72,4 +81,48 @@ test('fake with override', function () {
 
     expect($response['data'][0])
         ->url->toBe('https://openai.com/new-image.png');
+});
+
+test('from with usage', function () {
+    $response = EditResponse::from(imageEditWithUsage(), meta());
+
+    expect($response)
+        ->toBeInstanceOf(EditResponse::class)
+        ->created->toBe(1664136088)
+        ->data->toBeArray()->toHaveCount(1);
+
+    expect($response->data[0])
+        ->toBeInstanceOf(EditResponseData::class)
+        ->url->toBe('https://openai.com/image.png')
+        ->b64_json->toBeNull();
+
+    expect($response->usage)->toBeInstanceOf(ImageResponseUsage::class)
+        ->usage->totalTokens->toBe(100)
+        ->usage->inputTokens->toBe(50)
+        ->usage->outputTokens->toBe(50)
+        ->usage->inputTokensDetails->toBeInstanceOf(ImageResponseUsageInputTokensDetails::class)
+        ->usage->inputTokensDetails->textTokens->toBe(10)
+        ->usage->inputTokensDetails->imageTokens->toBe(40);
+});
+
+test('as array accessible', function () {
+    $response = EditResponse::from(imageEditWithUrl(), meta());
+
+    expect($response['created'])->toBe(1664136088);
+});
+
+test('to array', function () {
+    $response = EditResponse::from(imageEditWithUrl(), meta());
+
+    expect($response->toArray())
+        ->toBeArray()
+        ->toBe(imageEditWithUrl());
+});
+
+test('to array with usage', function () {
+    $response = EditResponse::from(imageEditWithUsage(), meta());
+
+    expect($response->toArray())
+        ->toBeArray()
+        ->toBe(imageEditWithUsage());
 });

--- a/tests/Responses/Images/VariationResponse.php
+++ b/tests/Responses/Images/VariationResponse.php
@@ -2,6 +2,8 @@
 
 use OpenAI\Responses\Images\VariationResponse;
 use OpenAI\Responses\Images\VariationResponseData;
+use OpenAI\Responses\Images\ImageResponseUsage;
+use OpenAI\Responses\Images\ImageResponseUsageInputTokensDetails;
 use OpenAI\Responses\Meta\MetaInformation;
 
 test('from with url', function () {
@@ -38,6 +40,13 @@ test('from with b64_json', function () {
         ->data->toBeArray()->toHaveCount(1)
         ->data->each->toBeInstanceOf(VariationResponseData::class)
         ->meta()->toBeInstanceOf(MetaInformation::class);
+
+    expect($response->data[0])
+        ->toBeInstanceOf(VariationResponseData::class)
+        ->url->toBeNull()
+        ->b64_json->toBe('image_in_base64_format');
+
+    expect($response->usage)->toBeNull();
 });
 
 test('as array accessible with b64_json', function () {
@@ -72,4 +81,48 @@ test('fake with override', function () {
 
     expect($response['data'][0])
         ->url->toBe('https://openai.com/new-image.png');
+});
+
+test('from with usage', function () {
+    $response = VariationResponse::from(imageVariationWithUsage(), meta());
+
+    expect($response)
+        ->toBeInstanceOf(VariationResponse::class)
+        ->created->toBe(1664136088)
+        ->data->toBeArray()->toHaveCount(1);
+
+    expect($response->data[0])
+        ->toBeInstanceOf(VariationResponseData::class)
+        ->url->toBe('https://openai.com/image.png')
+        ->b64_json->toBeNull();
+
+    expect($response->usage)->toBeInstanceOf(ImageResponseUsage::class)
+        ->usage->totalTokens->toBe(100)
+        ->usage->inputTokens->toBe(50)
+        ->usage->outputTokens->toBe(50)
+        ->usage->inputTokensDetails->toBeInstanceOf(ImageResponseUsageInputTokensDetails::class)
+        ->usage->inputTokensDetails->textTokens->toBe(10)
+        ->usage->inputTokensDetails->imageTokens->toBe(40);
+});
+
+test('as array accessible', function () {
+    $response = VariationResponse::from(imageVariationWithUrl(), meta());
+
+    expect($response['created'])->toBe(1664136088);
+});
+
+test('to array', function () {
+    $response = VariationResponse::from(imageVariationWithUrl(), meta());
+
+    expect($response->toArray())
+        ->toBeArray()
+        ->toBe(imageVariationWithUrl());
+});
+
+test('to array with usage', function () {
+    $response = VariationResponse::from(imageVariationWithUsage(), meta());
+
+    expect($response->toArray())
+        ->toBeArray()
+        ->toBe(imageVariationWithUsage());
 });


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

By setting a different baseUri, this package is fully compatible with OpenRouter.ai, a service that supports many different AI models through a common interface (OpenAI's).

However, OpenRouter does not provide an "index" property in its responses, which causes the response to fail. Setting a default index of 0 fixes this problem.