### PR TITLE
feat: Add usage field to image generation responses

### DIFF
--- a/src/Resources/Images.php
+++ b/src/Resources/Images.php
@@ -26,7 +26,7 @@ final class Images implements ImagesContract
     {
         $payload = Payload::create('images/generations', $parameters);
 
-        /** @var Response<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>}> $response */
+        /** @var Response<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>, usage: ?array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}> $response */
         $response = $this->transporter->requestObject($payload);
 
         return CreateResponse::from($response->data(), $response->meta());

--- a/src/Resources/Images.php
+++ b/src/Resources/Images.php
@@ -26,7 +26,7 @@ final class Images implements ImagesContract
     {
         $payload = Payload::create('images/generations', $parameters);
 
-        /** @var Response<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>, usage: ?array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}> $response */
+        /** @var Response<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}> $response */
         $response = $this->transporter->requestObject($payload);
 
         return CreateResponse::from($response->data(), $response->meta());

--- a/src/Responses/Images/CreateResponse.php
+++ b/src/Responses/Images/CreateResponse.php
@@ -12,12 +12,12 @@ use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
- * @implements ResponseContract<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>}>
+ * @implements ResponseContract<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>, usage: ?array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}>
  */
 final class CreateResponse implements ResponseContract, ResponseHasMetaInformationContract
 {
     /**
-     * @use ArrayAccessible<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>}>
+     * @use ArrayAccessible<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>, usage: ?array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}>
      */
     use ArrayAccessible;
 
@@ -30,13 +30,14 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
     private function __construct(
         public readonly int $created,
         public readonly array $data,
+        public readonly ?CreateResponseUsage $usage,
         private readonly MetaInformation $meta,
     ) {}
 
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>}  $attributes
+     * @param  array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>, usage: ?array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}  $attributes
      */
     public static function from(array $attributes, MetaInformation $meta): self
     {
@@ -47,6 +48,7 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
         return new self(
             $attributes['created'],
             $results,
+            isset($attributes['usage']) ? CreateResponseUsage::from($attributes['usage']) : null,
             $meta,
         );
     }
@@ -62,6 +64,7 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
                 static fn (CreateResponseData $result): array => $result->toArray(),
                 $this->data,
             ),
+            'usage' => $this->usage?->toArray(),
         ];
     }
 }

--- a/src/Responses/Images/CreateResponse.php
+++ b/src/Responses/Images/CreateResponse.php
@@ -12,12 +12,12 @@ use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
- * @implements ResponseContract<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>, usage: ?array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}>
+ * @implements ResponseContract<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}>
  */
 final class CreateResponse implements ResponseContract, ResponseHasMetaInformationContract
 {
     /**
-     * @use ArrayAccessible<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>, usage: ?array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}>
+     * @use ArrayAccessible<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}>
      */
     use ArrayAccessible;
 
@@ -37,7 +37,7 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>, usage: ?array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}  $attributes
+     * @param  array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}  $attributes
      */
     public static function from(array $attributes, MetaInformation $meta): self
     {
@@ -58,13 +58,13 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
      */
     public function toArray(): array
     {
-        return [
+        return array_filter([
             'created' => $this->created,
             'data' => array_map(
                 static fn (CreateResponseData $result): array => $result->toArray(),
                 $this->data,
             ),
             'usage' => $this->usage?->toArray(),
-        ];
+        ], fn (mixed $value): bool => ! is_null($value));
     }
 }

--- a/src/Responses/Images/CreateResponseUsage.php
+++ b/src/Responses/Images/CreateResponseUsage.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Responses\Images;
+
+final class CreateResponseUsage
+{
+    private function __construct(
+        public readonly int $totalTokens,
+        public readonly int $inputTokens,
+        public readonly int $outputTokens,
+        public readonly CreateResponseUsageInputTokensDetails $inputTokensDetails,
+    ) {}
+
+    /**
+     * @param  array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            $attributes['total_tokens'],
+            $attributes['input_tokens'],
+            $attributes['output_tokens'],
+            CreateResponseUsageInputTokensDetails::from($attributes['input_tokens_details']),
+        );
+    }
+
+    /**
+     * @return array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}
+     */
+    public function toArray(): array
+    {
+        return [
+            'total_tokens' => $this->totalTokens,
+            'input_tokens' => $this->inputTokens,
+            'output_tokens' => $this->outputTokens,
+            'input_tokens_details' => $this->inputTokensDetails->toArray(),
+        ];
+    }
+}

--- a/src/Responses/Images/CreateResponseUsageInputTokensDetails.php
+++ b/src/Responses/Images/CreateResponseUsageInputTokensDetails.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace OpenAI\Responses\Images;
+
+class CreateResponseUsageInputTokensDetails
+{
+    private function __construct(
+        public readonly int $imageTokens,
+        public readonly int $textTokens
+    ) {}
+
+    /**
+     * @param  array{image_tokens:int, text_tokens:int}  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            $attributes['image_tokens'],
+            $attributes['text_tokens'],
+        );
+    }
+
+    /**
+     * @return array{image_tokens:int, text_tokens:int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'image_tokens' => $this->imageTokens,
+            'text_tokens' => $this->textTokens,
+        ];
+    }
+}

--- a/tests/Fixtures/Image.php
+++ b/tests/Fixtures/Image.php
@@ -12,6 +12,7 @@ function imageCreateWithUrl(): array
                 'url' => 'https://openai.com/image.png',
             ],
         ],
+        'usage' => null,
     ];
 }
 
@@ -28,6 +29,7 @@ function imageCreateWithUrlDallE3(): array
                 'revised_prompt' => 'This is a revised prompt.',
             ],
         ],
+        'usage' => null,
     ];
 }
 
@@ -41,6 +43,31 @@ function imageCreateWithB46Json(): array
         'data' => [
             [
                 'b64_json' => 'iVBORw0KGgoAAAAN...',
+            ],
+        ],
+        'usage' => null,
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function imageCreateWithUsage(): array
+{
+    return [
+        'created' => 1664136088,
+        'data' => [
+            [
+                'b64_json' => 'iVBORw0KGgoAAAAN...',
+            ],
+        ],
+        'usage' => [
+            'total_tokens' => 250,
+            'input_tokens' => 100,
+            'output_tokens' => 150,
+            'input_tokens_details' => [
+                'image_tokens' => 100,
+                'text_tokens' => 100,
             ],
         ],
     ];

--- a/tests/Fixtures/Image.php
+++ b/tests/Fixtures/Image.php
@@ -12,7 +12,6 @@ function imageCreateWithUrl(): array
                 'url' => 'https://openai.com/image.png',
             ],
         ],
-        'usage' => null,
     ];
 }
 
@@ -29,7 +28,6 @@ function imageCreateWithUrlDallE3(): array
                 'revised_prompt' => 'This is a revised prompt.',
             ],
         ],
-        'usage' => null,
     ];
 }
 
@@ -45,7 +43,6 @@ function imageCreateWithB46Json(): array
                 'b64_json' => 'iVBORw0KGgoAAAAN...',
             ],
         ],
-        'usage' => null,
     ];
 }
 

--- a/tests/Responses/Images/CreateResponse.php
+++ b/tests/Responses/Images/CreateResponse.php
@@ -54,6 +54,14 @@ test('to array with b64_json', function () {
         ->toBe(imageCreateWithB46Json());
 });
 
+test('from usage', function () {
+    $response = CreateResponse::from(imageCreateWithUsage(), meta());
+
+    expect($response->toArray())
+        ->toBeArray()
+        ->toBe(imageCreateWithUsage());
+});
+
 test('fake', function () {
     $response = CreateResponse::fake();
 


### PR DESCRIPTION
### What:

- [x] New Feature

### Description:

Adds the 'usage' field which is supplied by OpenAI in Image creation responses.

### Related:

https://github.com/openai-php/client/issues/569