### PR TITLE
fix: Support streaming of non-OpenAI models that return "ping"

### DIFF
--- a/src/Responses/StreamResponse.php
+++ b/src/Responses/StreamResponse.php
@@ -53,11 +53,15 @@ final class StreamResponse implements ResponseHasMetaInformationContract, Respon
                 break;
             }
 
-            /** @var array{error?: array{message: string|array<int, string>, type: string, code: string}} $response */
+            /** @var array{error?: array{message: string|array<int, string>, type: string, code: string}, type?: string} $response */
             $response = json_decode($data, true, flags: JSON_THROW_ON_ERROR);
 
             if (isset($response['error'])) {
                 throw new ErrorException($response['error'], $this->response->getStatusCode());
+            }
+
+            if (isset($response['type']) && $response['type'] === 'ping') {
+                continue;
             }
 
             if ($event !== null) {

--- a/tests/Fixtures/Chat.php
+++ b/tests/Fixtures/Chat.php
@@ -310,6 +310,14 @@ function chatCompletionStream()
 /**
  * @return resource
  */
+function chatCompletionStreamPing()
+{
+    return fopen(__DIR__.'/Streams/ChatCompletionPing.txt', 'r');
+}
+
+/**
+ * @return resource
+ */
 function chatCompletionStreamError()
 {
     return fopen(__DIR__.'/Streams/ChatCompletionCreateError.txt', 'r');

--- a/tests/Fixtures/Streams/ChatCompletionPing.txt
+++ b/tests/Fixtures/Streams/ChatCompletionPing.txt
@@ -1,0 +1,9 @@
+data: {"id":"msg_0111RgCFCqN68mJbev6Rq1cz","choices":[{"index":0,"delta":{"role":"assistant"}}],"created":1744469024,"model":"claude-3-7-sonnet-20250219","object":"chat.completion.chunk"}
+data: {"type": "ping"}
+data: {"id":"msg_0111RgCFCqN68mJbev6Rq1cz","choices":[{"index":0,"delta":{"content":"Hello!"}}],"created":1744469024,"model":"claude-3-7-sonnet-20250219","object":"chat.completion.chunk"}
+data: {"id":"msg_0111RgCFCqN68mJbev6Rq1cz","choices":[{"index":0,"delta":{"content":" How can I assist you today? I'm here to help"}}],"created":1744469024,"model":"claude-3-7-sonnet-20250219","object":"chat.completion.chunk"}
+data: {"id":"msg_0111RgCFCqN68mJbev6Rq1cz","choices":[{"index":0,"delta":{"content":" with information, answer questions, or discuss"}}],"created":1744469024,"model":"claude-3-7-sonnet-20250219","object":"chat.completion.chunk"}
+data: {"id":"msg_0111RgCFCqN68mJbev6Rq1cz","choices":[{"index":0,"delta":{"content":" various topics. Feel free to let me know what you're"}}],"created":1744469024,"model":"claude-3-7-sonnet-20250219","object":"chat.completion.chunk"}
+data: {"id":"msg_0111RgCFCqN68mJbev6Rq1cz","choices":[{"index":0,"delta":{"content":" interested in talking about."}}],"created":1744469024,"model":"claude-3-7-sonnet-20250219","object":"chat.completion.chunk"}
+data: {"id":"msg_0111RgCFCqN68mJbev6Rq1cz","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"created":1744469024,"model":"claude-3-7-sonnet-20250219","object":"chat.completion.chunk"}
+data: [DONE]

--- a/tests/Resources/Chat.php
+++ b/tests/Resources/Chat.php
@@ -100,6 +100,29 @@ test('create streamed', function () {
         ->toBeInstanceOf(MetaInformation::class);
 });
 
+test('handles ping messages in stream', function () {
+    $response = new Response(
+        body: new Stream(chatCompletionStreamPing()),
+        headers: metaHeaders(),
+    );
+
+    $client = mockStreamClient('POST', 'chat/completions', [
+        'model' => 'gpt-3.5-turbo',
+        'messages' => ['role' => 'user', 'content' => 'Hello!'],
+        'stream' => true,
+    ], $response);
+
+    $stream = $client->chat()->createStreamed([
+        'model' => 'gpt-3.5-turbo',
+        'messages' => ['role' => 'user', 'content' => 'Hello!'],
+    ]);
+
+    foreach ($stream as $response) {
+        expect($response)
+            ->toBeInstanceOf(CreateStreamedResponse::class);
+    }
+});
+
 test('handles error messages in stream', function () {
     $response = new Response(
         body: new Stream(chatCompletionStreamError())

--- a/tests/Responses/Chat/CreateStreamedResponse.php
+++ b/tests/Responses/Chat/CreateStreamedResponse.php
@@ -60,3 +60,10 @@ test('fake with override', function () {
     expect($response->getIterator()->current())
         ->id->toBe('chatcmpl-6wdIE4DsUtqf1srdMTsfkJp0VWZgz');
 });
+
+test('fake with ping', function () {
+    $response = CreateStreamedResponse::fake(chatCompletionStreamPing());
+
+    expect($response->getIterator()->current())
+        ->id->toBe('msg_0111RgCFCqN68mJbev6Rq1cz');
+});


### PR DESCRIPTION
### What:

- [x] Bug Fix

### Description:

When running streaming from Claude in OpenAI compatibility mode we find that Claude returns a payload structure (shortened) like this.

```text
data: {"id":"msg_0111RgCFCqN68mJbev6Rq1cz","choices":[{"index":0,"delta":{"role":"assistant"}}],"created":1744469024,"model":"claude-3-7-sonnet-20250219","object":"chat.completion.chunk"}
data: {"type": "ping"}
data: {"id":"msg_0111RgCFCqN68mJbev6Rq1cz","choices":[{"index":0,"delta":{"content":"Hello!"}}],"created":1744469024,"model":"claude-3-7-sonnet-20250219","object":"chat.completion.chunk"}
data: [DONE]
```

### Related:

fixes: https://github.com/openai-php/client/issues/555