### PR TITLE
fix: correct completion endpoint when logprobs missing

### DIFF
--- a/src/Responses/Completions/CreateResponseChoice.php
+++ b/src/Responses/Completions/CreateResponseChoice.php
@@ -21,7 +21,9 @@ final class CreateResponseChoice
         return new self(
             $attributes['text'],
             $attributes['index'],
-            $attributes['logprobs'] ? CreateResponseChoiceLogprobs::from($attributes['logprobs']) : null,
+            isset($attributes['logprobs'])
+                ? CreateResponseChoiceLogprobs::from($attributes['logprobs'])
+                : null,
             $attributes['finish_reason'],
         );
     }

--- a/tests/Responses/Completions/CreateResponseChoice.php
+++ b/tests/Responses/Completions/CreateResponseChoice.php
@@ -13,6 +13,18 @@ test('from', function () {
         ->finishReason->toBeIn(['length', null]);
 });
 
+test('from with missing logprobs', function () {
+    $payload = completion()['choices'][0];
+    unset($payload['logprobs']);
+    $result = CreateResponseChoice::from($payload);
+
+    expect($result)
+        ->text->toBe("el, she elaborates more on the Corruptor's role, suggesting K")
+        ->index->toBe(0)
+        ->logprobs->toBeNull()
+        ->finishReason->toBeIn(['length', null]);
+});
+
 test('to array', function () {
     $result = CreateResponseChoice::from(completion()['choices'][0]);
 


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

In testing OpenAI's legacy completion endpoint. The `logprobs` property is not coming back anymore. Its neither `null` or filled - its simply missing. However, oddly a few API calls later it was back. This appears to be a bug on OpenAI's side with the legacy endpoint.

We can easily handle this though since a natural state of `logprobs` is null. We just expected it to be there.

### Related:

fixes: #522 
