### PR TITLE
Introduce OpenAIThrowable

### DIFF
--- a/src/Exceptions/ErrorException.php
+++ b/src/Exceptions/ErrorException.php
@@ -6,7 +6,7 @@ namespace OpenAI\Exceptions;
 
 use Exception;
 
-final class ErrorException extends Exception
+final class ErrorException extends Exception implements OpenAIThrowable
 {
     /**
      * Creates a new Exception instance.

--- a/src/Exceptions/InvalidArgumentException.php
+++ b/src/Exceptions/InvalidArgumentException.php
@@ -6,4 +6,4 @@ namespace OpenAI\Exceptions;
 
 use Exception;
 
-final class InvalidArgumentException extends Exception {}
+final class InvalidArgumentException extends Exception implements OpenAIThrowable {}

--- a/src/Exceptions/OpenAIThrowable.php
+++ b/src/Exceptions/OpenAIThrowable.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace OpenAI\Exceptions;
+
+use Throwable;
+
+interface OpenAIThrowable extends Throwable
+{
+}

--- a/src/Exceptions/OpenAIThrowable.php
+++ b/src/Exceptions/OpenAIThrowable.php
@@ -4,6 +4,4 @@ namespace OpenAI\Exceptions;
 
 use Throwable;
 
-interface OpenAIThrowable extends Throwable
-{
-}
+interface OpenAIThrowable extends Throwable {}

--- a/src/Exceptions/TransporterException.php
+++ b/src/Exceptions/TransporterException.php
@@ -7,7 +7,7 @@ namespace OpenAI\Exceptions;
 use Exception;
 use Psr\Http\Client\ClientExceptionInterface;
 
-final class TransporterException extends Exception
+final class TransporterException extends Exception implements OpenAIThrowable
 {
     /**
      * Creates a new Exception instance.

--- a/src/Exceptions/UnknownEventException.php
+++ b/src/Exceptions/UnknownEventException.php
@@ -6,4 +6,4 @@ namespace OpenAI\Exceptions;
 
 use Exception;
 
-final class UnknownEventException extends Exception {}
+final class UnknownEventException extends Exception implements OpenAIThrowable {}

--- a/src/Exceptions/UnserializableResponse.php
+++ b/src/Exceptions/UnserializableResponse.php
@@ -7,7 +7,7 @@ namespace OpenAI\Exceptions;
 use Exception;
 use JsonException;
 
-final class UnserializableResponse extends Exception
+final class UnserializableResponse extends Exception implements OpenAIThrowable
 {
     /**
      * Creates a new Exception instance.


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Hi @gehrisandro 

I'm trying to move https://github.com/openai-php/client/pull/287 forward by splitting it in 3 smaller PRs:
- First PR to introduce OpenAIThrowable
- Second PR to introduce UnreadableResponse exception
- Third PR with only Phpdoc update

The purpose of this PR is to provide an easy way to try/catch method of this lib:
- It avoids catching `\Exception` which catch everything
- It avoids catching `OpenAI\Exceptions\ErrorException|OpenAI\Exceptions\InvalidArgumentException|...` which is complicated and can miss an exception if a new one is introduced later.

### Related:

https://github.com/openai-php/client/pull/287
