### PR TITLE
Fixing CreateResponseChoice text option for GPT4

### DIFF
--- a/src/Responses/Completions/CreateResponseChoice.php
+++ b/src/Responses/Completions/CreateResponseChoice.php
@@ -15,15 +15,15 @@ final class CreateResponseChoice
     }
 
     /**
-     * @param  array{text: string, index: int, logprobs: array{tokens: array<int, string>, token_logprobs: array<int, float>, top_logprobs: array<int, string>|null, text_offset: array<int, int>}|null, finish_reason: string|null}  $attributes
+    @param  array{text?: string, delta?: array{content: string}, index: int, logprobs?: array{tokens: array<int, string>, token_logprobs: array<int, float>, top_logprobs: array<int, string>|null, text_offset: array<int, int>}|null, finish_reason?: string|null}  $attributes
      */
     public static function from(array $attributes): self
     {
         return new self(
-            $attributes['text'],
-            $attributes['index'],
-            $attributes['logprobs'] ? CreateResponseChoiceLogprobs::from($attributes['logprobs']) : null,
-            $attributes['finish_reason'],
+            text: $attributes['text'] ?? $attributes['delta']['content'] ?? '',
+            index: $attributes['index'],
+            logprobs: $attributes['logprobs'] ? CreateResponseChoiceLogprobs::from($attributes['logprobs']) : null,
+            finishReason: $attributes['finish_reason'],
         );
     }
 

--- a/tests/Testing/Resources/CompletionsTestResource.php
+++ b/tests/Testing/Resources/CompletionsTestResource.php
@@ -38,3 +38,24 @@ it('records a streamed completions create request', function () {
             $parameters['prompt'] === 'PHP is ';
     });
 });
+
+it('records a streamed completions create request using GPT 4', function () {
+    $fake = new ClientFake([
+        CreateStreamedResponse::fake(),
+    ]);
+
+    $fake->completions()->createStreamed([
+        'model' => 'gpt-4o',
+        'messages' => [
+            ['role' => 'system', 'content' => "PHP is "]
+        ]
+    ]);
+
+    $fake->assertSent(Completions::class, function ($method, $parameters) {
+        return $method === 'createStreamed' &&
+            $parameters['model'] === 'gpt-4o' &&
+            is_array($parameters['messages']) &&
+            $parameters['messages'][0]['role'] === 'system' &&
+            $parameters['messages'][0]['content'] === 'PHP is ';
+    });
+});


### PR DESCRIPTION
Updating CreateResponseChoice to support gpt-4o model's responses

<!--
- Fill in the form below correctly. This will help the OpenAI PHP team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Using the new GPT 4o model, you can't use the `completion()->createStreamed()` method since response is now different. 

A) The base API Url needs to be manually set to `https://api.openai.com/v1/chat` when declaring a new client. 
B) The response from the completion includes "choices", but using GPT-4o model the text result now comes from `$attributes['delta']['content']` instead of `$attributes['test']`
