### PR TITLE
Add index to CreateStreamedResponseToolCall

### DIFF
--- a/src/Responses/Chat/CreateStreamedResponseToolCall.php
+++ b/src/Responses/Chat/CreateStreamedResponseToolCall.php
@@ -7,17 +7,19 @@ namespace OpenAI\Responses\Chat;
 final class CreateStreamedResponseToolCall
 {
     private function __construct(
+        public readonly ?int $index,
         public readonly ?string $id,
         public readonly ?string $type,
         public readonly CreateStreamedResponseToolCallFunction $function,
     ) {}
 
     /**
-     * @param  array{id?: string, type?: string, function: array{name?: string, arguments: string}}  $attributes
+     * @param  array{index?: int, id?: string, type?: string, function: array{name?: string, arguments: string}}  $attributes
      */
     public static function from(array $attributes): self
     {
         return new self(
+            $attributes['index'] ?? null,
             $attributes['id'] ?? null,
             $attributes['type'] ?? null,
             CreateStreamedResponseToolCallFunction::from($attributes['function']),


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

When a response is streaming tool calls, we have to know the index of the delta to recompose the JSON arguments properly.

<details>
<summary>See tool calls chunk combination code</summary>

```php
foreach ($toolCallsDelta ?? [] as $toolCallDelta) {
    if (! isset($toolCalls[$toolCallDelta->index])) {
        // Initialize the tool call when first encountered
        $toolCalls[$toolCallDelta->index] = [
            'id' => $toolCallDelta->id,
            'type' => $toolCallDelta->type,
            'function' => [
                'name' => $toolCallDelta->function->name ?? '',
                'arguments' => $toolCallDelta->function->arguments ?? '',
            ],
        ];

        continue;
    }

    // Append to arguments for subsequent chunks
    if (isset($toolCallDelta->function->arguments)) {
        $toolCalls[$toolCallDelta->index]['function']['arguments'] .= $toolCallDelta->function->arguments;
    }
}
```
</details>

I don't see any other way to do this except not use any streaming which doesn't provide an acceptable UX.

I'm open to suggestions if I missed something.