### PR TITLE
Fix 'attachments' key exception on thread message modify

### DIFF
--- a/src/Responses/Threads/Messages/ThreadMessageResponse.php
+++ b/src/Responses/Threads/Messages/ThreadMessageResponse.php
@@ -61,7 +61,7 @@ final class ThreadMessageResponse implements ResponseContract, ResponseHasMetaIn
 
         $attachments = array_map(
             fn (array $attachment): ThreadMessageResponseAttachment => ThreadMessageResponseAttachment::from($attachment),
-            $attributes['attachments']
+            $attributes['attachments'] ?? []
         );
 
         return new self(


### PR DESCRIPTION
### What:

- [X] Bug Fix
- [ ] New Feature

### Description:

Modifying a thread message after creation throws an _attachments_ key exception. This uses the null coalescing operator to provide a fallback if the value is missing.

### Related:

Resolves #470 