### PR TITLE
Fix: `$acceptedPredictionTokens must be of type int, null given` | #524 😇

### DIFF
--- a/src/Responses/Chat/CreateResponseUsageCompletionTokensDetails.php
+++ b/src/Responses/Chat/CreateResponseUsageCompletionTokensDetails.php
@@ -9,8 +9,8 @@ final class CreateResponseUsageCompletionTokensDetails
     private function __construct(
         public readonly ?int $audioTokens,
         public readonly int $reasoningTokens,
-        public readonly int $acceptedPredictionTokens,
-        public readonly int $rejectedPredictionTokens
+        public readonly ?int $acceptedPredictionTokens,
+        public readonly ?int $rejectedPredictionTokens
     ) {}
 
     /**

--- a/src/Responses/Chat/CreateResponseUsageCompletionTokensDetails.php
+++ b/src/Responses/Chat/CreateResponseUsageCompletionTokensDetails.php
@@ -21,8 +21,8 @@ final class CreateResponseUsageCompletionTokensDetails
         return new self(
             $attributes['audio_tokens'] ?? null,
             $attributes['reasoning_tokens'],
-            $attributes['accepted_prediction_tokens'],
-            $attributes['rejected_prediction_tokens'],
+            $attributes['accepted_prediction_tokens'] ?? null,
+            $attributes['rejected_prediction_tokens'] ?? null,
         );
     }
 


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the OpenAI PHP team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Fix `$acceptedPredictionTokens must be of type int, null given` error for `deepseek-reasoner` model

### Related:
#524 
<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
