### PR TITLE
Handle missing attributes for assistant streaming

### DIFF
--- a/src/Responses/Threads/Runs/Steps/Delta/ThreadRunStepDeltaResponse.php
+++ b/src/Responses/Threads/Runs/Steps/Delta/ThreadRunStepDeltaResponse.php
@@ -21,7 +21,7 @@ final class ThreadRunStepDeltaResponse implements ResponseContract
     use Fakeable;
 
     private function __construct(
-        public string $id,
+        public ?string $id,
         public string $object,
         public ThreadRunStepDeltaObject $delta,
     ) {
@@ -35,7 +35,7 @@ final class ThreadRunStepDeltaResponse implements ResponseContract
     public static function from(array $attributes): self
     {
         return new self(
-            $attributes['id'],
+            $attributes['id'] ?? null,
             $attributes['object'],
             ThreadRunStepDeltaObject::from($attributes['delta']),
         );

--- a/src/Responses/Threads/Runs/Steps/ThreadRunStepResponseFunction.php
+++ b/src/Responses/Threads/Runs/Steps/ThreadRunStepResponseFunction.php
@@ -21,7 +21,7 @@ final class ThreadRunStepResponseFunction implements ResponseContract
     use Fakeable;
 
     private function __construct(
-        public string $name,
+        public ?string $name,
         public string $arguments,
         public ?string $output,
     ) {
@@ -35,7 +35,7 @@ final class ThreadRunStepResponseFunction implements ResponseContract
     public static function from(array $attributes): self
     {
         return new self(
-            $attributes['name'],
+            $attributes['name'] ?? null,
             $attributes['arguments'],
             $attributes['output'] ?? null,
         );

--- a/src/Responses/Threads/Runs/Steps/ThreadRunStepResponseFunctionToolCall.php
+++ b/src/Responses/Threads/Runs/Steps/ThreadRunStepResponseFunctionToolCall.php
@@ -24,7 +24,7 @@ final class ThreadRunStepResponseFunctionToolCall implements ResponseContract
      * @param  'function'  $type
      */
     private function __construct(
-        public string $id,
+        public ?string $id,
         public string $type,
         public ThreadRunStepResponseFunction $function,
     ) {
@@ -38,7 +38,7 @@ final class ThreadRunStepResponseFunctionToolCall implements ResponseContract
     public static function from(array $attributes): self
     {
         return new self(
-            $attributes['id'],
+            $attributes['id'] ?? null,
             $attributes['type'],
             ThreadRunStepResponseFunction::from($attributes['function']),
         );


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the OpenAI PHP team to understand the PR and also work on it.
-->

### What:

- [X] Bug Fix
- [ ] New Feature

### Description:

Fixes an error when OpenAI's API returns a delta object which has empty tool calls:

`Undefined array key "id" {"exception":"[object] (ErrorException(code: 0): Undefined array key \"id\" at /var/www/html/vendor/openai-php/client/src/Responses/Threads/Runs/Steps/ThreadRunStepResponseFunctionToolCall.php:41)`

```
(
    [id] => step_voklimBxRmx023PqaIxX6hya
    [object] => thread.run.step.delta
    [delta] => Array
        (
            [step_details] => Array
                (
                    [type] => tool_calls
                    [tool_calls] => Array
                        (
                            [0] => Array
                                (
                                    [index] => 0
                                    [type] => function
                                    [function] => Array
                                        (
                                            [arguments] => {}
                                        )
                                )
                        )
                )
        )
)
```

This is happening to me for all streamed assistant responses that invoke function calls, the function itself appears in one delta, and the next delta then shows the empty function above.

The current implementation is expecting these delta objects to have ID and name fields, which it seems the empty functions don't have.

This is related to the assistants streaming functionality merged in earlier today: https://github.com/openai-php/client/pull/367/