### PR TITLE
Avoid naming confusion of variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ $client = OpenAI::factory()
     ->withOrganization('your-organization') // default: null
     ->withProject('Your Project') // default: null
     ->withBaseUri('openai.example.com/v1') // default: api.openai.com/v1
-    ->withHttpClient($client = new \GuzzleHttp\Client([])) // default: HTTP client found using PSR-18 HTTP Client Discovery
+    ->withHttpClient($httpClient = new \GuzzleHttp\Client([])) // default: HTTP client found using PSR-18 HTTP Client Discovery
     ->withHttpHeader('X-My-Header', 'foo')
     ->withQueryParam('my-param', 'bar')
-    ->withStreamHandler(fn (RequestInterface $request): ResponseInterface => $client->send($request, [
+    ->withStreamHandler(fn (RequestInterface $request): ResponseInterface => $httpClient->send($request, [
         'stream' => true // Allows to provide a custom stream handler for the http client.
     ]))
     ->make();


### PR DESCRIPTION
Make http $client different from openai $client variable names

<!--
- Fill in the form below correctly. This will help the OpenAI PHP team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description: 
Make http $client different from openai $client variable names
<!-- describe what your PR is solving -->

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
