### PR TITLE
Fix TypeError in VectorStoresFilesTestResource and VectorStoresFileBatchesTestResource

### DIFF
--- a/src/Testing/Resources/VectorStoresTestResource.php
+++ b/src/Testing/Resources/VectorStoresTestResource.php
@@ -47,11 +47,11 @@ final class VectorStoresTestResource implements VectorStoresContract
 
     public function files(): VectorStoresFilesContract
     {
-        return new VectorStoresFilesTestResource($this);
+        return new VectorStoresFilesTestResource($this->fake);
     }
 
     public function batches(): VectorStoresFileBatchesContract
     {
-        return new VectorStoresFileBatchesTestResource($this);
+        return new VectorStoresFileBatchesTestResource($this->fake);
     }
 }


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

The constructor of VectorStoresFilesTestResource and VectorStoresFileBatchesTestResource was receiving an incorrect parameter type, which resulted in a TypeError.
![image](https://github.com/user-attachments/assets/8c722943-c406-437c-a55f-bed04d0a0759)
