### PR TITLE
HTTP status in ErrorException

### DIFF
--- a/src/Exceptions/ErrorException.php
+++ b/src/Exceptions/ErrorException.php
@@ -12,7 +12,6 @@ final class ErrorException extends Exception
      * Creates a new Exception instance.
      *
      * @param  array{message: string|array<int, string>, type: ?string, code: string|int|null}  $contents
-     * @param int $statusCode
      */
     public function __construct(private readonly array $contents, private readonly int $statusCode)
     {

--- a/src/Exceptions/ErrorException.php
+++ b/src/Exceptions/ErrorException.php
@@ -12,8 +12,9 @@ final class ErrorException extends Exception
      * Creates a new Exception instance.
      *
      * @param  array{message: string|array<int, string>, type: ?string, code: string|int|null}  $contents
+     * @param int $statusCode
      */
-    public function __construct(private readonly array $contents)
+    public function __construct(private readonly array $contents, private readonly int $statusCode)
     {
         $message = ($contents['message'] ?: (string) $this->contents['code']) ?: 'Unknown error';
 
@@ -22,6 +23,16 @@ final class ErrorException extends Exception
         }
 
         parent::__construct($message);
+    }
+
+    /**
+     * Returns the HTTP status code.
+     *
+     * **Note: For streamed requests it might be 200 even in case of an error.**
+     */
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
     }
 
     /**

--- a/src/Responses/StreamResponse.php
+++ b/src/Responses/StreamResponse.php
@@ -57,7 +57,7 @@ final class StreamResponse implements ResponseHasMetaInformationContract, Respon
             $response = json_decode($data, true, flags: JSON_THROW_ON_ERROR);
 
             if (isset($response['error'])) {
-                throw new ErrorException($response['error']);
+                throw new ErrorException($response['error'], $this->response->getStatusCode());
             }
 
             if ($event !== null) {

--- a/src/Transporters/HttpTransporter.php
+++ b/src/Transporters/HttpTransporter.php
@@ -119,6 +119,8 @@ final class HttpTransporter implements TransporterContract
             return;
         }
 
+        $statusCode = $response->getStatusCode();
+
         if ($contents instanceof ResponseInterface) {
             $contents = $contents->getBody()->getContents();
         }
@@ -128,7 +130,7 @@ final class HttpTransporter implements TransporterContract
             $response = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
 
             if (isset($response['error'])) {
-                throw new ErrorException($response['error']);
+                throw new ErrorException($response['error'], $statusCode);
             }
         } catch (JsonException $jsonException) {
             throw new UnserializableResponse($jsonException);

--- a/tests/Testing/ClientFake.php
+++ b/tests/Testing/ClientFake.php
@@ -54,7 +54,7 @@ it('throws fake exceptions', function () {
             'message' => 'The model `gpt-1` does not exist',
             'type' => 'invalid_request_error',
             'code' => null,
-        ]),
+        ], 404),
     ]);
 
     $fake->completions()->create([


### PR DESCRIPTION
### What:
- [ ] Bug Fix
- [X] New Feature

### Description:

I've added the HTTP status code to ErrorException, so it's possible to ignore 404 errors for deleting files that don't exist, if desired. OpenAI doesn't provide an exhaustive enough error response for missing files that I can just quickly and universally check:

```json
{
  "error": {
    "message": "No such File object: file-testFile",
    "type": "invalid_request_error",
    "param": "id",
    "code": null
  }
}
```

As you can see there's no easy error code for missing resources, parsing the message is a terrible idea, so exposing the HTTP status code (404 in this case) enables to perform such simple checks.
