### PR TITLE
fix: add missing properties (specially `cached_usage`) to chat `CreateResponseUsage`

### DIFF
--- a/src/Responses/Chat/CreateResponse.php
+++ b/src/Responses/Chat/CreateResponse.php
@@ -41,7 +41,7 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{id: string, object: string, created: int, model: string, system_fingerprint?: string, choices: array<int, array{index: int, message: array{role: string, content: ?string, function_call: ?array{name: string, arguments: string}, tool_calls: ?array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}, finish_reason: string|null}>, usage: array{prompt_tokens: int, completion_tokens: int|null, total_tokens: int}}  $attributes
+     * @param  array{id: string, object: string, created: int, model: string, system_fingerprint?: string, choices: array<int, array{index: int, message: array{role: string, content: ?string, function_call: ?array{name: string, arguments: string}, tool_calls: ?array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}, finish_reason: string|null}>, usage: array{prompt_tokens: int, completion_tokens: int|null, total_tokens: int, prompt_tokens_details?:array{cached_tokens:int}, completion_tokens_details?:array{audio_tokens?:int, reasoning_tokens:int, accepted_prediction_tokens:int, rejected_prediction_tokens:int}}}  $attributes
      */
     public static function from(array $attributes, MetaInformation $meta): self
     {

--- a/src/Responses/Chat/CreateResponseUsage.php
+++ b/src/Responses/Chat/CreateResponseUsage.php
@@ -10,10 +10,12 @@ final class CreateResponseUsage
         public readonly int $promptTokens,
         public readonly ?int $completionTokens,
         public readonly int $totalTokens,
+        public readonly ?CreateResponseUsagePromptTokensDetails $promptTokensDetails,
+        public readonly ?CreateResponseUsageCompletionTokensDetails $completionTokensDetails
     ) {}
 
     /**
-     * @param  array{prompt_tokens: int, completion_tokens: int|null, total_tokens: int}  $attributes
+     * @param  array{prompt_tokens: int, completion_tokens: int|null, total_tokens: int, prompt_tokens_details?:array{cached_tokens:int}, completion_tokens_details?:array{audio_tokens?:int, reasoning_tokens:int, accepted_prediction_tokens:int, rejected_prediction_tokens:int}}  $attributes
      */
     public static function from(array $attributes): self
     {
@@ -21,18 +23,30 @@ final class CreateResponseUsage
             $attributes['prompt_tokens'],
             $attributes['completion_tokens'] ?? null,
             $attributes['total_tokens'],
+            isset($attributes['prompt_tokens_details']) ? CreateResponseUsagePromptTokensDetails::from($attributes['prompt_tokens_details']) : null,
+            isset($attributes['completion_tokens_details']) ? CreateResponseUsageCompletionTokensDetails::from($attributes['completion_tokens_details']) : null
         );
     }
 
     /**
-     * @return array{prompt_tokens: int, completion_tokens: int|null, total_tokens: int}
+     * @return array{prompt_tokens: int, completion_tokens: int|null, total_tokens: int, prompt_tokens_details?:array{cached_tokens:int}}
      */
     public function toArray(): array
     {
-        return [
+        $result = [
             'prompt_tokens' => $this->promptTokens,
             'completion_tokens' => $this->completionTokens,
             'total_tokens' => $this->totalTokens,
         ];
+
+        if ($this->promptTokensDetails) {
+            $result['prompt_tokens_details'] = $this->promptTokensDetails->toArray();
+        }
+
+        if ($this->completionTokensDetails) {
+            $result['completion_tokens_details'] = $this->completionTokensDetails->toArray();
+        }
+
+        return $result;
     }
 }

--- a/src/Responses/Chat/CreateResponseUsageCompletionTokensDetails.php
+++ b/src/Responses/Chat/CreateResponseUsageCompletionTokensDetails.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Responses\Chat;
+
+final class CreateResponseUsageCompletionTokensDetails
+{
+    private function __construct(
+        public readonly ?int $audioTokens,
+        public readonly int $reasoningTokens,
+        public readonly int $acceptedPredictionTokens,
+        public readonly int $rejectedPredictionTokens
+    ) {}
+
+    /**
+     * @param  array{audio_tokens?:int, reasoning_tokens:int, accepted_prediction_tokens:int, rejected_prediction_tokens:int}  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            $attributes['audio_tokens'] ?? null,
+            $attributes['reasoning_tokens'],
+            $attributes['accepted_prediction_tokens'],
+            $attributes['rejected_prediction_tokens'],
+        );
+    }
+
+    /**
+     * @return array{audio_tokens?:int, reasoning_tokens:int, accepted_prediction_tokens:int, rejected_prediction_tokens:int}
+     */
+    public function toArray(): array
+    {
+        $result = [
+            'reasoning_tokens' => $this->reasoningTokens,
+            'accepted_prediction_tokens' => $this->acceptedPredictionTokens,
+            'rejected_prediction_tokens' => $this->rejectedPredictionTokens,
+        ];
+
+        if (! is_null($this->audioTokens)) {
+            $result['audio_tokens'] = $this->audioTokens;
+        }
+
+        return $result;
+    }
+}

--- a/src/Responses/Chat/CreateResponseUsagePromptTokensDetails.php
+++ b/src/Responses/Chat/CreateResponseUsagePromptTokensDetails.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Responses\Chat;
+
+final class CreateResponseUsagePromptTokensDetails
+{
+    private function __construct(
+        public readonly ?int $audioTokens,
+        public readonly int $cachedTokens
+    ) {}
+
+    /**
+     * @param  array{audio_tokens?:int, cached_tokens?: int}  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            $attributes['audio_tokens'] ?? null,
+            $attributes['cached_tokens'] ?? 0,
+        );
+    }
+
+    /**
+     * @return array{cached_tokens: int, audio_tokens?:int}
+     */
+    public function toArray(): array
+    {
+        $result = [
+            'cached_tokens' => $this->cachedTokens,
+        ];
+
+        if (! is_null($this->audioTokens)) {
+            $result['audio_tokens'] = $this->audioTokens;
+        }
+
+        return $result;
+    }
+}

--- a/tests/Fixtures/Chat.php
+++ b/tests/Fixtures/Chat.php
@@ -24,6 +24,14 @@ function chatCompletion(): array
             'prompt_tokens' => 9,
             'completion_tokens' => 12,
             'total_tokens' => 21,
+            'prompt_tokens_details' => [
+                'cached_tokens' => 5,
+            ],
+            'completion_tokens_details' => [
+                'reasoning_tokens' => 0,
+                'accepted_prediction_tokens' => 0,
+                'rejected_prediction_tokens' => 0,
+            ],
         ],
     ];
 }
@@ -53,6 +61,43 @@ function chatCompletionWithSystemFingerprint(): array
             'prompt_tokens' => 9,
             'completion_tokens' => 12,
             'total_tokens' => 21,
+        ],
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function chatCompletionWithCachedUsage(): array
+{
+    return [
+        'id' => 'chatcmpl-123',
+        'object' => 'chat.completion',
+        'created' => 1677652288,
+        'model' => 'gpt-3.5-turbo',
+        'system_fingerprint' => 'fp_44709d6fcb',
+        'choices' => [
+            [
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => "\n\nHello there, how may I assist you today?",
+                ],
+                'finish_reason' => 'stop',
+            ],
+        ],
+        'usage' => [
+            'prompt_tokens' => 9,
+            'completion_tokens' => 12,
+            'total_tokens' => 21,
+            'prompt_tokens_details' => [
+                'cached_tokens' => 5,
+            ],
+            'completion_tokens_details' => [
+                'reasoning_tokens' => 0,
+                'accepted_prediction_tokens' => 0,
+                'rejected_prediction_tokens' => 0,
+            ],
         ],
     ];
 }

--- a/tests/Fixtures/Chat.php
+++ b/tests/Fixtures/Chat.php
@@ -68,43 +68,6 @@ function chatCompletionWithSystemFingerprint(): array
 /**
  * @return array<string, mixed>
  */
-function chatCompletionWithCachedUsage(): array
-{
-    return [
-        'id' => 'chatcmpl-123',
-        'object' => 'chat.completion',
-        'created' => 1677652288,
-        'model' => 'gpt-3.5-turbo',
-        'system_fingerprint' => 'fp_44709d6fcb',
-        'choices' => [
-            [
-                'index' => 0,
-                'message' => [
-                    'role' => 'assistant',
-                    'content' => "\n\nHello there, how may I assist you today?",
-                ],
-                'finish_reason' => 'stop',
-            ],
-        ],
-        'usage' => [
-            'prompt_tokens' => 9,
-            'completion_tokens' => 12,
-            'total_tokens' => 21,
-            'prompt_tokens_details' => [
-                'cached_tokens' => 5,
-            ],
-            'completion_tokens_details' => [
-                'reasoning_tokens' => 0,
-                'accepted_prediction_tokens' => 0,
-                'rejected_prediction_tokens' => 0,
-            ],
-        ],
-    ];
-}
-
-/**
- * @return array<string, mixed>
- */
 function chatCompletionWithFunction(): array
 {
     return [

--- a/tests/Responses/Chat/CreateResponseUsage.php
+++ b/tests/Responses/Chat/CreateResponseUsage.php
@@ -1,6 +1,8 @@
 <?php
 
 use OpenAI\Responses\Chat\CreateResponseUsage;
+use OpenAI\Responses\Chat\CreateResponseUsageCompletionTokensDetails;
+use OpenAI\Responses\Chat\CreateResponseUsagePromptTokensDetails;
 
 test('from', function () {
     $result = CreateResponseUsage::from(chatCompletion()['usage']);
@@ -8,7 +10,9 @@ test('from', function () {
     expect($result)
         ->promptTokens->toBe(9)
         ->completionTokens->toBe(12)
-        ->totalTokens->toBe(21);
+        ->totalTokens->toBe(21)
+        ->promptTokensDetails->toBeInstanceOf(CreateResponseUsagePromptTokensDetails::class)
+        ->completionTokensDetails->toBeInstanceOf(CreateResponseUsageCompletionTokensDetails::class);
 });
 
 test('to array', function () {

--- a/tests/Responses/Chat/CreateResponseUsageCompletionTokensDetails.php
+++ b/tests/Responses/Chat/CreateResponseUsageCompletionTokensDetails.php
@@ -1,0 +1,20 @@
+<?php
+
+use OpenAI\Responses\Chat\CreateResponseUsageCompletionTokensDetails;
+
+test('from', function () {
+    $result = CreateResponseUsageCompletionTokensDetails::from(chatCompletion()['usage']['completion_tokens_details']);
+
+    expect($result)
+        ->audioTokens->toBeNull()
+        ->reasoningTokens->toBe(0)
+        ->acceptedPredictionTokens->toBe(0)
+        ->rejectedPredictionTokens->toBe(0);
+});
+
+test('to array', function () {
+    $result = CreateResponseUsageCompletionTokensDetails::from(chatCompletion()['usage']['completion_tokens_details']);
+
+    expect($result->toArray())
+        ->toBe(chatCompletion()['usage']['completion_tokens_details']);
+});

--- a/tests/Responses/Chat/CreateResponseUsagePromptTokensDetails.php
+++ b/tests/Responses/Chat/CreateResponseUsagePromptTokensDetails.php
@@ -1,0 +1,17 @@
+<?php
+
+use OpenAI\Responses\Chat\CreateResponseUsagePromptTokensDetails;
+
+test('from', function () {
+    $result = CreateResponseUsagePromptTokensDetails::from(chatCompletion()['usage']['prompt_tokens_details']);
+
+    expect($result)
+        ->cachedTokens->toBe(5);
+});
+
+test('to array', function () {
+    $result = CreateResponseUsagePromptTokensDetails::from(chatCompletion()['usage']['prompt_tokens_details']);
+
+    expect($result->toArray())
+        ->toBe(chatCompletion()['usage']['prompt_tokens_details']);
+});


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the OpenAI PHP team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:
Chat `CreateResponseUsage` object is omitting some properties which have probably been have added in more modern versions of the API which are related to the tokens usage. I think `cached_usage` is specially important (two issues were already requesting this) as this would help users track if their prompts are being cached properly and could directly contribute to save money.

Check the `usage` property for reference: 
https://platform.openai.com/docs/api-reference/chat/object
<!-- describe what your PR is solving -->

### Related:

Fixes #486 #492 
<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
