### PR TITLE
Correct GitHub Action deprecations + Opt into Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/formats.yml
+++ b/.github/workflows/formats.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Cache dependencies
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ~/.composer/cache/files
         key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Cache dependencies
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ~/.composer/cache/files
         key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Correcting the build sweet, because the leveraged actions/* versions are far EOLed they don't even work anymore. Additionally I've added Dependabot on a weekly schedule to only update GitHub Actions. Since this repo uses large tags (ie v1, v2) - these upgrades would only be triggered when a new major version is released.

Laravel PR: https://github.com/openai-php/laravel/pull/142/commits
