### PR TITLE
Allow arguments to be passed to files list request

### DIFF
--- a/src/Contracts/Resources/FilesContract.php
+++ b/src/Contracts/Resources/FilesContract.php
@@ -13,8 +13,10 @@ interface FilesContract
      * Returns a list of files that belong to the user's organization.
      *
      * @see https://platform.openai.com/docs/api-reference/files/list
+     *
+     * @param  array<string, mixed>  $parameters
      */
-    public function list(): ListResponse;
+    public function list(array $parameters = []): ListResponse;
 
     /**
      * Returns information about a specific file.

--- a/src/Resources/Files.php
+++ b/src/Resources/Files.php
@@ -20,12 +20,10 @@ final class Files implements FilesContract
      * Returns a list of files that belong to the user's organization.
      *
      * @see https://platform.openai.com/docs/api-reference/files/list
-     *
-     * @param  array<string, mixed>  $parameters
      */
     public function list(array $parameters = []): ListResponse
     {
-        $payload = Payload::list('files', parameters: $parameters);
+        $payload = Payload::list('files', $parameters);
 
         /** @var Response<array{object: string, data: array<int, array{id: string, object: string, created_at: int, bytes: ?int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>}> $response */
         $response = $this->transporter->requestObject($payload);

--- a/src/Resources/Files.php
+++ b/src/Resources/Files.php
@@ -20,10 +20,12 @@ final class Files implements FilesContract
      * Returns a list of files that belong to the user's organization.
      *
      * @see https://platform.openai.com/docs/api-reference/files/list
+     *
+     * @param  array<string, mixed>  $parameters
      */
-    public function list(): ListResponse
+    public function list(array $parameters = []): ListResponse
     {
-        $payload = Payload::list('files');
+        $payload = Payload::list('files', parameters: $parameters);
 
         /** @var Response<array{object: string, data: array<int, array{id: string, object: string, created_at: int, bytes: ?int, filename: string, purpose: string, status: string, status_details: array<array-key, mixed>|string|null}>}> $response */
         $response = $this->transporter->requestObject($payload);

--- a/src/Testing/Resources/FilesTestResource.php
+++ b/src/Testing/Resources/FilesTestResource.php
@@ -19,9 +19,9 @@ final class FilesTestResource implements FilesContract
         return Files::class;
     }
 
-    public function list(): ListResponse
+    public function list(array $parameters = []): ListResponse
     {
-        return $this->record(__FUNCTION__);
+        return $this->record(__FUNCTION__, func_get_args());
     }
 
     public function retrieve(string $file): RetrieveResponse

--- a/tests/Testing/Resources/FilesTestResource.php
+++ b/tests/Testing/Resources/FilesTestResource.php
@@ -32,6 +32,21 @@ it('records a files list request', function () {
     });
 });
 
+it('records a file list request with parameters', function () {
+    $fake = new ClientFake([
+        ListResponse::fake(),
+    ]);
+
+    $fake->files()->list([
+        'limit' => 1,
+    ]);
+
+    $fake->assertSent(Files::class, function ($method, $parameters) {
+        return $method === 'list' &&
+            $parameters['limit'] === 1;
+    });
+});
+
 it('records a files download request', function () {
     $fake = new ClientFake([
         'fake-file-content',


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

[From a discussion on Twitter...](https://x.com/assertchris/status/1910355384562229390)

TL;DR:
You can't currently pass parameters to the files list request, which means you can only ever get the first 10. This PR adds the ability to paginate, change limit etc.

Unrelated: the refactor commands in readme don't appear to work. Everything else passed.

### Related:

fixes: #500 