### PR TITLE
Add streamed response usage

### DIFF
--- a/src/Responses/Chat/CreateStreamedResponse.php
+++ b/src/Responses/Chat/CreateStreamedResponse.php
@@ -29,6 +29,7 @@ final class CreateStreamedResponse implements ResponseContract
         public readonly int $created,
         public readonly string $model,
         public readonly array $choices,
+        public readonly ?CreateResponseUsage $usage,
     ) {
     }
 
@@ -49,6 +50,7 @@ final class CreateStreamedResponse implements ResponseContract
             $attributes['created'],
             $attributes['model'],
             $choices,
+            isset($attributes['usage']) ? CreateResponseUsage::from($attributes['usage']) : null,
         );
     }
 
@@ -66,6 +68,7 @@ final class CreateStreamedResponse implements ResponseContract
                 static fn (CreateStreamedResponseChoice $result): array => $result->toArray(),
                 $this->choices,
             ),
+            'usage' => $this->usage?->toArray() ?? null,
         ];
     }
 }


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the OpenAI PHP team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Adds missing field when streaming called with [`stream_options`](https://platform.openai.com/docs/api-reference/chat/create#chat-create-stream_options)

### Related:
- #386
