### PR TITLE
feat: support 'attributes' on vector store files

### DIFF
--- a/src/Resources/VectorStoresFileBatches.php
+++ b/src/Resources/VectorStoresFileBatches.php
@@ -57,7 +57,7 @@ final class VectorStoresFileBatches implements VectorStoresFileBatchesContract
     {
         $payload = Payload::list("vector_stores/$vectorStoreId/file_batches/$fileBatchId/files", $parameters);
 
-        /** @var Response<array{object: string, data: array<int, array{id: string, object: string, usage_bytes: int, created_at: int, vector_store_id: string, status: string, last_error: ?array{code: string, message: string}, chunking_strategy: array{type: 'static', static: array{max_chunk_size_tokens: int, chunk_overlap_tokens: int}}|array{type: 'other'}}>, first_id: ?string, last_id: ?string, has_more: bool}> $response */
+        /** @var Response<array{object: string, data: array<int, array{id: string, object: string, usage_bytes: int, created_at: int, vector_store_id: string, status: string, attributes: array<string, string>, last_error: ?array{code: string, message: string}, chunking_strategy: array{type: 'static', static: array{max_chunk_size_tokens: int, chunk_overlap_tokens: int}}|array{type: 'other'}}>, first_id: ?string, last_id: ?string, has_more: bool}> $response */
         $response = $this->transporter->requestObject($payload);
 
         return VectorStoreFileListResponse::from($response->data(), $response->meta());

--- a/src/Resources/VectorStoresFiles.php
+++ b/src/Resources/VectorStoresFiles.php
@@ -26,7 +26,7 @@ final class VectorStoresFiles implements VectorStoresFilesContract
     {
         $payload = Payload::create("vector_stores/$vectorStoreId/files", $parameters);
 
-        /** @var Response<array{id: string, object: string, usage_bytes: int, created_at: int, vector_store_id: string, status: string, last_error: ?array{code: string, message: string}, chunking_strategy: array{type: 'static', static: array{max_chunk_size_tokens: int, chunk_overlap_tokens: int}}|array{type: 'other'}}> $response */
+        /** @var Response<array{id: string, object: string, usage_bytes: int, created_at: int, vector_store_id: string, status: string, attributes: array<string, string>, last_error: ?array{code: string, message: string}, chunking_strategy: array{type: 'static', static: array{max_chunk_size_tokens: int, chunk_overlap_tokens: int}}|array{type: 'other'}}> $response */
         $response = $this->transporter->requestObject($payload);
 
         return VectorStoreFileResponse::from($response->data(), $response->meta());
@@ -43,7 +43,7 @@ final class VectorStoresFiles implements VectorStoresFilesContract
     {
         $payload = Payload::list("vector_stores/$vectorStoreId/files", $parameters);
 
-        /** @var Response<array{object: string, data: array<int, array{id: string, object: string, usage_bytes: int, created_at: int, vector_store_id: string, status: string, last_error: ?array{code: string, message: string}, chunking_strategy: array{type: 'static', static: array{max_chunk_size_tokens: int, chunk_overlap_tokens: int}}|array{type: 'other'}}>, first_id: ?string, last_id: ?string, has_more: bool}> $response */
+        /** @var Response<array{object: string, data: array<int, array{id: string, object: string, usage_bytes: int, created_at: int, vector_store_id: string, status: string, attributes: array<string, string>, last_error: ?array{code: string, message: string}, chunking_strategy: array{type: 'static', static: array{max_chunk_size_tokens: int, chunk_overlap_tokens: int}}|array{type: 'other'}}>, first_id: ?string, last_id: ?string, has_more: bool}> $response */
         $response = $this->transporter->requestObject($payload);
 
         return VectorStoreFileListResponse::from($response->data(), $response->meta());
@@ -58,7 +58,7 @@ final class VectorStoresFiles implements VectorStoresFilesContract
     {
         $payload = Payload::retrieve("vector_stores/$vectorStoreId/files", $fileId);
 
-        /** @var Response<array{id: string, object: string, usage_bytes: int, created_at: int, vector_store_id: string, status: string, last_error: ?array{code: string, message: string}, chunking_strategy: array{type: 'static', static: array{max_chunk_size_tokens: int, chunk_overlap_tokens: int}}|array{type: 'other'}}> $response */
+        /** @var Response<array{id: string, object: string, usage_bytes: int, created_at: int, vector_store_id: string, status: string, attributes: array<string, string>, last_error: ?array{code: string, message: string}, chunking_strategy: array{type: 'static', static: array{max_chunk_size_tokens: int, chunk_overlap_tokens: int}}|array{type: 'other'}}> $response */
         $response = $this->transporter->requestObject($payload);
 
         return VectorStoreFileResponse::from($response->data(), $response->meta());

--- a/src/Responses/VectorStores/Files/VectorStoreFileListResponse.php
+++ b/src/Responses/VectorStores/Files/VectorStoreFileListResponse.php
@@ -12,12 +12,12 @@ use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
- * @implements ResponseContract<array{object: string, data: array<int, array{id: string, object: string, usage_bytes: int, created_at: int, vector_store_id: string, status: string, last_error: ?array{code: string, message: string}}>, first_id: ?string, last_id: ?string, has_more: bool}>
+ * @implements ResponseContract<array{object: string, data: array<int, array{id: string, object: string, usage_bytes: int, created_at: int, vector_store_id: string, status: string, attributes: array<string, string>, last_error: ?array{code: string, message: string}}>, first_id: ?string, last_id: ?string, has_more: bool}>
  */
 final class VectorStoreFileListResponse implements ResponseContract, ResponseHasMetaInformationContract
 {
     /**
-     * @use ArrayAccessible<array{object: string, data: array<int, array{id: string, object: string, usage_bytes: int, created_at: int, vector_store_id: string, status: string, last_error: ?array{code: string, message: string}}>, first_id: ?string, last_id: ?string, has_more: bool}>
+     * @use ArrayAccessible<array{object: string, data: array<int, array{id: string, object: string, usage_bytes: int, created_at: int, vector_store_id: string, status: string, attributes: array<string, string>, last_error: ?array{code: string, message: string}}>, first_id: ?string, last_id: ?string, has_more: bool}>
      */
     use ArrayAccessible;
 
@@ -39,7 +39,7 @@ final class VectorStoreFileListResponse implements ResponseContract, ResponseHas
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{object: string, data: array<int, array{id: string, object: string, usage_bytes: int, created_at: int, vector_store_id: string, status: string, last_error: ?array{code: string, message: string}, chunking_strategy: array{type: 'static', static: array{max_chunk_size_tokens: int, chunk_overlap_tokens: int}}|array{type: 'other'}}>, first_id: ?string, last_id: ?string, has_more: bool}  $attributes
+     * @param  array{object: string, data: array<int, array{id: string, object: string, usage_bytes: int, created_at: int, vector_store_id: string, status: string, attributes: array<string, string>, last_error: ?array{code: string, message: string}, chunking_strategy: array{type: 'static', static: array{max_chunk_size_tokens: int, chunk_overlap_tokens: int}}|array{type: 'other'}}>, first_id: ?string, last_id: ?string, has_more: bool}  $attributes
      */
     public static function from(array $attributes, MetaInformation $meta): self
     {
@@ -61,7 +61,7 @@ final class VectorStoreFileListResponse implements ResponseContract, ResponseHas
     /**
      * {@inheritDoc}
      *
-     * @return array{object: string, data: array<int, array{id: string, object: string, usage_bytes: int, created_at: int, vector_store_id: string, status: string, last_error: array{code: string, message: string}|null}>, first_id: string|null, last_id: string|null, has_more: bool}
+     * @return array{object: string, data: array<int, array{id: string, object: string, usage_bytes: int, created_at: int, vector_store_id: string, status: string, attributes: array<string, string>, last_error: array{code: string, message: string}|null}>, first_id: string|null, last_id: string|null, has_more: bool}
      */
     public function toArray(): array
     {

--- a/src/Responses/VectorStores/Files/VectorStoreFileResponse.php
+++ b/src/Responses/VectorStores/Files/VectorStoreFileResponse.php
@@ -12,18 +12,21 @@ use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
- * @implements ResponseContract<array{id: string, object: string, usage_bytes: int, created_at: int, vector_store_id: string, status: string, last_error: ?array{code: string, message: string}, chunking_strategy: array{type: 'static', static: array{max_chunk_size_tokens: int, chunk_overlap_tokens: int}}|array{type: 'other'}}>
+ * @implements ResponseContract<array{id: string, object: string, usage_bytes: int, created_at: int, vector_store_id: string, status: string, attributes: array<string, string>, last_error: ?array{code: string, message: string}, chunking_strategy: array{type: 'static', static: array{max_chunk_size_tokens: int, chunk_overlap_tokens: int}}|array{type: 'other'}}>
  */
 final class VectorStoreFileResponse implements ResponseContract, ResponseHasMetaInformationContract
 {
     /**
-     * @use ArrayAccessible<array{id: string, object: string, usage_bytes: int, created_at: int, vector_store_id: string, status: string, last_error: ?array{code: string, message: string}, chunking_strategy: array{type: 'static', static: array{max_chunk_size_tokens: int, chunk_overlap_tokens: int}}|array{type: 'other'}}>
+     * @use ArrayAccessible<array{id: string, object: string, usage_bytes: int, created_at: int, vector_store_id: string, status: string, attributes: array<string, string>, last_error: ?array{code: string, message: string}, chunking_strategy: array{type: 'static', static: array{max_chunk_size_tokens: int, chunk_overlap_tokens: int}}|array{type: 'other'}}>
      */
     use ArrayAccessible;
 
     use Fakeable;
     use HasMetaInformation;
 
+    /**
+     * @param  array<string, string>  $attributes
+     */
     private function __construct(
         public readonly string $id,
         public readonly string $object,
@@ -31,6 +34,7 @@ final class VectorStoreFileResponse implements ResponseContract, ResponseHasMeta
         public readonly int $createdAt,
         public readonly string $vectorStoreId,
         public readonly string $status,
+        public readonly array $attributes,
         public readonly ?VectorStoreFileResponseLastError $lastError,
         public readonly VectorStoreFileResponseChunkingStrategyStatic|VectorStoreFileResponseChunkingStrategyOther $chunkingStrategy,
         private readonly MetaInformation $meta,
@@ -39,7 +43,7 @@ final class VectorStoreFileResponse implements ResponseContract, ResponseHasMeta
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{id: string, object: string, usage_bytes: int, created_at: int, vector_store_id: string, status: string, last_error: ?array{code: string, message: string}, chunking_strategy: array{type: 'static', static: array{max_chunk_size_tokens: int, chunk_overlap_tokens: int}}|array{type: 'other'}}  $attributes
+     * @param  array{id: string, object: string, usage_bytes: int, created_at: int, vector_store_id: string, status: string, attributes: ?array<string, string>, last_error: ?array{code: string, message: string}, chunking_strategy: array{type: 'static', static: array{max_chunk_size_tokens: int, chunk_overlap_tokens: int}}|array{type: 'other'}}  $attributes
      */
     public static function from(array $attributes, MetaInformation $meta): self
     {
@@ -50,6 +54,7 @@ final class VectorStoreFileResponse implements ResponseContract, ResponseHasMeta
             $attributes['created_at'],
             $attributes['vector_store_id'],
             $attributes['status'],
+            $attributes['attributes'] ?? [],
             isset($attributes['last_error']) ? VectorStoreFileResponseLastError::from($attributes['last_error']) : null,
             $attributes['chunking_strategy']['type'] === 'static' ? VectorStoreFileResponseChunkingStrategyStatic::from($attributes['chunking_strategy']) : VectorStoreFileResponseChunkingStrategyOther::from($attributes['chunking_strategy']),
             $meta,
@@ -68,6 +73,7 @@ final class VectorStoreFileResponse implements ResponseContract, ResponseHasMeta
             'created_at' => $this->createdAt,
             'vector_store_id' => $this->vectorStoreId,
             'status' => $this->status,
+            'attributes' => $this->attributes,
             'last_error' => $this->lastError instanceof VectorStoreFileResponseLastError ? $this->lastError->toArray() : null,
             'chunking_strategy' => $this->chunkingStrategy->toArray(),
         ];

--- a/src/Testing/Responses/Fixtures/VectorStores/Files/VectorStoreFileListResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/VectorStores/Files/VectorStoreFileListResponseFixture.php
@@ -14,6 +14,7 @@ final class VectorStoreFileListResponseFixture
                 'created_at' => 1_715_956_697,
                 'vector_store_id' => 'vs_xds05V7ep0QMGI5JmYnWsJwb',
                 'status' => 'completed',
+                'attributes' => [],
                 'last_error' => null,
             ],
         ],

--- a/src/Testing/Responses/Fixtures/VectorStores/Files/VectorStoreFileResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/VectorStores/Files/VectorStoreFileResponseFixture.php
@@ -11,6 +11,7 @@ final class VectorStoreFileResponseFixture
         'created_at' => 1_715_956_697,
         'vector_store_id' => 'vs_xds05V7ep0QMGI5JmYnWsJwb',
         'status' => 'completed',
+        'attributes' => [],
         'last_error' => null,
     ];
 }

--- a/src/Testing/Responses/Fixtures/VectorStores/VectorStoreListResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/VectorStores/VectorStoreListResponseFixture.php
@@ -12,6 +12,7 @@ final class VectorStoreListResponseFixture
                 'object' => 'vector_store',
                 'name' => 'Product Knowledge Base',
                 'status' => 'completed',
+                'attributes' => [],
                 'usage_bytes' => 29882,
                 'created_at' => 1_715_953_317,
                 'file_counts' => [
@@ -31,6 +32,7 @@ final class VectorStoreListResponseFixture
                 'object' => 'vector_store',
                 'name' => null,
                 'status' => 'completed',
+                'attributes' => [],
                 'usage_bytes' => 0,
                 'created_at' => 1_710_869_420,
                 'file_counts' => [

--- a/tests/Fixtures/VectorStoreFile.php
+++ b/tests/Fixtures/VectorStoreFile.php
@@ -38,9 +38,6 @@ function vectorStoreFileWithLastErrorResource(): array
         'created_at' => 1715956697,
         'vector_store_id' => 'vs_xds05V7ep0QMGI5JmYnWsJwb',
         'status' => 'completed',
-        'attributes' => [
-            'foo' => 'bar',
-        ],
         'last_error' => [
             'code' => 'error-001',
             'message' => 'Error scanning file',

--- a/tests/Fixtures/VectorStoreFile.php
+++ b/tests/Fixtures/VectorStoreFile.php
@@ -12,6 +12,9 @@ function vectorStoreFileResource(): array
         'created_at' => 1715956697,
         'vector_store_id' => 'vs_xds05V7ep0QMGI5JmYnWsJwb',
         'status' => 'completed',
+        'attributes' => [
+            'foo' => 'bar',
+        ],
         'last_error' => null,
         'chunking_strategy' => [
             'type' => 'static',
@@ -35,6 +38,9 @@ function vectorStoreFileWithLastErrorResource(): array
         'created_at' => 1715956697,
         'vector_store_id' => 'vs_xds05V7ep0QMGI5JmYnWsJwb',
         'status' => 'completed',
+        'attributes' => [
+            'foo' => 'bar',
+        ],
         'last_error' => [
             'code' => 'error-001',
             'message' => 'Error scanning file',

--- a/tests/Responses/VectorStores/Files/VectorStoreFileResponse.php
+++ b/tests/Responses/VectorStores/Files/VectorStoreFileResponse.php
@@ -21,6 +21,15 @@ test('from', function () {
         ->chunkingStrategy->chunkOverlapTokens->toBe(400);
 });
 
+test('from while missing attributes', function () {
+    $payload = vectorStoreFileResource();
+    unset($payload['attributes']);
+    $result = VectorStoreFileResponse::from($payload, meta());
+
+    expect($result)
+        ->attributes->toBe([]);
+});
+
 test('as array accessible', function () {
     $result = VectorStoreFileResponse::from(vectorStoreFileResource(), meta());
 

--- a/tests/Responses/VectorStores/Files/VectorStoreFileResponse.php
+++ b/tests/Responses/VectorStores/Files/VectorStoreFileResponse.php
@@ -13,6 +13,7 @@ test('from', function () {
         ->createdAt->toBe(1715956697)
         ->vectorStoreId->toBe('vs_xds05V7ep0QMGI5JmYnWsJwb')
         ->status->toBe('completed')
+        ->attributes->toBe(['foo' => 'bar'])
         ->lastError->toBeNull()
         ->chunkingStrategy->toBeInstanceOf(VectorStoreFileResponseChunkingStrategyStatic::class)
         ->chunkingStrategy->type->toBe('static')


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

The custom attribute (key/value) pair on Vector Store files was missing. They have some limitations, but we just treat them as a generic array of string/string.

> Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format, and querying for objects via API or the dashboard. Keys are strings with a maximum length of 64 characters. Values are strings with a maximum length of 512 characters, booleans, or numbers.

### Related:

fixes: #537 
