### PR TITLE
Added API error separation by their HTTP codes

### DIFF
--- a/src/Exceptions/APIError.php
+++ b/src/Exceptions/APIError.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace OpenAI\Exceptions;
+
+use Psr\Http\Message\RequestInterface;
+
+class APIError extends ErrorException
+{
+    public function __construct(protected readonly RequestInterface $request, array $contents)
+    {
+        parent::__construct($contents);
+    }
+
+    public function getRequest(): RequestInterface
+    {
+        return $this->request;
+    }
+}

--- a/src/Exceptions/APIStatusError.php
+++ b/src/Exceptions/APIStatusError.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace OpenAI\Exceptions;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class APIStatusError extends APIError
+{
+    protected int $statusCode;
+    protected ?string $requestId;
+
+    public function __construct(RequestInterface $request, protected readonly ResponseInterface $response, array $contents)
+    {
+        parent::__construct($request, $contents);
+
+        $this->statusCode = $response->getStatusCode();
+        $this->requestId = $response->getHeader('x-request-id')[0] ?? null;
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+
+    public function getRequestId(): ?string
+    {
+        return $this->requestId;
+    }
+}

--- a/src/Exceptions/AuthenticationError.php
+++ b/src/Exceptions/AuthenticationError.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace OpenAI\Exceptions;
+
+class AuthenticationError extends APIStatusError
+{
+    protected int $statusCode = 401;
+}

--- a/src/Exceptions/BadRequestError.php
+++ b/src/Exceptions/BadRequestError.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace OpenAI\Exceptions;
+
+class BadRequestError extends APIStatusError
+{
+    protected int $statusCode = 400;
+}

--- a/src/Exceptions/ConflictError.php
+++ b/src/Exceptions/ConflictError.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace OpenAI\Exceptions;
+
+class ConflictError extends APIStatusError
+{
+    protected int $statusCode = 409;
+}

--- a/src/Exceptions/ErrorException.php
+++ b/src/Exceptions/ErrorException.php
@@ -6,14 +6,14 @@ namespace OpenAI\Exceptions;
 
 use Exception;
 
-final class ErrorException extends Exception
+class ErrorException extends Exception
 {
     /**
      * Creates a new Exception instance.
      *
      * @param  array{message: string|array<int, string>, type: ?string, code: string|int|null}  $contents
      */
-    public function __construct(private readonly array $contents)
+    public function __construct(protected readonly array $contents)
     {
         $message = ($contents['message'] ?: (string) $this->contents['code']) ?: 'Unknown error';
 

--- a/src/Exceptions/NotFoundError.php
+++ b/src/Exceptions/NotFoundError.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace OpenAI\Exceptions;
+
+class NotFoundError extends APIStatusError
+{
+    protected int $statusCode = 404;
+}

--- a/src/Exceptions/PermissionDeniedError.php
+++ b/src/Exceptions/PermissionDeniedError.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace OpenAI\Exceptions;
+
+class PermissionDeniedError extends APIStatusError
+{
+    protected int $statusCode = 403;
+}

--- a/src/Exceptions/RateLimitError.php
+++ b/src/Exceptions/RateLimitError.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace OpenAI\Exceptions;
+
+class RateLimitError extends APIStatusError
+{
+    protected int $statusCode = 429;
+}

--- a/src/Exceptions/UnprocessableEntityError.php
+++ b/src/Exceptions/UnprocessableEntityError.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace OpenAI\Exceptions;
+
+class UnprocessableEntityError extends APIStatusError
+{
+    protected int $statusCode = 422;
+}


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Added separation of API errors by their HTTP codes. This enhancement improves error handling by categorizing errors based on their HTTP status codes, allowing for more precise error management and debugging.

### Related:

https://github.com/openai-php/client/issues/402