### PR TITLE
chore: handle all UnhandledMatchErrors

### DIFF
--- a/src/Exceptions/UnknownTypeException.php
+++ b/src/Exceptions/UnknownTypeException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Exceptions;
+
+use Exception;
+
+final class UnknownTypeException extends Exception
+{
+    public function __construct(private string $unknownType)
+    {
+        parent::__construct('Unknown type: '.$this->unknownType);
+    }
+
+    public function getType(): string
+    {
+        return $this->unknownType;
+    }
+}

--- a/src/Responses/Assistants/AssistantResponse.php
+++ b/src/Responses/Assistants/AssistantResponse.php
@@ -6,6 +6,7 @@ namespace OpenAI\Responses\Assistants;
 
 use OpenAI\Contracts\ResponseContract;
 use OpenAI\Contracts\ResponseHasMetaInformationContract;
+use OpenAI\Exceptions\UnknownTypeException;
 use OpenAI\Responses\Concerns\ArrayAccessible;
 use OpenAI\Responses\Concerns\HasMetaInformation;
 use OpenAI\Responses\Meta\MetaInformation;
@@ -43,13 +44,12 @@ final class AssistantResponse implements ResponseContract, ResponseHasMetaInform
         public ?float $topP,
         public string|AssistantResponseResponseFormat $responseFormat,
         private readonly MetaInformation $meta,
-    ) {
-    }
+    ) {}
 
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{id: string, object: string, created_at: int, name: ?string, description: ?string, model: string, instructions: ?string, tools: array<int, array{type: 'code_interpreter'}|array{type: 'file_search'}|array{type: 'function', function: array{description: string, name: string, parameters: array<string, mixed>}}>, tool_resources: ?array{code_interpreter?: array{file_ids: array<int,string>}, file_search?: array{vector_store_ids: array<int,string>}}, metadata: array<string, string>, temperature: ?float, top_p: ?float, response_format: string|array{type: 'text'|'json_object'}}  $attributes
+     * @param  array{id: string, object: string, created_at: int, name: ?string, description: ?string, model: string, instructions: ?string, tools: array<int, array{type: 'unknown'}|array{type: 'code_interpreter'}|array{type: 'file_search'}|array{type: 'function', function: array{description: string, name: string, parameters: array<string, mixed>}}>, tool_resources: ?array{code_interpreter?: array{file_ids: array<int,string>}, file_search?: array{vector_store_ids: array<int,string>}}, metadata: array<string, string>, temperature: ?float, top_p: ?float, response_format: string|array{type: 'text'|'json_object'}}  $attributes
      */
     public static function from(array $attributes, MetaInformation $meta): self
     {
@@ -58,6 +58,7 @@ final class AssistantResponse implements ResponseContract, ResponseHasMetaInform
                 'code_interpreter' => AssistantResponseToolCodeInterpreter::from($tool),
                 'file_search' => AssistantResponseToolFileSearch::from($tool),
                 'function' => AssistantResponseToolFunction::from($tool),
+                default => throw new UnknownTypeException($tool['type']),
             },
             $attributes['tools'],
         );

--- a/src/Responses/Threads/Messages/Delta/ThreadMessageDeltaObject.php
+++ b/src/Responses/Threads/Messages/Delta/ThreadMessageDeltaObject.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Responses\Threads\Messages\Delta;
 
 use OpenAI\Contracts\ResponseContract;
+use OpenAI\Exceptions\UnknownTypeException;
 use OpenAI\Responses\Concerns\ArrayAccessible;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
@@ -28,13 +29,12 @@ final class ThreadMessageDeltaObject implements ResponseContract
         public ?string $role,
         public array $content,
         public ?array $fileIds,
-    ) {
-    }
+    ) {}
 
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{role?: string, content: array<int, array{index: int, type: 'image_file', image_file: array{file_id: string, detail?: string}}|array{index: int, type: 'text', text: array{value?: string, annotations: array<int, array{type: 'file_citation', text: string, file_citation: array{file_id: string, quote?: string}, start_index: int, end_index: int}|array{type: 'file_path', text: string, file_path: array{file_id: string}, start_index: int, end_index: int}>}}>, file_ids?: array<int, string>}  $attributes
+     * @param  array{role?: string, content: array<int, array{type: 'unknown'}|array{index: int, type: 'image_file', image_file: array{file_id: string, detail?: string}}|array{index: int, type: 'text', text: array{value?: string, annotations: array<int, array{type: 'file_citation', text: string, file_citation: array{file_id: string, quote?: string}, start_index: int, end_index: int}|array{type: 'file_path', text: string, file_path: array{file_id: string}, start_index: int, end_index: int}>}}>, file_ids?: array<int, string>}  $attributes
      */
     public static function from(array $attributes): self
     {
@@ -42,6 +42,7 @@ final class ThreadMessageDeltaObject implements ResponseContract
             fn (array $content): ThreadMessageDeltaResponseContentTextObject|ThreadMessageDeltaResponseContentImageFileObject => match ($content['type']) {
                 'text' => ThreadMessageDeltaResponseContentTextObject::from($content),
                 'image_file' => ThreadMessageDeltaResponseContentImageFileObject::from($content),
+                default => throw new UnknownTypeException($content['type']),
             },
             $attributes['content'],
         );

--- a/src/Responses/Threads/Messages/Delta/ThreadMessageDeltaResponseContentText.php
+++ b/src/Responses/Threads/Messages/Delta/ThreadMessageDeltaResponseContentText.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Responses\Threads\Messages\Delta;
 
 use OpenAI\Contracts\ResponseContract;
+use OpenAI\Exceptions\UnknownTypeException;
 use OpenAI\Responses\Concerns\ArrayAccessible;
 use OpenAI\Responses\Threads\Messages\ThreadMessageResponseContentTextAnnotationFileCitationObject;
 use OpenAI\Responses\Threads\Messages\ThreadMessageResponseContentTextAnnotationFilePathObject;
@@ -28,13 +29,12 @@ final class ThreadMessageDeltaResponseContentText implements ResponseContract
     private function __construct(
         public ?string $value,
         public array $annotations,
-    ) {
-    }
+    ) {}
 
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{value?: string, annotations?: array<int, array{type: 'file_citation', text: string, file_citation: array{file_id: string, quote?: string}, start_index: int, end_index: int}|array{type: 'file_path', text: string, file_path: array{file_id: string}, start_index: int, end_index: int}>}  $attributes
+     * @param  array{value?: string, annotations?: array<int, array{type: 'unknown'}|array{type: 'file_citation', text: string, file_citation: array{file_id: string, quote?: string}, start_index: int, end_index: int}|array{type: 'file_path', text: string, file_path: array{file_id: string}, start_index: int, end_index: int}>}  $attributes
      */
     public static function from(array $attributes): self
     {
@@ -42,6 +42,7 @@ final class ThreadMessageDeltaResponseContentText implements ResponseContract
             fn (array $annotation): ThreadMessageResponseContentTextAnnotationFileCitationObject|ThreadMessageResponseContentTextAnnotationFilePathObject => match ($annotation['type']) {
                 'file_citation' => ThreadMessageResponseContentTextAnnotationFileCitationObject::from($annotation),
                 'file_path' => ThreadMessageResponseContentTextAnnotationFilePathObject::from($annotation),
+                default => throw new UnknownTypeException($annotation['type']),
             },
             $attributes['annotations'] ?? [],
         );

--- a/src/Responses/Threads/Messages/ThreadMessageResponse.php
+++ b/src/Responses/Threads/Messages/ThreadMessageResponse.php
@@ -6,6 +6,7 @@ namespace OpenAI\Responses\Threads\Messages;
 
 use OpenAI\Contracts\ResponseContract;
 use OpenAI\Contracts\ResponseHasMetaInformationContract;
+use OpenAI\Exceptions\UnknownTypeException;
 use OpenAI\Responses\Concerns\ArrayAccessible;
 use OpenAI\Responses\Concerns\HasMetaInformation;
 use OpenAI\Responses\Meta\MetaInformation;
@@ -41,13 +42,12 @@ final class ThreadMessageResponse implements ResponseContract, ResponseHasMetaIn
         public array $attachments,
         public array $metadata,
         private readonly MetaInformation $meta,
-    ) {
-    }
+    ) {}
 
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{id: string, object: string, created_at: int, thread_id: string, role: string, content: array<int, array{type: 'image_url', image_url: array{url: string, detail?: string}}|array{type: 'image_file', image_file: array{file_id: string, detail?: string}}|array{type: 'text', text: array{value: string, annotations: array<int, array{type: 'file_citation', text: string, file_citation: array{file_id: string, quote?: string}, start_index: int, end_index: int}|array{type: 'file_path', text: string, file_path: array{file_id: string}, start_index: int, end_index: int}>}}>, assistant_id: ?string, run_id: ?string, attachments: array<int, array{file_id: string, tools: array<int, array{type: 'file_search'}|array{type: 'code_interpreter'}>}>, metadata: array<string, string>}  $attributes
+     * @param  array{id: string, object: string, created_at: int, thread_id: string, role: string, content: array<int, array{type: 'unknown'}|array{type: 'image_url', image_url: array{url: string, detail?: string}}|array{type: 'image_file', image_file: array{file_id: string, detail?: string}}|array{type: 'text', text: array{value: string, annotations: array<int, array{type: 'file_citation', text: string, file_citation: array{file_id: string, quote?: string}, start_index: int, end_index: int}|array{type: 'file_path', text: string, file_path: array{file_id: string}, start_index: int, end_index: int}>}}>, assistant_id: ?string, run_id: ?string, attachments: array<int, array{file_id: string, tools: array<int, array{type: 'file_search'}|array{type: 'code_interpreter'}>}>, metadata: array<string, string>}  $attributes
      */
     public static function from(array $attributes, MetaInformation $meta): self
     {
@@ -56,6 +56,7 @@ final class ThreadMessageResponse implements ResponseContract, ResponseHasMetaIn
                 'text' => ThreadMessageResponseContentTextObject::from($content),
                 'image_file' => ThreadMessageResponseContentImageFileObject::from($content),
                 'image_url' => ThreadMessageResponseContentImageUrlObject::from($content),
+                default => throw new UnknownTypeException($content['type']),
             },
             $attributes['content'],
         );

--- a/src/Responses/Threads/Messages/ThreadMessageResponseAttachment.php
+++ b/src/Responses/Threads/Messages/ThreadMessageResponseAttachment.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Responses\Threads\Messages;
 
 use OpenAI\Contracts\ResponseContract;
+use OpenAI\Exceptions\UnknownTypeException;
 use OpenAI\Responses\Concerns\ArrayAccessible;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
@@ -26,19 +27,19 @@ final class ThreadMessageResponseAttachment implements ResponseContract
     private function __construct(
         public string $fileId,
         public array $tools,
-    ) {
-    }
+    ) {}
 
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{file_id: string, tools: array<int, array{type: 'file_search'}|array{type: 'code_interpreter'}>}  $attributes
+     * @param  array{file_id: string, tools: array<int, array{type: 'unknown'}|array{type: 'file_search'}|array{type: 'code_interpreter'}>}  $attributes
      */
     public static function from(array $attributes): self
     {
         $tools = array_map(fn (array $tool): ThreadMessageResponseAttachmentFileSearchTool|ThreadMessageResponseAttachmentCodeInterpreterTool => match ($tool['type']) {
             'file_search' => ThreadMessageResponseAttachmentFileSearchTool::from($tool),
             'code_interpreter' => ThreadMessageResponseAttachmentCodeInterpreterTool::from($tool),
+            default => throw new UnknownTypeException($tool['type']),
         }, $attributes['tools']);
 
         return new self(

--- a/src/Responses/Threads/Messages/ThreadMessageResponseContentText.php
+++ b/src/Responses/Threads/Messages/ThreadMessageResponseContentText.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Responses\Threads\Messages;
 
 use OpenAI\Contracts\ResponseContract;
+use OpenAI\Exceptions\UnknownTypeException;
 use OpenAI\Responses\Concerns\ArrayAccessible;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
@@ -26,13 +27,12 @@ final class ThreadMessageResponseContentText implements ResponseContract
     private function __construct(
         public string $value,
         public array $annotations,
-    ) {
-    }
+    ) {}
 
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{value: string, annotations: array<int, array{type: 'file_citation', text: string, file_citation: array{file_id: string, quote?: string}, start_index: int, end_index: int}|array{type: 'file_path', text: string, file_path: array{file_id: string}, start_index: int, end_index: int}>}  $attributes
+     * @param  array{value: string, annotations: array<int, array{type: 'unknown'}|array{type: 'file_citation', text: string, file_citation: array{file_id: string, quote?: string}, start_index: int, end_index: int}|array{type: 'file_path', text: string, file_path: array{file_id: string}, start_index: int, end_index: int}>}  $attributes
      */
     public static function from(array $attributes): self
     {
@@ -40,6 +40,7 @@ final class ThreadMessageResponseContentText implements ResponseContract
             fn (array $annotation): ThreadMessageResponseContentTextAnnotationFileCitationObject|ThreadMessageResponseContentTextAnnotationFilePathObject => match ($annotation['type']) {
                 'file_citation' => ThreadMessageResponseContentTextAnnotationFileCitationObject::from($annotation),
                 'file_path' => ThreadMessageResponseContentTextAnnotationFilePathObject::from($annotation),
+                default => throw new UnknownTypeException($annotation['type']),
             },
             $attributes['annotations'],
         );

--- a/src/Responses/Threads/Runs/Steps/Delta/ThreadRunStepDeltaObject.php
+++ b/src/Responses/Threads/Runs/Steps/Delta/ThreadRunStepDeltaObject.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Responses\Threads\Runs\Steps\Delta;
 
 use OpenAI\Contracts\ResponseContract;
+use OpenAI\Exceptions\UnknownTypeException;
 use OpenAI\Responses\Concerns\ArrayAccessible;
 use OpenAI\Responses\Threads\Runs\Steps\ThreadRunStepResponseMessageCreationStepDetails;
 use OpenAI\Responses\Threads\Runs\Steps\ThreadRunStepResponseToolCallsStepDetails;
@@ -24,19 +25,19 @@ final class ThreadRunStepDeltaObject implements ResponseContract
 
     private function __construct(
         public ThreadRunStepResponseMessageCreationStepDetails|ThreadRunStepResponseToolCallsStepDetails $stepDetails,
-    ) {
-    }
+    ) {}
 
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{step_details: array{type: 'tool_calls', tool_calls: array<int, array{id?: string, type: 'code_interpreter', code_interpreter: array{input: string, outputs?: array<int, array{type: 'image', image: array{file_id: string}}|array{type: 'logs', logs: string}>}}|array{id: string, type: 'file_search', file_search: array<string, string>}|array{id?: string, type: 'function', function: array{name?: string, arguments: string, output?: ?string}}>}|array{type: 'message_creation', message_creation: array{message_id: string}}}  $attributes
+     * @param  array{step_details: array{type: 'unknown'}|array{type: 'tool_calls', tool_calls: array<int, array{id?: string, type: 'code_interpreter', code_interpreter: array{input: string, outputs?: array<int, array{type: 'image', image: array{file_id: string}}|array{type: 'logs', logs: string}>}}|array{id: string, type: 'file_search', file_search: array<string, string>}|array{id?: string, type: 'function', function: array{name?: string, arguments: string, output?: ?string}}>}|array{type: 'message_creation', message_creation: array{message_id: string}}}  $attributes
      */
     public static function from(array $attributes): self
     {
         $stepDetails = match ($attributes['step_details']['type']) {
             'message_creation' => ThreadRunStepResponseMessageCreationStepDetails::from($attributes['step_details']),
             'tool_calls' => ThreadRunStepResponseToolCallsStepDetails::from($attributes['step_details']),
+            default => throw new UnknownTypeException($attributes['step_details']['type']),
         };
 
         return new self(

--- a/src/Responses/Threads/Runs/Steps/ThreadRunStepResponse.php
+++ b/src/Responses/Threads/Runs/Steps/ThreadRunStepResponse.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Responses\Threads\Runs\Steps;
 
 use OpenAI\Contracts\ResponseContract;
+use OpenAI\Exceptions\UnknownTypeException;
 use OpenAI\Responses\Concerns\ArrayAccessible;
 use OpenAI\Responses\Concerns\HasMetaInformation;
 use OpenAI\Responses\Meta\MetaInformation;
@@ -45,19 +46,19 @@ final class ThreadRunStepResponse implements ResponseContract
         public array $metadata,
         private readonly MetaInformation $meta,
         public ?ThreadRunStepResponseUsage $usage
-    ) {
-    }
+    ) {}
 
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{id: string, object: string, created_at: int, thread_id: string, assistant_id: string, run_id: string, type: string, status: string, step_details: array{type: 'tool_calls', tool_calls: array<int, array{id?: string, type: 'code_interpreter', code_interpreter: array{input: string, outputs: array<int, array{type: 'image', image: array{file_id: string}}|array{type: 'logs', logs: string}>}}|array{id: string, type: 'file_search', file_search: array<string, string>}|array{id?: string, type: 'function', function: array{name?: string, arguments: string, output?: ?string}}>}|array{type: 'message_creation', message_creation: array{message_id: string}}, last_error: ?array{code: string, message: string}, expires_at: ?int, cancelled_at: ?int, failed_at: ?int, completed_at: ?int, metadata?: array<string, string>, usage: ?array{prompt_tokens: int, completion_tokens: int, total_tokens: int}}  $attributes
+     * @param  array{id: string, object: string, created_at: int, thread_id: string, assistant_id: string, run_id: string, type: string, status: string, step_details: array{type: 'unknown'}|array{type: 'tool_calls', tool_calls: array<int, array{id?: string, type: 'code_interpreter', code_interpreter: array{input: string, outputs: array<int, array{type: 'image', image: array{file_id: string}}|array{type: 'logs', logs: string}>}}|array{id: string, type: 'file_search', file_search: array<string, string>}|array{id?: string, type: 'function', function: array{name?: string, arguments: string, output?: ?string}}>}|array{type: 'message_creation', message_creation: array{message_id: string}}, last_error: ?array{code: string, message: string}, expires_at: ?int, cancelled_at: ?int, failed_at: ?int, completed_at: ?int, metadata?: array<string, string>, usage: ?array{prompt_tokens: int, completion_tokens: int, total_tokens: int}}  $attributes
      */
     public static function from(array $attributes, MetaInformation $meta): self
     {
         $stepDetails = match ($attributes['step_details']['type']) {
             'message_creation' => ThreadRunStepResponseMessageCreationStepDetails::from($attributes['step_details']),
             'tool_calls' => ThreadRunStepResponseToolCallsStepDetails::from($attributes['step_details']),
+            default => throw new UnknownTypeException($attributes['step_details']['type']),
         };
 
         return new self(

--- a/src/Responses/Threads/Runs/Steps/ThreadRunStepResponseCodeInterpreter.php
+++ b/src/Responses/Threads/Runs/Steps/ThreadRunStepResponseCodeInterpreter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Responses\Threads\Runs\Steps;
 
 use OpenAI\Contracts\ResponseContract;
+use OpenAI\Exceptions\UnknownTypeException;
 use OpenAI\Responses\Concerns\ArrayAccessible;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
@@ -26,13 +27,12 @@ final class ThreadRunStepResponseCodeInterpreter implements ResponseContract
     private function __construct(
         public ?string $input,
         public ?array $outputs,
-    ) {
-    }
+    ) {}
 
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{input?: string, outputs?: array<int, array{type: 'image', image: array{file_id: string}}|array{type: 'logs', logs: string}>}  $attributes
+     * @param  array{input?: string, outputs?: array<int, array{type: 'unknown'}|array{type: 'image', image: array{file_id: string}}|array{type: 'logs', logs: string}>}  $attributes
      */
     public static function from(array $attributes): self
     {
@@ -40,6 +40,7 @@ final class ThreadRunStepResponseCodeInterpreter implements ResponseContract
             fn (array $output): \OpenAI\Responses\Threads\Runs\Steps\ThreadRunStepResponseCodeInterpreterOutputImage|\OpenAI\Responses\Threads\Runs\Steps\ThreadRunStepResponseCodeInterpreterOutputLogs => match ($output['type']) {
                 'image' => ThreadRunStepResponseCodeInterpreterOutputImage::from($output),
                 'logs' => ThreadRunStepResponseCodeInterpreterOutputLogs::from($output),
+                default => throw new UnknownTypeException($output['type']),
             },
             $attributes['outputs'] ?? [],
         );

--- a/src/Responses/Threads/Runs/Steps/ThreadRunStepResponseToolCallsStepDetails.php
+++ b/src/Responses/Threads/Runs/Steps/ThreadRunStepResponseToolCallsStepDetails.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace OpenAI\Responses\Threads\Runs\Steps;
 
 use OpenAI\Contracts\ResponseContract;
+use OpenAI\Exceptions\UnknownTypeException;
 use OpenAI\Responses\Concerns\ArrayAccessible;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
@@ -27,13 +28,12 @@ final class ThreadRunStepResponseToolCallsStepDetails implements ResponseContrac
     private function __construct(
         public string $type,
         public array $toolCalls,
-    ) {
-    }
+    ) {}
 
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{type: 'tool_calls', tool_calls: array<int, array{id?: string, type: 'code_interpreter', code_interpreter: array{input: string, outputs?: array<int, array{type: 'image', image: array{file_id: string}}|array{type: 'logs', logs: string}>}}|array{id: string, type: 'file_search', file_search: array<string, string>}|array{id?: string, type: 'function', function: array{name?: string, arguments: string, output?: ?string}}>}  $attributes
+     * @param  array{type: 'tool_calls', tool_calls: array<int, array{type: 'unknown'}|array{id?: string, type: 'code_interpreter', code_interpreter: array{input: string, outputs?: array<int, array{type: 'image', image: array{file_id: string}}|array{type: 'logs', logs: string}>}}|array{id: string, type: 'file_search', file_search: array<string, string>}|array{id?: string, type: 'function', function: array{name?: string, arguments: string, output?: ?string}}>}  $attributes
      */
     public static function from(array $attributes): self
     {
@@ -42,6 +42,7 @@ final class ThreadRunStepResponseToolCallsStepDetails implements ResponseContrac
                 'code_interpreter' => ThreadRunStepResponseCodeToolCall::from($toolCall),
                 'file_search' => ThreadRunStepResponseFileSearchToolCall::from($toolCall),
                 'function' => ThreadRunStepResponseFunctionToolCall::from($toolCall),
+                default => throw new UnknownTypeException($toolCall['type']),
             },
             $attributes['tool_calls'],
         );

--- a/src/Responses/Threads/Runs/ThreadRunResponse.php
+++ b/src/Responses/Threads/Runs/ThreadRunResponse.php
@@ -6,6 +6,7 @@ namespace OpenAI\Responses\Threads\Runs;
 
 use OpenAI\Contracts\ResponseContract;
 use OpenAI\Contracts\ResponseHasMetaInformationContract;
+use OpenAI\Exceptions\UnknownTypeException;
 use OpenAI\Responses\Assistants\AssistantResponseResponseFormat;
 use OpenAI\Responses\Concerns\ArrayAccessible;
 use OpenAI\Responses\Concerns\HasMetaInformation;
@@ -57,13 +58,12 @@ final class ThreadRunResponse implements ResponseContract, ResponseHasMetaInform
         public null|string|ThreadRunResponseToolChoice $toolChoice,
         public null|string|AssistantResponseResponseFormat $responseFormat,
         private readonly MetaInformation $meta,
-    ) {
-    }
+    ) {}
 
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{id: string, object: string, created_at: int, thread_id: string, assistant_id: string, status: string, required_action?: array{type: string, submit_tool_outputs: array{tool_calls: array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}}, last_error: ?array{code: string, message: string}, expires_at: ?int, started_at: ?int, cancelled_at: ?int, failed_at: ?int, completed_at: ?int, model: string, instructions: ?string, tools: array<int, array{type: 'code_interpreter'}|array{type: 'file_search'}|array{type: 'function', function: array{description: string, name: string, parameters: array<string, mixed>}}>, metadata: array<string, string>, usage?: array{prompt_tokens: int, completion_tokens: int|null, total_tokens: int}, incomplete_details: ?array{reason: string}, temperature: float|int|null, top_p: null|float|int, max_prompt_tokens: ?int, max_completion_tokens: ?int, truncation_strategy: ?array{type: string, last_messages: ?int}, tool_choice: null|string|array{type: string, function?: array{name: string}}, response_format: null|string|array{type: 'text'|'json_object'}}  $attributes
+     * @param  array{id: string, object: string, created_at: int, thread_id: string, assistant_id: string, status: string, required_action?: array{type: string, submit_tool_outputs: array{tool_calls: array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}}, last_error: ?array{code: string, message: string}, expires_at: ?int, started_at: ?int, cancelled_at: ?int, failed_at: ?int, completed_at: ?int, model: string, instructions: ?string, tools: array<int, array{type: 'unknown'}|array{type: 'code_interpreter'}|array{type: 'file_search'}|array{type: 'function', function: array{description: string, name: string, parameters: array<string, mixed>}}>, metadata: array<string, string>, usage?: array{prompt_tokens: int, completion_tokens: int|null, total_tokens: int}, incomplete_details: ?array{reason: string}, temperature: float|int|null, top_p: null|float|int, max_prompt_tokens: ?int, max_completion_tokens: ?int, truncation_strategy: ?array{type: string, last_messages: ?int}, tool_choice: null|string|array{type: string, function?: array{name: string}}, response_format: null|string|array{type: 'text'|'json_object'}}  $attributes
      */
     public static function from(array $attributes, MetaInformation $meta): self
     {
@@ -72,6 +72,7 @@ final class ThreadRunResponse implements ResponseContract, ResponseHasMetaInform
                 'code_interpreter' => ThreadRunResponseToolCodeInterpreter::from($tool),
                 'file_search' => ThreadRunResponseFileSearch::from($tool),
                 'function' => ThreadRunResponseToolFunction::from($tool),
+                default => throw new UnknownTypeException($tool['type']),
             },
             $attributes['tools'],
         );

--- a/tests/Arch.php
+++ b/tests/Arch.php
@@ -33,6 +33,7 @@ test('responses')->expect('OpenAI\Responses')->toOnlyUse([
     'OpenAI\Enums',
     'OpenAI\Exceptions\ErrorException',
     'OpenAI\Exceptions\UnknownEventException',
+    'OpenAI\Exceptions\UnknownTypeException',
     'OpenAI\Contracts',
     'OpenAI\Testing\Responses\Concerns',
     'Psr\Http\Message\ResponseInterface',


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the OpenAI PHP team to understand the PR and also work on it.
-->

### What:

- [X] Bug Fix
- [ ] New Feature

### Description:

Our sentry has been logged many times **UnhandledMatchError** with class ThreadRunStepResponseToolCallsStepDetails.

![截圖 2024-08-20 下午6 57 08](https://github.com/user-attachments/assets/4c10a31a-6b2c-48f0-a768-d1031165e07e)

So this PR try to throw wrapped exception like **ThreadRunStreamResponse** does for all matches.

### Related:

N/A
