### PR TITLE
Changed type of the description prop to nullable

### DIFF
--- a/src/Responses/Assistants/AssistantResponseToolFunctionFunction.php
+++ b/src/Responses/Assistants/AssistantResponseToolFunctionFunction.php
@@ -14,7 +14,7 @@ use OpenAI\Testing\Responses\Concerns\Fakeable;
 final class AssistantResponseToolFunctionFunction implements ResponseContract
 {
     /**
-     * @use ArrayAccessible<array{description: string, name: string, parameters: array<string, mixed>}>
+     * @use ArrayAccessible<array{description: string|null, name: string, parameters: array<string, mixed>}>
      */
     use ArrayAccessible;
 
@@ -24,7 +24,7 @@ final class AssistantResponseToolFunctionFunction implements ResponseContract
      * @param  array<string, mixed>  $parameters
      */
     private function __construct(
-        public string $description,
+        public string|null $description,
         public string $name,
         public array $parameters,
     ) {}


### PR DESCRIPTION
### What:

- [X] Bug Fix
- [ ] New Feature

### Description:

The description property of `\OpenAI\Responses\Assistants\AssistantResponseToolFunctionFunction` is nullable.

When creating an assistant with a function that does not have a description specified, I received an error:

```
OpenAI\Responses\Assistants\AssistantResponseToolFunctionFunction::__construct(): Argument #1 ($description) must be of type string, null given, called in /var/www/html/vendor/openai-php/client/src/Responses/Assistants/AssistantResponseToolFunctionFunction.php on line 40
```

OpenAI documentation: https://platform.openai.com/docs/api-reference/assistants/createAssistant

Exception
![Exception](https://github.com/user-attachments/assets/ce1e8027-58cd-4087-8d86-1b5ccd7aee08)

Source of response
![Source of response](https://github.com/user-attachments/assets/44c4a534-7508-4e2a-b109-186c5a770247)

Screenshot of documentation
![Screenshot of documentation](https://github.com/user-attachments/assets/a07c1ebc-a945-4acc-ac76-7b0e9a3b56c8)
