### PR TITLE
Fix "image_url" in ThreadMessageResponseContentImageUrlObject.php

### DIFF
--- a/src/Responses/Threads/Messages/ThreadMessageResponseContentImageUrlObject.php
+++ b/src/Responses/Threads/Messages/ThreadMessageResponseContentImageUrlObject.php
@@ -38,7 +38,7 @@ final class ThreadMessageResponseContentImageUrlObject implements ResponseContra
     {
         return new self(
             $attributes['type'],
-            ThreadMessageResponseContentImageUrl::from($attributes['image_url']),
+            ThreadMessageResponseContentImageUrl::from($attributes),
         );
     }
 


### PR DESCRIPTION
### What:

- [X] Bug Fix
- [ ] New Feature

### Description:
There was an error with the passed attributes to the image_url object .

### Related:

Fixed the issue [456](https://github.com/openai-php/client/issues/456).
