### PR TITLE
Fix faking response metadata

### DIFF
--- a/src/Testing/Responses/Concerns/Fakeable.php
+++ b/src/Testing/Responses/Concerns/Fakeable.php
@@ -35,12 +35,8 @@ trait Fakeable
             unset($override[$key]);
         }
 
-        // we are going to append all remaining overrides with numeric keys
+        // we are going to append all remaining overrides
         foreach ($override as $key => $value) {
-            if (! is_numeric($key)) {
-                continue;
-            }
-
             $new[$key] = $value;
         }
 

--- a/tests/Responses/Assistants/AssistantResponse.php
+++ b/tests/Responses/Assistants/AssistantResponse.php
@@ -46,8 +46,13 @@ test('fake', function () {
 test('fake with override', function () {
     $response = AssistantResponse::fake([
         'id' => 'asst_1234',
+        'metadata' => [
+            'key' => 'value',
+        ],
     ]);
 
     expect($response)
-        ->id->toBe('asst_1234');
+        ->id->toBe('asst_1234')
+        ->metadata->toBeArray()
+        ->metadata->key->toBe('value');
 });


### PR DESCRIPTION
This PR fixes an error preventing the `metadata` key from being faked.

Fixes #409