### PR TITLE
fix critical issue: parsing messages with image_url

### DIFF
--- a/src/Responses/Threads/Messages/ThreadMessageResponseContentImageUrl.php
+++ b/src/Responses/Threads/Messages/ThreadMessageResponseContentImageUrl.php
@@ -14,14 +14,14 @@ use OpenAI\Testing\Responses\Concerns\Fakeable;
 final class ThreadMessageResponseContentImageUrl implements ResponseContract
 {
     /**
-     * @use ArrayAccessible<array{file_id: string, detail?: string}>
+     * @use ArrayAccessible<array{url: string, detail?: string}>
      */
     use ArrayAccessible;
 
     use Fakeable;
 
     private function __construct(
-        public string $url,
+        public string $imageUrl,
         public ?string $detail,
     ) {}
 
@@ -44,7 +44,7 @@ final class ThreadMessageResponseContentImageUrl implements ResponseContract
     public function toArray(): array
     {
         return array_filter([
-            'url' => $this->url,
+            'url' => $this->imageUrl,
             'detail' => $this->detail,
         ], fn (?string $value): bool => $value !== null);
     }

--- a/src/Responses/Threads/Messages/ThreadMessageResponseContentImageUrlObject.php
+++ b/src/Responses/Threads/Messages/ThreadMessageResponseContentImageUrlObject.php
@@ -25,7 +25,7 @@ final class ThreadMessageResponseContentImageUrlObject implements ResponseContra
      */
     private function __construct(
         public string $type,
-        public ThreadMessageResponseContentImageUrl $imageFile,
+        public ThreadMessageResponseContentImageUrl $imageUrl,
     ) {}
 
     /**
@@ -48,7 +48,7 @@ final class ThreadMessageResponseContentImageUrlObject implements ResponseContra
     {
         return [
             'type' => $this->type,
-            'image_url' => $this->imageFile->toArray(),
+            'image_url' => $this->imageUrl->toArray(),
         ];
     }
 }


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

I've experienced issue while using the #openai-php/laravel repo which depends on this repo.
The issue was related to messages with content type image_url instead of image_file. Parsing this type of file within the current structure of the project is wrong. I assume it's copy/paste issue because the structure of the classes that parse image_file response was the same as these for image_url response. 

With the current PR I'm solving this issue.

Here is the API reference:
https://platform.openai.com/docs/api-reference/messages/createMessage#messages-createmessage-content

### Related:
https://github.com/openai-php/client/issues/456
https://github.com/openai-php/laravel/issues/107
https://github.com/openai-php/laravel/issues/116
