### PR TITLE
Fix gemini list models

### DIFF
--- a/src/Responses/Models/ListResponse.php
+++ b/src/Responses/Models/ListResponse.php
@@ -12,12 +12,12 @@ use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
- * @implements ResponseContract<array{object: string, data: array<int, array{id: string, object: string, created: int, owned_by: string}>}>
+ * @implements ResponseContract<array{object: string, data: array<int, array{id: string, object: string, created: ?int, owned_by: string}>}>
  */
 final class ListResponse implements ResponseContract, ResponseHasMetaInformationContract
 {
     /**
-     * @use ArrayAccessible<array{object: string, data: array<int, array{id: string, object: string, created: int, owned_by: string}>}>
+     * @use ArrayAccessible<array{object: string, data: array<int, array{id: string, object: string, created: ?int, owned_by: string}>}>
      */
     use ArrayAccessible;
 
@@ -36,7 +36,7 @@ final class ListResponse implements ResponseContract, ResponseHasMetaInformation
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{object: string, data: array<int, array{id: string, object: string, created: int, owned_by: string}>}  $attributes
+     * @param  array{object: string, data: array<int, array{id: string, object: string, created: ?int, owned_by: string}>}  $attributes
      */
     public static function from(array $attributes, MetaInformation $meta): self
     {

--- a/src/Responses/Models/RetrieveResponse.php
+++ b/src/Responses/Models/RetrieveResponse.php
@@ -12,12 +12,12 @@ use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
- * @implements ResponseContract<array{id: string, object: string, created: int, owned_by: string}>
+ * @implements ResponseContract<array{id: string, object: string, created: ?int, owned_by: string}>
  */
 final class RetrieveResponse implements ResponseContract, ResponseHasMetaInformationContract
 {
     /**
-     * @use ArrayAccessible<array{id: string, object: string, created: int, owned_by: string}>
+     * @use ArrayAccessible<array{id: string, object: string, created: ?int, owned_by: string}>
      */
     use ArrayAccessible;
 
@@ -35,7 +35,7 @@ final class RetrieveResponse implements ResponseContract, ResponseHasMetaInforma
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{id: string, object: string, created: int, owned_by: string}  $attributes
+     * @param  array{id: string, object: string, created: ?int, owned_by: string}  $attributes
      */
     public static function from(array $attributes, MetaInformation $meta): self
     {

--- a/src/Responses/Models/RetrieveResponse.php
+++ b/src/Responses/Models/RetrieveResponse.php
@@ -27,7 +27,7 @@ final class RetrieveResponse implements ResponseContract, ResponseHasMetaInforma
     private function __construct(
         public readonly string $id,
         public readonly string $object,
-        public readonly int $created,
+        public readonly ?int $created,
         public readonly string $ownedBy,
         private readonly MetaInformation $meta,
     ) {}
@@ -42,7 +42,7 @@ final class RetrieveResponse implements ResponseContract, ResponseHasMetaInforma
         return new self(
             $attributes['id'],
             $attributes['object'],
-            $attributes['created'],
+            $attributes['created'] ?? null,
             $attributes['owned_by'],
             $meta,
         );

--- a/tests/Fixtures/Model.php
+++ b/tests/Fixtures/Model.php
@@ -14,6 +14,18 @@ function model(): array
 }
 
 /**
+ * @return array<string, string>
+ */
+function googleModel(): array
+{
+    return [
+        'id' => 'text-davinci-003',
+        'object' => 'model',
+        'owned_by' => 'google',
+    ];
+}
+
+/**
  * @return array<string, mixed>
  */
 function modelList(): array

--- a/tests/Responses/Models/RetrieveResponse.php
+++ b/tests/Responses/Models/RetrieveResponse.php
@@ -15,6 +15,17 @@ test('from', function () {
         ->meta()->toBeInstanceOf(MetaInformation::class);
 });
 
+test('from google', function () {
+    $result = RetrieveResponse::from(googleModel(), meta());
+
+    expect($result)
+        ->toBeInstanceOf(RetrieveResponse::class)
+        ->id->toBe('text-davinci-003')
+        ->object->toBe('model')
+        ->ownedBy->toBe('google')
+        ->meta()->toBeInstanceOf(MetaInformation::class);
+});
+
 test('as array accessible', function () {
     $result = RetrieveResponse::from(model(), meta());
 


### PR DESCRIPTION
### What:

- [x] Bug Fix

### Description:

It seems the 'created' field doesn't always exist on some of these APIs. I experienced the issue with Google Gemini, but after I worked on this code briefly I noticed another pull request existed that was addressing issues with Azure, but by falling back to 0 instead of null. 

This just marks the field as nullable and yields null. I think it's worth discussing (as noted in the linked PR) whether this approach is better or if created should fall back to '0' or something similar.

### Related:

fixes: https://github.com/openai-php/client/issues/566
closes: https://github.com/openai-php/client/pull/458
