### PR TITLE
fix: vector stores file batch cancel payload

### DIFF
--- a/src/Resources/VectorStoresFileBatches.php
+++ b/src/Resources/VectorStoresFileBatches.php
@@ -70,7 +70,7 @@ final class VectorStoresFileBatches implements VectorStoresFileBatchesContract
      */
     public function cancel(string $vectorStoreId, string $fileBatchId): VectorStoreFileBatchResponse
     {
-        $payload = Payload::delete("vector_stores/$vectorStoreId/file_batches", $fileBatchId);
+        $payload = Payload::cancel("vector_stores/$vectorStoreId/file_batches", $fileBatchId);
 
         /** @var Response<array{id: string, object: string, created_at: int, vector_store_id: string, status: string, file_counts: array{in_progress: int, completed: int, failed: int, cancelled: int, total: int}}> $response */
         $response = $this->transporter->requestObject($payload);

--- a/tests/Resources/VectorStoresFileBatches.php
+++ b/tests/Resources/VectorStoresFileBatches.php
@@ -44,7 +44,7 @@ test('retrieve', function () {
 });
 
 test('cancel', function () {
-    $client = mockClient('DELETE', 'vector_stores/vs_abc123/file_batches/vsfb_abc123', [], Response::from(vectorStoreFileBatchResource(), metaHeaders()));
+    $client = mockClient('POST', 'vector_stores/vs_abc123/file_batches/vsfb_abc123/cancel', [], Response::from(vectorStoreFileBatchResource(), metaHeaders()));
 
     $result = $client->vectorStores()->batches()->cancel('vs_abc123', 'vsfb_abc123');
 


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the OpenAI PHP team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:
\OpenAI\Resources\VectorStoresFileBatches::cancel should POST
<!-- describe what your PR is solving -->

### Related:
#433 
[OpenAI API Document](https://platform.openai.com/docs/api-reference/vector-stores-file-batches/cancelBatch)
<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
