### PR TITLE
fix: logprobs may not exist on completion response choice

### DIFF
--- a/src/Responses/Completions/CreateResponseChoice.php
+++ b/src/Responses/Completions/CreateResponseChoice.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenAI\Responses\Completions;
 
+
 final class CreateResponseChoice
 {
     private function __construct(
@@ -22,7 +23,7 @@ final class CreateResponseChoice
         return new self(
             $attributes['text'],
             $attributes['index'],
-            $attributes['logprobs'] ? CreateResponseChoiceLogprobs::from($attributes['logprobs']) : null,
+            key_exists('logprobs', $attributes) && $attributes['logprobs'] ? CreateResponseChoiceLogprobs::from($attributes['logprobs']) : null,
             $attributes['finish_reason'],
         );
     }


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the OpenAI PHP team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Some openai server implementation miss **logprobs** attributes (localai).

```sh
curl http://localhost:8000/v1/completions -H "Content-Type: application/json" -d '{
          "model": "custom",
          "prompt": "Calculate 2*2"
}'
```

```json
{
  "created": 1713099889,
  "object": "text_completion",
  "id": "59fd6975-64ff-4220-8576-9b6e3a6848b5",
  "model": "custom",
  "choices": [
    {
      "index": 0,
      "finish_reason": "stop",
      "text": "2 * 2 = 4"
    }
  ],
  "usage": {
    "prompt_tokens": 0,
    "completion_tokens": 11,
    "total_tokens": 11
  }
}
```

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
