### PR TITLE
Add compatibility for aliyun LLM APIs

### DIFF
--- a/src/Responses/Files/CreateResponse.php
+++ b/src/Responses/Files/CreateResponse.php
@@ -54,7 +54,7 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
             $attributes['filename'],
             $attributes['purpose'],
             $attributes['status'],
-            $attributes['status_details'],
+            $attributes['status_details'] ?? null,
             $meta,
         );
     }

--- a/src/Responses/Files/RetrieveResponse.php
+++ b/src/Responses/Files/RetrieveResponse.php
@@ -54,7 +54,7 @@ final class RetrieveResponse implements ResponseContract, ResponseHasMetaInforma
             $attributes['filename'],
             $attributes['purpose'],
             $attributes['status'],
-            $attributes['status_details'],
+            $attributes['status_details'] ?? null,
             $meta,
         );
     }

--- a/src/Responses/FineTunes/RetrieveResponseFile.php
+++ b/src/Responses/FineTunes/RetrieveResponseFile.php
@@ -46,7 +46,7 @@ final class RetrieveResponseFile implements ResponseContract
             $attributes['filename'],
             $attributes['purpose'],
             $attributes['status'],
-            $attributes['status_details'],
+            $attributes['status_details'] ?? null,
         );
     }
 

--- a/tests/Responses/Files/RetrieveResponse.php
+++ b/tests/Responses/Files/RetrieveResponse.php
@@ -50,6 +50,17 @@ test('from with byte is null', function () {
         ->meta()->toBeInstanceOf(MetaInformation::class);
 });
 
+test('from with status_details missing', function () {
+    $data = fileResource();
+    unset($data['status_details']);
+
+    $result = RetrieveResponse::from($data, meta());
+
+    expect($result)
+        ->toBeInstanceOf(RetrieveResponse::class)
+        ->statusDetails->toBeNull();
+});
+
 test('as array accessible', function () {
     $result = RetrieveResponse::from(fileResource(), meta());
 


### PR DESCRIPTION
### Summary
Some Aliyun API responses do not include the `status_details` field, which causes an error when trying to access it. This PR ensures compatibility by setting `status_details` to `null` when it is missing.

### Changes
- Checks if `status_details` exists in the response before accessing it.
- Defaults `status_details` to `null` if it is not present.
- Ensures compatibility with both OpenAI and Aliyun APIs.

### Why this is needed
Without this fix, Aliyun API responses that lack `status_details` will cause runtime errors, breaking the client integration.

### Testing
- Tested with OpenAI API (unchanged behavior).
- Tested with Aliyun API (no more errors when `status_details` is missing).

### Backward Compatibility
✅ Fully backward compatible. If `status_details` is present, the behavior remains unchanged.
