### PR TITLE
feat: add reasoning_content field to chat completions response

### DIFF
--- a/src/Responses/Chat/CreateResponse.php
+++ b/src/Responses/Chat/CreateResponse.php
@@ -12,12 +12,12 @@ use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
- * @implements ResponseContract<array{id: string, object: string, created: int, model: string, system_fingerprint?: string, choices: array<int, array{index: int, message: array{role: string, content: string|null, function_call?: array{name: string, arguments: string}, tool_calls?: array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}, finish_reason: string|null}>, usage: array{prompt_tokens: int, completion_tokens: int|null, total_tokens: int}}>
+ * @implements ResponseContract<array{id: string, object: string, created: int, model: string, system_fingerprint?: string, choices: array<int, array{index: int, message: array{role: string, content: string|null, reasoning_content?: string|null, function_call?: array{name: string, arguments: string}, tool_calls?: array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}, finish_reason: string|null}>, usage: array{prompt_tokens: int, completion_tokens: int|null, total_tokens: int}}>
  */
 final class CreateResponse implements ResponseContract, ResponseHasMetaInformationContract
 {
     /**
-     * @use ArrayAccessible<array{id: string, object: string, created: int, model: string, system_fingerprint?: string, choices: array<int, array{index: int, message: array{role: string, content: string|null, function_call?: array{name: string, arguments: string}, tool_calls?: array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}, finish_reason: string|null}>, usage: array{prompt_tokens: int, completion_tokens: int|null, total_tokens: int}}>
+     * @use ArrayAccessible<array{id: string, object: string, created: int, model: string, system_fingerprint?: string, choices: array<int, array{index: int, message: array{role: string, content: string|null, reasoning_content?: string|null, function_call?: array{name: string, arguments: string}, tool_calls?: array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}, finish_reason: string|null}>, usage: array{prompt_tokens: int, completion_tokens: int|null, total_tokens: int}}>
      */
     use ArrayAccessible;
 
@@ -41,7 +41,7 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{id: string, object: string, created: int, model: string, system_fingerprint?: string, choices: array<int, array{index: int, message: array{role: string, content: ?string, function_call: ?array{name: string, arguments: string}, tool_calls: ?array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}, finish_reason: string|null}>, usage: array{prompt_tokens: int, completion_tokens: int|null, total_tokens: int, prompt_tokens_details?:array{cached_tokens:int}, completion_tokens_details?:array{audio_tokens?:int, reasoning_tokens:int, accepted_prediction_tokens:int, rejected_prediction_tokens:int}}}  $attributes
+     * @param  array{id: string, object: string, created: int, model: string, system_fingerprint?: string, choices: array<int, array{index: int, message: array{role: string, content: ?string, reasoning_content?: ?string, function_call: ?array{name: string, arguments: string}, tool_calls: ?array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}, finish_reason: string|null}>, usage: array{prompt_tokens: int, completion_tokens: int|null, total_tokens: int, prompt_tokens_details?:array{cached_tokens:int}, completion_tokens_details?:array{audio_tokens?:int, reasoning_tokens:int, accepted_prediction_tokens:int, rejected_prediction_tokens:int}}}  $attributes
      */
     public static function from(array $attributes, MetaInformation $meta): self
     {

--- a/src/Responses/Chat/CreateResponseChoice.php
+++ b/src/Responses/Chat/CreateResponseChoice.php
@@ -13,7 +13,7 @@ final class CreateResponseChoice
     ) {}
 
     /**
-     * @param  array{index: int, message: array{role: string, content: ?string, function_call: ?array{name: string, arguments: string}, tool_calls: ?array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}, finish_reason: string|null}  $attributes
+     * @param  array{index: int, message: array{role: string, content: ?string, reasoning_content?: ?string, function_call: ?array{name: string, arguments: string}, tool_calls: ?array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}, finish_reason: string|null}  $attributes
      */
     public static function from(array $attributes): self
     {
@@ -25,7 +25,7 @@ final class CreateResponseChoice
     }
 
     /**
-     * @return array{index: int, message: array{role: string, content: string|null, function_call?: array{name: string, arguments: string}, tool_calls?: array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}, finish_reason: string|null}
+     * @return array{index: int, message: array{role: string, content: string|null, reasoning_content?: string|null, function_call?: array{name: string, arguments: string}, tool_calls?: array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}, finish_reason: string|null}
      */
     public function toArray(): array
     {

--- a/src/Responses/Chat/CreateResponseMessage.php
+++ b/src/Responses/Chat/CreateResponseMessage.php
@@ -13,11 +13,12 @@ final class CreateResponseMessage
         public readonly string $role,
         public readonly ?string $content,
         public readonly array $toolCalls,
+        public readonly ?string $reasoningContent,
         public readonly ?CreateResponseFunctionCall $functionCall,
     ) {}
 
     /**
-     * @param  array{role: string, content: ?string, function_call: ?array{name: string, arguments: string}, tool_calls: ?array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}  $attributes
+     * @param  array{role: string, content: ?string, reasoning_content?: ?string, function_call: ?array{name: string, arguments: string}, tool_calls: ?array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}  $attributes
      */
     public static function from(array $attributes): self
     {
@@ -29,12 +30,13 @@ final class CreateResponseMessage
             $attributes['role'],
             $attributes['content'] ?? null,
             $toolCalls,
+            $attributes['reasoning_content'] ?? null,
             isset($attributes['function_call']) ? CreateResponseFunctionCall::from($attributes['function_call']) : null,
         );
     }
 
     /**
-     * @return array{role: string, content: string|null, function_call?: array{name: string, arguments: string}, tool_calls?: array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}
+     * @return array{role: string, content: string|null, reasoning_content?: string|null, function_call?: array{name: string, arguments: string}, tool_calls?: array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}
      */
     public function toArray(): array
     {
@@ -42,6 +44,10 @@ final class CreateResponseMessage
             'role' => $this->role,
             'content' => $this->content,
         ];
+
+        if ($this->reasoningContent !== null) {
+            $data['reasoning_content'] = $this->reasoningContent;
+        }
 
         if ($this->functionCall instanceof CreateResponseFunctionCall) {
             $data['function_call'] = $this->functionCall->toArray();

--- a/src/Responses/Chat/CreateStreamedResponse.php
+++ b/src/Responses/Chat/CreateStreamedResponse.php
@@ -9,12 +9,12 @@ use OpenAI\Responses\Concerns\ArrayAccessible;
 use OpenAI\Testing\Responses\Concerns\FakeableForStreamedResponse;
 
 /**
- * @implements ResponseContract<array{id: string, object: string, created: int, model: string, choices: array<int, array{index: int, delta: array{role?: string, content?: string}|array{role?: string, content: null, function_call: array{name?: string, arguments?: string}}, finish_reason: string|null}>, usage?: array{prompt_tokens: int, completion_tokens: int|null, total_tokens: int}}>
+ * @implements ResponseContract<array{id: string, object: string, created: int, model: string, choices: array<int, array{index: int, delta: array{role?: string, content?: string, reasoning_content?: string}|array{role?: string, content: null, reasoning_content?: string, function_call: array{name?: string, arguments?: string}}, finish_reason: string|null}>, usage?: array{prompt_tokens: int, completion_tokens: int|null, total_tokens: int}}>
  */
 final class CreateStreamedResponse implements ResponseContract
 {
     /**
-     * @use ArrayAccessible<array{id: string, object: string, created: int, model: string, choices: array<int, array{index: int, delta: array{role?: string, content?: string}|array{role?: string, content: null, function_call: array{name?: string, arguments?: string}}, finish_reason: string|null}>, usage?: array{prompt_tokens: int, completion_tokens: int|null, total_tokens: int}}>
+     * @use ArrayAccessible<array{id: string, object: string, created: int, model: string, choices: array<int, array{index: int, delta: array{role?: string, content?: string, reasoning_content?: string}|array{role?: string, content: null, reasoning_content?: string, function_call: array{name?: string, arguments?: string}}, finish_reason: string|null}>, usage?: array{prompt_tokens: int, completion_tokens: int|null, total_tokens: int}}>
      */
     use ArrayAccessible;
 
@@ -35,7 +35,7 @@ final class CreateStreamedResponse implements ResponseContract
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{id: string, object: string, created: int, model: string, choices: array<int, array{index: int, delta: array{role?: string, content?: string}, finish_reason: string|null}>, usage?: array{prompt_tokens: int, completion_tokens: int|null, total_tokens: int}}  $attributes
+     * @param  array{id: string, object: string, created: int, model: string, choices: array<int, array{index: int, delta: array{role?: string, content?: string, reasoning_content?: string}, finish_reason: string|null}>, usage?: array{prompt_tokens: int, completion_tokens: int|null, total_tokens: int}}  $attributes
      */
     public static function from(array $attributes): self
     {

--- a/src/Responses/Chat/CreateStreamedResponseChoice.php
+++ b/src/Responses/Chat/CreateStreamedResponseChoice.php
@@ -13,7 +13,7 @@ final class CreateStreamedResponseChoice
     ) {}
 
     /**
-     * @param  array{index: int, delta?: array{role?: string, content?: string}, finish_reason: string|null}  $attributes
+     * @param  array{index: int, delta?: array{role?: string, content?: string, reasoning_content?: string}, finish_reason: string|null}  $attributes
      */
     public static function from(array $attributes): self
     {
@@ -25,7 +25,7 @@ final class CreateStreamedResponseChoice
     }
 
     /**
-     * @return array{index: int, delta: array{role?: string, content?: string}|array{role?: string, content: null, function_call: array{name?: string, arguments?: string}}, finish_reason: string|null}
+     * @return array{index: int, delta: array{role?: string, content?: string, reasoning_content?: string}|array{role?: string, content: null, reasoning_content?: string, function_call: array{name?: string, arguments?: string}}, finish_reason: string|null}
      */
     public function toArray(): array
     {

--- a/src/Responses/Chat/CreateStreamedResponseDelta.php
+++ b/src/Responses/Chat/CreateStreamedResponseDelta.php
@@ -13,11 +13,12 @@ final class CreateStreamedResponseDelta
         public readonly ?string $role,
         public readonly ?string $content,
         public readonly array $toolCalls,
+        public readonly ?string $reasoningContent,
         public readonly ?CreateStreamedResponseFunctionCall $functionCall,
     ) {}
 
     /**
-     * @param  array{role?: string, content?: string, function_call?: array{name?: ?string, arguments?: ?string}, tool_calls?: array<int, array{id?: string, type?: string, function: array{name?: string, arguments: string}}>}  $attributes
+     * @param  array{role?: string, content?: string, reasoning_content?: string, function_call?: array{name?: ?string, arguments?: ?string}, tool_calls?: array<int, array{id?: string, type?: string, function: array{name?: string, arguments: string}}>}  $attributes
      */
     public static function from(array $attributes): self
     {
@@ -29,18 +30,20 @@ final class CreateStreamedResponseDelta
             $attributes['role'] ?? null,
             $attributes['content'] ?? null,
             $toolCalls,
+            $attributes['reasoning_content'] ?? null,
             isset($attributes['function_call']) ? CreateStreamedResponseFunctionCall::from($attributes['function_call']) : null,
         );
     }
 
     /**
-     * @return array{role?: string, content?: string}|array{role?: string, content: null, function_call: array{name?: string, arguments?: string}}
+     * @return array{role?: string, content?: string, reasoning_content?: string}|array{role?: string, content: null, reasoning_content?: string, function_call: array{name?: string, arguments?: string}}
      */
     public function toArray(): array
     {
         $data = array_filter([
             'role' => $this->role,
             'content' => $this->content,
+            'reasoning_content' => $this->reasoningContent,
         ], fn (?string $value): bool => ! is_null($value));
 
         if ($this->functionCall instanceof CreateStreamedResponseFunctionCall) {


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [√] New Feature

### Description:

Add support for the reasoning_content field in chat completions API responses. This field is added at the same level as content in both streaming and non-streaming requests. The field is marked as optional to handle cases where it's not present in the API response.


### Related:

#517
