### PR TITLE
fix: add throwIfNotSuccessfulStatusCode method to validate HTTP statu…

### DIFF
--- a/src/Exceptions/UnexpectedStatusCodeException.php
+++ b/src/Exceptions/UnexpectedStatusCodeException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Exceptions;
+
+use Exception;
+
+final class UnexpectedStatusCodeException extends Exception
+{
+    /**
+     * Creates a new Exception instance.
+     *
+     * @param int $statusCode The HTTP status code.
+     */
+
+    public function __construct(int $statusCode)
+    {
+        $message = "Unexpected status code: {$statusCode}";
+
+        parent::__construct($message, $statusCode);
+    }
+}

--- a/tests/Transporters/HttpTransporter.php
+++ b/tests/Transporters/HttpTransporter.php
@@ -16,6 +16,7 @@ use OpenAI\ValueObjects\Transporter\QueryParams;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use \OpenAI\Exceptions\UnexpectedStatusCodeException;
 
 beforeEach(function () {
     $this->client = Mockery::mock(ClientInterface::class);
@@ -529,5 +530,173 @@ test('request stream server errors', function () {
                 ->and($e->getErrorMessage())->toBe('Incorrect API key provided: foo. You can find your API key at https://platform.openai.com.')
                 ->and($e->getErrorCode())->toBe('invalid_api_key')
                 ->and($e->getErrorType())->toBe('invalid_request_error');
+        });
+});
+
+test('request stream client error 400', function () {
+    $payload = Payload::create('completions', []);
+
+    $response = new Response(400, [], json_encode([
+        'error' => [
+            'message' => 'Bad Request',
+            'type' => 'client_error',
+            'param' => null,
+            'code' => 'bad_request',
+        ],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendAsyncRequest')
+        ->once()
+        ->andReturn($response);
+
+    expect(fn () => $this->http->requestStream($payload))
+        ->toThrow(function (UnexpectedStatusCodeException $e) {
+            expect($e->getMessage())->toBe('Unexpected status code: 400')
+                ->and($e->getCode())->toBe(400);
+        });
+});
+
+test('request stream client error 401', function () {
+    $payload = Payload::create('completions', []);
+
+    $response = new Response(401, [], json_encode([
+        'error' => [
+            'message' => 'Unauthorized',
+            'type' => 'client_error',
+            'param' => null,
+            'code' => 'unauthorized',
+        ],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendAsyncRequest')
+        ->once()
+        ->andReturn($response);
+
+    expect(fn () => $this->http->requestStream($payload))
+        ->toThrow(function (UnexpectedStatusCodeException $e) {
+            expect($e->getMessage())->toBe('Unexpected status code: 401')
+                ->and($e->getCode())->toBe(401);
+        });
+});
+
+test('request stream client error 403', function () {
+    $payload = Payload::create('completions', []);
+
+    $response = new Response(403, [], json_encode([
+        'error' => [
+            'message' => 'Forbidden',
+            'type' => 'client_error',
+            'param' => null,
+            'code' => 'forbidden',
+        ],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendAsyncRequest')
+        ->once()
+        ->andReturn($response);
+
+    expect(fn () => $this->http->requestStream($payload))
+        ->toThrow(function (UnexpectedStatusCodeException $e) {
+            expect($e->getMessage())->toBe('Unexpected status code: 403')
+                ->and($e->getCode())->toBe(403);
+        });
+});
+
+test('request stream client error 404', function () {
+    $payload = Payload::create('completions', []);
+
+    $response = new Response(404, [], json_encode([
+        'error' => [
+            'message' => 'Not Found',
+            'type' => 'client_error',
+            'param' => null,
+            'code' => 'not_found',
+        ],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendAsyncRequest')
+        ->once()
+        ->andReturn($response);
+
+    expect(fn () => $this->http->requestStream($payload))
+        ->toThrow(function (UnexpectedStatusCodeException $e) {
+            expect($e->getMessage())->toBe('Unexpected status code: 404')
+                ->and($e->getCode())->toBe(404);
+        });
+});
+
+test('request stream client error 422', function () {
+    $payload = Payload::create('completions', []);
+
+    $response = new Response(422, [], json_encode([
+        'error' => [
+            'message' => 'Unprocessable Entity',
+            'type' => 'client_error',
+            'param' => null,
+            'code' => 'unprocessable_entity',
+        ],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendAsyncRequest')
+        ->once()
+        ->andReturn($response);
+
+    expect(fn () => $this->http->requestStream($payload))
+        ->toThrow(function (UnexpectedStatusCodeException $e) {
+            expect($e->getMessage())->toBe('Unexpected status code: 422')
+                ->and($e->getCode())->toBe(422);
+        });
+});
+
+test('request stream client error 429', function () {
+    $payload = Payload::create('completions', []);
+
+    $response = new Response(429, [], json_encode([
+        'error' => [
+            'message' => 'Too Many Requests',
+            'type' => 'client_error',
+            'param' => null,
+            'code' => 'too_many_requests',
+        ],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendAsyncRequest')
+        ->once()
+        ->andReturn($response);
+
+    expect(fn () => $this->http->requestStream($payload))
+        ->toThrow(function (UnexpectedStatusCodeException $e) {
+            expect($e->getMessage())->toBe('Unexpected status code: 429')
+                ->and($e->getCode())->toBe(429);
+        });
+});
+
+test('request stream client error 500', function () {
+    $payload = Payload::create('completions', []);
+
+    $response = new Response(500, [], json_encode([
+        'error' => [
+            'message' => 'Internal Server Error',
+            'type' => 'client_error',
+            'param' => null,
+            'code' => 'internal_server_error',
+        ],
+    ]));
+
+    $this->client
+        ->shouldReceive('sendAsyncRequest')
+        ->once()
+        ->andReturn($response);
+
+    expect(fn () => $this->http->requestStream($payload))
+        ->toThrow(function (UnexpectedStatusCodeException $e) {
+            expect($e->getMessage())->toBe('Unexpected status code: 500')
+                ->and($e->getCode())->toBe(500);
         });
 });


### PR DESCRIPTION
### Summary
This PR introduces stricter HTTP status code validation to the `HttpTransporter` by adding a new method: `throwIfNotSuccessfulStatusCode`. The method ensures that only successful HTTP responses (status codes 200–299) are allowed to proceed. Any other status code results in a thrown `UnexpectedStatusCodeException`.

### Changes
- ✅ Added `throwIfNotSuccessfulStatusCode` method to validate response status codes.
- 🔄 Updated `requestObject`, `requestContent`, and `requestStream` methods to call this validation method.
- 🧪 Added comprehensive tests for various non-successful HTTP status codes.
- 🔧 Fixes issues: #341 and #339.

### Expected Outcome
With this improvement, the client will now provide immediate and clearer feedback when encountering invalid or unexpected HTTP responses, preventing potentially misleading or silent failures.

Looking forward to your feedback!
