### PR TITLE
Add fake 64_json string to test image response

### DIFF
--- a/src/Testing/Responses/Fixtures/Images/CreateResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Images/CreateResponseFixture.php
@@ -9,6 +9,7 @@ final class CreateResponseFixture
         'data' => [
             [
                 'url' => 'https://openai.com/fake-image.png',
+                'b64_json' => 'fake-b64_json',
             ],
         ],
     ];


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

According to issue #340 it is not possible to receive a fake b64_json string when testing the image response. 
The PR solves this issue.

### Related:

[Issue #340](https://github.com/openai-php/client/issues/340)
