### PR TITLE
Moderation Omni - New Categories (Illicit*) support.

### DIFF
--- a/src/Enums/Moderations/Category.php
+++ b/src/Enums/Moderations/Category.php
@@ -10,6 +10,8 @@ enum Category: string
     case HateThreatening = 'hate/threatening';
     case Harassment = 'harassment';
     case HarassmentThreatening = 'harassment/threatening';
+    case Illicit = 'illicit';
+    case IllicitViolent = 'illicit/violent';
     case SelfHarm = 'self-harm';
     case SelfHarmIntent = 'self-harm/intent';
     case SelfHarmInstructions = 'self-harm/instructions';

--- a/src/Responses/Moderations/CreateResponseResult.php
+++ b/src/Responses/Moderations/CreateResponseResult.php
@@ -27,6 +27,10 @@ final class CreateResponseResult
         $categories = [];
 
         foreach (Category::cases() as $category) {
+            if (! isset($attributes['category_scores'][$category->value])) {
+                continue;
+            }
+
             $categories[$category->value] = CreateResponseCategory::from([
                 'category' => $category->value,
                 'violated' => $attributes['categories'][$category->value],

--- a/tests/Fixtures/Moderation.php
+++ b/tests/Fixtures/Moderation.php
@@ -41,3 +41,49 @@ function moderationResource(): array
         ],
     ];
 }
+
+/**
+ * @return array<string, mixed>
+ */
+function moderationOmniResource(): array
+{
+    return [
+        'id' => 'modr-5MWoLO',
+        'model' => 'omni-moderation-001',
+        'results' => [
+            [
+                'categories' => [
+                    'hate' => false,
+                    'hate/threatening' => true,
+                    'harassment' => false,
+                    'harassment/threatening' => false,
+                    'illicit' => false,
+                    'illicit/violent' => true,
+                    'self-harm' => false,
+                    'self-harm/intent' => false,
+                    'self-harm/instructions' => false,
+                    'sexual' => false,
+                    'sexual/minors' => false,
+                    'violence' => false,
+                    'violence/graphic' => false,
+                ],
+                'category_scores' => [
+                    'hate' => 0.22714105248451233,
+                    'hate/threatening' => 0.4132447838783264,
+                    'illicit' => 0.1602763684674149,
+                    'illicit/violent' => 0.9223177433013916,
+                    'harassment' => 0.1602763684674149,
+                    'harassment/threatening' => 0.1602763684674149,
+                    'self-harm' => 0.005232391878962517,
+                    'self-harm/intent' => 0.005134391873962517,
+                    'self-harm/instructions' => 0.005132591874962517,
+                    'sexual' => 0.01407341007143259,
+                    'sexual/minors' => 0.0038522258400917053,
+                    'violence' => 0.4132447838783264,
+                    'violence/graphic' => 0.036865197122097015,
+                ],
+                'flagged' => true,
+            ],
+        ],
+    ];
+}

--- a/tests/Resources/Moderations.php
+++ b/tests/Resources/Moderations.php
@@ -7,7 +7,7 @@ use OpenAI\Responses\Moderations\CreateResponseCategory;
 use OpenAI\Responses\Moderations\CreateResponseResult;
 use OpenAI\ValueObjects\Transporter\Response;
 
-test('create', closure: function () {
+test('create legacy', closure: function () {
     $client = mockClient('POST', 'moderations', [
         'model' => 'text-moderation-latest',
         'input' => 'I want to kill them.',
@@ -37,6 +37,43 @@ test('create', closure: function () {
 
     expect($result->results[0]->categories[Category::Violence->value])
         ->category->toBe(Category::Violence)
+        ->violated->toBe(true)
+        ->score->toBe(0.9223177433013916);
+
+    expect($result->meta())
+        ->toBeInstanceOf(MetaInformation::class);
+});
+
+test('create omni', closure: function () {
+    $client = mockClient('POST', 'moderations', [
+        'model' => 'omni-moderation-latest',
+        'input' => 'I want to kill them.',
+    ], Response::from(moderationOmniResource(), metaHeaders()));
+
+    $result = $client->moderations()->create([
+        'model' => 'omni-moderation-latest',
+        'input' => 'I want to kill them.',
+    ]);
+
+    expect($result)
+        ->toBeInstanceOf(CreateResponse::class)
+        ->id->toBe('modr-5MWoLO')
+        ->model->toBe('omni-moderation-001')
+        ->results->toBeArray()->toHaveCount(1)
+        ->results->each->toBeInstanceOf(CreateResponseResult::class);
+
+    expect($result->results[0])
+        ->flagged->toBeTrue()
+        ->categories->toHaveCount(13)
+        ->each->toBeInstanceOf(CreateResponseCategory::class);
+
+    expect($result->results[0]->categories[Category::Illicit->value])
+        ->category->toBe(Category::Illicit)
+        ->violated->toBe(false)
+        ->score->toBe(0.1602763684674149);
+
+    expect($result->results[0]->categories[Category::IllicitViolent->value])
+        ->category->toBe(Category::IllicitViolent)
         ->violated->toBe(true)
         ->score->toBe(0.9223177433013916);
 


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

The Omni Moderation models were released, thus deprecating the older models (now referred to as Legacy). This introduced the `illicit` and `illicit/violent` moderation category, but ONLY for Omni. This presented an issue as this library iterated all known types and assumed all models will have it.

Now we only set a Category if we have it and thus support partial support of Omni Moderation.

Ref: https://platform.openai.com/docs/guides/moderation


This does NOT add support for the new `category_applied_input_types` field.
