### PR TITLE
build: remove prestissimo (unneeded in composer: v2)

### DIFF
--- a/.github/workflows/formats.yml
+++ b/.github/workflows/formats.yml
@@ -31,7 +31,6 @@ jobs:
       with:
         php-version: ${{ matrix.php }}
         extensions: dom, mbstring, zip
-        tools: prestissimo
         coverage: pcov
 
     - name: Install Composer dependencies


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

```
Formats P8.1 - ubuntu-latest - prefer-stable
Skipping prestissimo, as it does not support Composer . Specify composer:v1 in tools to use prestissimo
```

This removes prestissimo, as its not really useful anymore with composer:v2. 

### Related:

