### PR TITLE
Add thread messages delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -1280,6 +1280,23 @@ $response->metadata; // ['name' => 'My new message name']
 $response->toArray(); // ['id' => 'msg_SKYwvF3zcigxthfn6F4hnpdU', ...]
 ```
 
+#### `delete`
+
+Deletes a message.
+
+```php
+$response = $client->threads()->messages()->delete(
+    threadId: 'thread_tKFLqzRN9n7MnyKKvc1Q7868',
+    messageId: 'msg_SKYwvF3zcigxthfn6F4hnpdU'
+);
+
+$response->id; // 'msg_SKYwvF3zcigxthfn6F4hnpdU'
+$response->object; // 'thread.message.deleted'
+$response->deleted; // true
+
+$response->toArray(); // ['id' => 'msg_SKYwvF3zcigxthfn6F4hnpdU', ...]
+```
+
 #### `list`
 
 Returns a list of messages for a given thread.

--- a/src/Contracts/Resources/ThreadsMessagesContract.php
+++ b/src/Contracts/Resources/ThreadsMessagesContract.php
@@ -2,6 +2,7 @@
 
 namespace OpenAI\Contracts\Resources;
 
+use OpenAI\Responses\Threads\Messages\ThreadMessageDeleteResponse;
 use OpenAI\Responses\Threads\Messages\ThreadMessageListResponse;
 use OpenAI\Responses\Threads\Messages\ThreadMessageResponse;
 
@@ -31,6 +32,13 @@ interface ThreadsMessagesContract
      * @param  array<string, mixed>  $parameters
      */
     public function modify(string $threadId, string $messageId, array $parameters): ThreadMessageResponse;
+
+    /**
+     * Deletes a message.
+     *
+     * @see https://platform.openai.com/docs/api-reference/messages/deleteMessage
+     */
+    public function delete(string $threadId, string $messageId): ThreadMessageDeleteResponse;
 
     /**
      * Returns a list of messages for a given thread.

--- a/src/Resources/ThreadsMessages.php
+++ b/src/Resources/ThreadsMessages.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Resources;
 
 use OpenAI\Contracts\Resources\ThreadsMessagesContract;
+use OpenAI\Responses\Threads\Messages\ThreadMessageDeleteResponse;
 use OpenAI\Responses\Threads\Messages\ThreadMessageListResponse;
 use OpenAI\Responses\Threads\Messages\ThreadMessageResponse;
 use OpenAI\ValueObjects\Transporter\Payload;
@@ -61,6 +62,21 @@ final class ThreadsMessages implements ThreadsMessagesContract
         $response = $this->transporter->requestObject($payload);
 
         return ThreadMessageResponse::from($response->data(), $response->meta());
+    }
+
+    /**
+     * Deletes a message.
+     *
+     * @see https://platform.openai.com/docs/api-reference/messages/deleteMessage
+     */
+    public function delete(string $threadId, string $messageId): ThreadMessageDeleteResponse
+    {
+        $payload = Payload::delete("threads/$threadId/messages", $messageId);
+
+        /** @var Response<array{id: string, object: string, deleted: bool}> $response */
+        $response = $this->transporter->requestObject($payload);
+
+        return ThreadMessageDeleteResponse::from($response->data(), $response->meta());
     }
 
     /**

--- a/src/Responses/Threads/Messages/ThreadMessageDeleteResponse.php
+++ b/src/Responses/Threads/Messages/ThreadMessageDeleteResponse.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Responses\Threads\Messages;
+
+use OpenAI\Contracts\ResponseContract;
+use OpenAI\Contracts\ResponseHasMetaInformationContract;
+use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Responses\Concerns\HasMetaInformation;
+use OpenAI\Responses\Meta\MetaInformation;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * @implements ResponseContract<array{id: string, object: string, deleted: bool}>
+ */
+final class ThreadMessageDeleteResponse implements ResponseContract, ResponseHasMetaInformationContract
+{
+    /**
+     * @use ArrayAccessible<array{id: string, object: string, deleted: bool}>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+    use HasMetaInformation;
+
+    private function __construct(
+        public readonly string $id,
+        public readonly string $object,
+        public readonly bool $deleted,
+        private readonly MetaInformation $meta,
+    ) {
+    }
+
+    /**
+     * Acts as static factory, and returns a new Response instance.
+     *
+     * @param  array{id: string, object: string, deleted: bool}  $attributes
+     */
+    public static function from(array $attributes, MetaInformation $meta): self
+    {
+        return new self(
+            $attributes['id'],
+            $attributes['object'],
+            $attributes['deleted'],
+            $meta,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'object' => $this->object,
+            'deleted' => $this->deleted,
+        ];
+    }
+}

--- a/src/Testing/Resources/ThreadsMessagesTestResource.php
+++ b/src/Testing/Resources/ThreadsMessagesTestResource.php
@@ -4,6 +4,7 @@ namespace OpenAI\Testing\Resources;
 
 use OpenAI\Contracts\Resources\ThreadsMessagesContract;
 use OpenAI\Resources\ThreadsMessages;
+use OpenAI\Responses\Threads\Messages\ThreadMessageDeleteResponse;
 use OpenAI\Responses\Threads\Messages\ThreadMessageListResponse;
 use OpenAI\Responses\Threads\Messages\ThreadMessageResponse;
 use OpenAI\Testing\Resources\Concerns\Testable;
@@ -28,6 +29,11 @@ final class ThreadsMessagesTestResource implements ThreadsMessagesContract
     }
 
     public function modify(string $threadId, string $messageId, array $parameters): ThreadMessageResponse
+    {
+        return $this->record(__FUNCTION__, func_get_args());
+    }
+
+    public function delete(string $threadId, string $messageId): ThreadMessageDeleteResponse
     {
         return $this->record(__FUNCTION__, func_get_args());
     }

--- a/tests/Fixtures/ThreadMessage.php
+++ b/tests/Fixtures/ThreadMessage.php
@@ -81,3 +81,15 @@ function threadMessageListResource(): array
         'has_more' => false,
     ];
 }
+
+/**
+ * @return array<string, mixed>
+ */
+function threadMessageDeleteResource(): array
+{
+    return [
+        'id' => 'msg_KNsDDwE41BUAHhcPNpDkdHWZ',
+        'object' => 'thread.message.deleted',
+        'deleted' => true,
+    ];
+}

--- a/tests/Resources/ThreadsMessages.php
+++ b/tests/Resources/ThreadsMessages.php
@@ -1,6 +1,7 @@
 <?php
 
 use OpenAI\Responses\Meta\MetaInformation;
+use OpenAI\Responses\Threads\Messages\ThreadMessageDeleteResponse;
 use OpenAI\Responses\Threads\Messages\ThreadMessageListResponse;
 use OpenAI\Responses\Threads\Messages\ThreadMessageResponse;
 use OpenAI\Responses\Threads\Messages\ThreadMessageResponseAttachment;
@@ -128,6 +129,21 @@ test('retrieve', function () {
         ->runId->toBeNull()
         ->metadata->toBeArray()
         ->metadata->toBeEmpty();
+
+    expect($result->meta())
+        ->toBeInstanceOf(MetaInformation::class);
+});
+
+test('delete', function () {
+    $client = mockClient('DELETE', 'threads/thread_agvtHUGezjTCt4SKgQg0NJ2Y/messages/msg_KNsDDwE41BUAHhcPNpDkdHWZ', [], Response::from(threadMessageDeleteResource(), metaHeaders()));
+
+    $result = $client->threads()->messages()->delete('thread_agvtHUGezjTCt4SKgQg0NJ2Y', 'msg_KNsDDwE41BUAHhcPNpDkdHWZ');
+
+    expect($result)
+        ->toBeInstanceOf(ThreadMessageDeleteResponse::class)
+        ->id->toBe('msg_KNsDDwE41BUAHhcPNpDkdHWZ')
+        ->object->toBe('thread.message.deleted')
+        ->deleted->toBe(true);
 
     expect($result->meta())
         ->toBeInstanceOf(MetaInformation::class);

--- a/tests/Responses/Threads/Messages/ThreadMessageDeleteResponse.php
+++ b/tests/Responses/Threads/Messages/ThreadMessageDeleteResponse.php
@@ -1,0 +1,47 @@
+<?php
+
+use OpenAI\Responses\Meta\MetaInformation;
+use OpenAI\Responses\Threads\Messages\ThreadMessageDeleteResponse;
+
+test('from', function () {
+    $result = ThreadMessageDeleteResponse::from(threadMessageDeleteResource(), meta());
+
+    expect($result)
+        ->id->toBe('msg_KNsDDwE41BUAHhcPNpDkdHWZ')
+        ->object->toBe('thread.message.deleted')
+        ->deleted->toBe(true)
+        ->meta()->toBeInstanceOf(MetaInformation::class);
+});
+
+test('as array accessible', function () {
+    $result = ThreadMessageDeleteResponse::from(threadMessageDeleteResource(), meta());
+
+    expect($result['id'])
+        ->toBe('msg_KNsDDwE41BUAHhcPNpDkdHWZ');
+});
+
+test('to array', function () {
+    $result = ThreadMessageDeleteResponse::from(threadMessageDeleteResource(), meta());
+
+    expect($result->toArray())
+        ->toBe(threadMessageDeleteResource());
+});
+
+test('fake', function () {
+    $response = ThreadMessageDeleteResponse::fake();
+
+    expect($response)
+        ->id->toBe('msg_KNsDDwE41BUAHhcPNpDkdHWZ')
+        ->deleted->toBe(true);
+});
+
+test('fake with override', function () {
+    $response = ThreadMessageDeleteResponse::fake([
+        'id' => 'msg_1234',
+        'deleted' => false,
+    ]);
+
+    expect($response)
+        ->id->toBe('msg_1234')
+        ->deleted->toBe(false);
+});

--- a/tests/Testing/Resources/ThreadsMessagesTestResource.php
+++ b/tests/Testing/Resources/ThreadsMessagesTestResource.php
@@ -65,6 +65,20 @@ it('records a thread message modify request', function () {
     });
 });
 
+it('records a thread message delete request', function () {
+    $fake = new ClientFake([
+        \OpenAI\Responses\Threads\Messages\ThreadMessageDeleteResponse::fake(),
+    ]);
+
+    $fake->threads()->messages()->delete('thread_tKFLqzRN9n7MnyKKvc1Q7868', 'msg_KNsDDwE41BUAHhcPNpDkdHWZ');
+
+    $fake->assertSent(ThreadsMessages::class, function ($method, $threadId, $messageId) {
+        return $method === 'delete' &&
+            $threadId === 'thread_tKFLqzRN9n7MnyKKvc1Q7868' &&
+            $messageId === 'msg_KNsDDwE41BUAHhcPNpDkdHWZ';
+    });
+});
+
 it('records a thread message list request', function () {
     $fake = new ClientFake([
         ThreadMessageListResponse::fake(),


### PR DESCRIPTION
This PR adds the missing endpoint to delete messages from a thread: https://platform.openai.com/docs/api-reference/messages/deleteMessage

Implements #417 