### PR TITLE
Fix: Support string input for $contents in Exception constructor

### DIFF
--- a/src/Exceptions/ErrorException.php
+++ b/src/Exceptions/ErrorException.php
@@ -11,15 +11,21 @@ final class ErrorException extends Exception
     /**
      * Creates a new Exception instance.
      *
-     * @param  array{message: string|array<int, string>, type: ?string, code: string|int|null}  $contents
+     * @param array|string $contents
+     * @param int $statusCode
      */
-    public function __construct(private readonly array $contents, private readonly int $statusCode)
+    public function __construct(private readonly array|string $contents, private readonly int $statusCode)
     {
-        $message = ($contents['message'] ?: (string) $this->contents['code']) ?: 'Unknown error';
+        if(is_string($contents)) {
+            $message = $contents;
+        } else {
+            $message = ($contents['message'] ?: (string) $this->contents['code']) ?: 'Unknown error';
 
-        if (is_array($message)) {
-            $message = implode(PHP_EOL, $message);
+            if (is_array($message)) {
+                $message = implode(PHP_EOL, $message);
+            }
         }
+
 
         parent::__construct($message);
     }


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the OpenAI PHP team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Fix: Handle cases where $contents is a string instead of an array. Updated constructor to support both array and string types, preventing errors when $contents is not an array.

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
