### PR TITLE
fix: chat completion choices to allow responses without logprobs field

### DIFF
--- a/src/Responses/Chat/CreateResponseChoice.php
+++ b/src/Responses/Chat/CreateResponseChoice.php
@@ -14,14 +14,14 @@ final class CreateResponseChoice
     ) {}
 
     /**
-     * @param  array{index: int, message: array{role: string, content: ?string, function_call: ?array{name: string, arguments: string}, tool_calls: ?array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}, logprobs: ?array{content: ?array<int, array{token: string, logprob: float, bytes: ?array<int, int>}>}, finish_reason: string|null}  $attributes
+     * @param  array{index: int, message: array{role: string, content: ?string, function_call: ?array{name: string, arguments: string}, tool_calls: ?array<int, array{id: string, type: string, function: array{name: string, arguments: string}}>}, logprobs?: ?array{content: ?array<int, array{token: string, logprob: float, bytes: ?array<int, int>}>}, finish_reason: string|null}  $attributes
      */
     public static function from(array $attributes): self
     {
         return new self(
             $attributes['index'],
             CreateResponseMessage::from($attributes['message']),
-            $attributes['logprobs'] ? CreateResponseChoiceLogprobs::from($attributes['logprobs']) : null,
+            isset($attributes['logprobs']) ? CreateResponseChoiceLogprobs::from($attributes['logprobs']) : null,
             $attributes['finish_reason'] ?? null,
         );
     }

--- a/tests/Fixtures/Chat.php
+++ b/tests/Fixtures/Chat.php
@@ -98,6 +98,42 @@ function chatCompletionWithoutUsage(): array
 /**
  * @return array<string, mixed>
  */
+function chatCompletionWithoutLogprobs(): array
+{
+    return [
+        'id' => 'chatcmpl-123',
+        'object' => 'chat.completion',
+        'created' => 1677652288,
+        'model' => 'gpt-3.5-turbo',
+        'choices' => [
+            [
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => "\n\nHello there, how may I assist you today?",
+                ],
+                'finish_reason' => 'stop',
+            ],
+        ],
+        'usage' => [
+            'prompt_tokens' => 9,
+            'completion_tokens' => 12,
+            'total_tokens' => 21,
+            'prompt_tokens_details' => [
+                'cached_tokens' => 5,
+            ],
+            'completion_tokens_details' => [
+                'reasoning_tokens' => 0,
+                'accepted_prediction_tokens' => 0,
+                'rejected_prediction_tokens' => 0,
+            ],
+        ],
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
 function chatCompletionWithLogprobs(): array
 {
     return [

--- a/tests/Responses/Chat/CreateResponseChoice.php
+++ b/tests/Responses/Chat/CreateResponseChoice.php
@@ -14,6 +14,16 @@ test('from', function () {
         ->finishReason->toBeIn(['stop', null]);
 });
 
+test('from without logprobs', function () {
+    $result = CreateResponseChoice::from(chatCompletionWithoutLogprobs()['choices'][0]);
+
+    expect($result)
+        ->index->toBe(0)
+        ->message->toBeInstanceOf(CreateResponseMessage::class)
+        ->logprobs->toBeNull()
+        ->finishReason->toBeIn(['stop', null]);
+});
+
 test('from with logprobs', function () {
     $result = CreateResponseChoice::from(chatCompletionWithLogprobs()['choices'][0]);
 


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the OpenAI PHP team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

<!-- describe what your PR is solving -->

As it has been some time since I last forked the repository, I noticed from OpenAI's documentation that the chat completion's 'choices' now includes a 'logprobs' field. However, Google Gemini's OpenAI compatibility layer doesn't yet support this field. Therefore, I've modified the code to allow chat completion 'choices' to function without requiring the 'logprobs' field.

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->

fixes: #502 