### PR TITLE
feat(OpenAI): Add Image Response usage

### DIFF
--- a/src/Resources/Images.php
+++ b/src/Resources/Images.php
@@ -26,7 +26,7 @@ final class Images implements ImagesContract
     {
         $payload = Payload::create('images/generations', $parameters);
 
-        /** @var Response<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>}> $response */
+        /** @var Response<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}> $response */
         $response = $this->transporter->requestObject($payload);
 
         return CreateResponse::from($response->data(), $response->meta());
@@ -43,7 +43,7 @@ final class Images implements ImagesContract
     {
         $payload = Payload::upload('images/edits', $parameters);
 
-        /** @var Response<array{created: int, data: array<int, array{url?: string, b64_json?: string}>}> $response */
+        /** @var Response<array{created: int, data: array<int, array{url?: string, b64_json?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}> $response */
         $response = $this->transporter->requestObject($payload);
 
         return EditResponse::from($response->data(), $response->meta());
@@ -60,7 +60,7 @@ final class Images implements ImagesContract
     {
         $payload = Payload::upload('images/variations', $parameters);
 
-        /** @var Response<array{created: int, data: array<int, array{url?: string, b64_json?: string}>}> $response */
+        /** @var Response<array{created: int, data: array<int, array{url?: string, b64_json?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}> $response */
         $response = $this->transporter->requestObject($payload);
 
         return VariationResponse::from($response->data(), $response->meta());

--- a/src/Responses/Images/CreateResponse.php
+++ b/src/Responses/Images/CreateResponse.php
@@ -12,12 +12,12 @@ use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
- * @implements ResponseContract<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>}>
+ * @implements ResponseContract<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}>
  */
 final class CreateResponse implements ResponseContract, ResponseHasMetaInformationContract
 {
     /**
-     * @use ArrayAccessible<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>}>
+     * @use ArrayAccessible<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}>
      */
     use ArrayAccessible;
 
@@ -31,12 +31,13 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
         public readonly int $created,
         public readonly array $data,
         private readonly MetaInformation $meta,
+        public readonly ?ImageResponseUsage $usage = null,
     ) {}
 
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>}  $attributes
+     * @param  array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}  $attributes
      */
     public static function from(array $attributes, MetaInformation $meta): self
     {
@@ -48,6 +49,7 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
             $attributes['created'],
             $results,
             $meta,
+            isset($attributes['usage']) ? ImageResponseUsage::from($attributes['usage']) : null,
         );
     }
 
@@ -56,12 +58,18 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
      */
     public function toArray(): array
     {
-        return [
+        $result = [
             'created' => $this->created,
             'data' => array_map(
                 static fn (CreateResponseData $result): array => $result->toArray(),
                 $this->data,
             ),
         ];
+
+        if ($this->usage !== null) {
+            $result['usage'] = $this->usage->toArray();
+        }
+
+        return $result;
     }
 }

--- a/src/Responses/Images/EditResponse.php
+++ b/src/Responses/Images/EditResponse.php
@@ -12,12 +12,12 @@ use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
- * @implements ResponseContract<array{created: int, data: array<int, array{url?: string, b64_json?: string}>}>
+ * @implements ResponseContract<array{created: int, data: array<int, array{url?: string, b64_json?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}>
  */
 final class EditResponse implements ResponseContract, ResponseHasMetaInformationContract
 {
     /**
-     * @use ArrayAccessible<array{created: int, data: array<int, array{url?: string, b64_json?: string}>}>
+     * @use ArrayAccessible<array{created: int, data: array<int, array{url?: string, b64_json?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}>
      */
     use ArrayAccessible;
 
@@ -31,12 +31,13 @@ final class EditResponse implements ResponseContract, ResponseHasMetaInformation
         public readonly int $created,
         public readonly array $data,
         private readonly MetaInformation $meta,
+        public readonly ?ImageResponseUsage $usage = null,
     ) {}
 
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{created: int, data: array<int, array{url?: string, b64_json?: string}>}  $attributes
+     * @param  array{created: int, data: array<int, array{url?: string, b64_json?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}  $attributes
      */
     public static function from(array $attributes, MetaInformation $meta): self
     {
@@ -48,6 +49,7 @@ final class EditResponse implements ResponseContract, ResponseHasMetaInformation
             $attributes['created'],
             $results,
             $meta,
+            isset($attributes['usage']) ? ImageResponseUsage::from($attributes['usage']) : null,
         );
     }
 
@@ -56,12 +58,18 @@ final class EditResponse implements ResponseContract, ResponseHasMetaInformation
      */
     public function toArray(): array
     {
-        return [
+        $result = [
             'created' => $this->created,
             'data' => array_map(
                 static fn (EditResponseData $result): array => $result->toArray(),
                 $this->data,
             ),
         ];
+
+        if ($this->usage !== null) {
+            $result['usage'] = $this->usage->toArray();
+        }
+
+        return $result;
     }
 }

--- a/src/Responses/Images/ImageResponseUsage.php
+++ b/src/Responses/Images/ImageResponseUsage.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Responses\Images;
+
+final class ImageResponseUsage
+{
+    private function __construct(
+        public readonly int $totalTokens,
+        public readonly int $inputTokens,
+        public readonly int $outputTokens,
+        public readonly ImageResponseUsageInputTokensDetails $inputTokensDetails,
+    ) {}
+
+    /**
+     * @param  array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            $attributes['total_tokens'],
+            $attributes['input_tokens'],
+            $attributes['output_tokens'],
+            ImageResponseUsageInputTokensDetails::from($attributes['input_tokens_details']),
+        );
+    }
+
+    /**
+     * @return array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}
+     */
+    public function toArray(): array
+    {
+        return [
+            'total_tokens' => $this->totalTokens,
+            'input_tokens' => $this->inputTokens,
+            'output_tokens' => $this->outputTokens,
+            'input_tokens_details' => $this->inputTokensDetails->toArray(),
+        ];
+    }
+}

--- a/src/Responses/Images/ImageResponseUsageInputTokensDetails.php
+++ b/src/Responses/Images/ImageResponseUsageInputTokensDetails.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Responses\Images;
+
+final class ImageResponseUsageInputTokensDetails
+{
+    private function __construct(
+        public readonly int $textTokens,
+        public readonly int $imageTokens,
+    ) {}
+
+    /**
+     * @param  array{text_tokens: int, image_tokens: int}  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            $attributes['text_tokens'],
+            $attributes['image_tokens'],
+        );
+    }
+
+    /**
+     * @return array{text_tokens: int, image_tokens: int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'text_tokens' => $this->textTokens,
+            'image_tokens' => $this->imageTokens,
+        ];
+    }
+}

--- a/src/Responses/Images/VariationResponse.php
+++ b/src/Responses/Images/VariationResponse.php
@@ -12,12 +12,12 @@ use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
- * @implements ResponseContract<array{created: int, data: array<int, array{url?: string, b64_json?: string}>}>
+ * @implements ResponseContract<array{created: int, data: array<int, array{url?: string, b64_json?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}>
  */
 final class VariationResponse implements ResponseContract, ResponseHasMetaInformationContract
 {
     /**
-     * @use ArrayAccessible<array{created: int, data: array<int, array{url?: string, b64_json?: string}>}>
+     * @use ArrayAccessible<array{created: int, data: array<int, array{url?: string, b64_json?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}>
      */
     use ArrayAccessible;
 
@@ -31,12 +31,13 @@ final class VariationResponse implements ResponseContract, ResponseHasMetaInform
         public readonly int $created,
         public readonly array $data,
         private readonly MetaInformation $meta,
+        public readonly ?ImageResponseUsage $usage = null,
     ) {}
 
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{created: int, data: array<int, array{url?: string, b64_json?: string}>}  $attributes
+     * @param  array{created: int, data: array<int, array{url?: string, b64_json?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}  $attributes
      */
     public static function from(array $attributes, MetaInformation $meta): self
     {
@@ -48,6 +49,7 @@ final class VariationResponse implements ResponseContract, ResponseHasMetaInform
             $attributes['created'],
             $results,
             $meta,
+            isset($attributes['usage']) ? ImageResponseUsage::from($attributes['usage']) : null,
         );
     }
 
@@ -56,12 +58,18 @@ final class VariationResponse implements ResponseContract, ResponseHasMetaInform
      */
     public function toArray(): array
     {
-        return [
+        $result = [
             'created' => $this->created,
             'data' => array_map(
                 static fn (VariationResponseData $result): array => $result->toArray(),
                 $this->data,
             ),
         ];
+
+        if ($this->usage !== null) {
+            $result['usage'] = $this->usage->toArray();
+        }
+
+        return $result;
     }
 }

--- a/tests/Fixtures/Image.php
+++ b/tests/Fixtures/Image.php
@@ -49,6 +49,30 @@ function imageCreateWithB46Json(): array
 /**
  * @return array<string, mixed>
  */
+function imageCreateWithUsage(): array
+{
+    return [
+        'created' => 1664136088,
+        'data' => [
+            [
+                'url' => 'https://openai.com/image.png',
+            ],
+        ],
+        'usage' => [
+            'total_tokens' => 100,
+            'input_tokens' => 50,
+            'output_tokens' => 50,
+            'input_tokens_details' => [
+                'text_tokens' => 10,
+                'image_tokens' => 40,
+            ],
+        ],
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
 function imageEditWithUrl(): array
 {
     return [
@@ -79,6 +103,30 @@ function imageEditWithB46Json(): array
 /**
  * @return array<string, mixed>
  */
+function imageEditWithUsage(): array
+{
+    return [
+        'created' => 1664136088,
+        'data' => [
+            [
+                'url' => 'https://openai.com/image.png',
+            ],
+        ],
+        'usage' => [
+            'total_tokens' => 100,
+            'input_tokens' => 50,
+            'output_tokens' => 50,
+            'input_tokens_details' => [
+                'text_tokens' => 10,
+                'image_tokens' => 40,
+            ],
+        ],
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
 function imageVariationWithUrl(): array
 {
     return [
@@ -101,6 +149,30 @@ function imageVariationWithB46Json(): array
         'data' => [
             [
                 'b64_json' => 'iVBORw0KGgoAAAAN...',
+            ],
+        ],
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function imageVariationWithUsage(): array
+{
+    return [
+        'created' => 1664136088,
+        'data' => [
+            [
+                'url' => 'https://openai.com/image.png',
+            ],
+        ],
+        'usage' => [
+            'total_tokens' => 100,
+            'input_tokens' => 50,
+            'output_tokens' => 50,
+            'input_tokens_details' => [
+                'text_tokens' => 10,
+                'image_tokens' => 40,
             ],
         ],
     ];

--- a/tests/Resources/Images.php
+++ b/tests/Resources/Images.php
@@ -4,6 +4,8 @@ use OpenAI\Responses\Images\CreateResponse;
 use OpenAI\Responses\Images\CreateResponseData;
 use OpenAI\Responses\Images\EditResponse;
 use OpenAI\Responses\Images\EditResponseData;
+use OpenAI\Responses\Images\ImageResponseUsage;
+use OpenAI\Responses\Images\ImageResponseUsageInputTokensDetails;
 use OpenAI\Responses\Images\VariationResponse;
 use OpenAI\Responses\Images\VariationResponseData;
 use OpenAI\Responses\Meta\MetaInformation;
@@ -27,7 +29,43 @@ test('create', function () {
         ->toBeInstanceOf(CreateResponse::class)
         ->created->toBe(1664136088)
         ->data->toBeArray()->toHaveCount(1)
-        ->data->each->toBeInstanceOf(CreateResponseData::class);
+        ->data->each->toBeInstanceOf(CreateResponseData::class)
+        ->usage->toBeNull();
+
+    expect($result->data[0])
+        ->url->toBe('https://openai.com/image.png');
+
+    expect($result->meta())
+        ->toBeInstanceOf(MetaInformation::class);
+});
+
+test('create with usage', function () {
+    $client = mockClient('POST', 'images/generations', [
+        'prompt' => 'A cute baby sea otter',
+        'n' => 1,
+        'size' => '256x256',
+        'response_format' => 'url',
+    ], \OpenAI\ValueObjects\Transporter\Response::from(imageCreateWithUsage(), metaHeaders()));
+
+    $result = $client->images()->create([
+        'prompt' => 'A cute baby sea otter',
+        'n' => 1,
+        'size' => '256x256',
+        'response_format' => 'url',
+    ]);
+
+    expect($result)
+        ->toBeInstanceOf(CreateResponse::class)
+        ->created->toBe(1664136088)
+        ->data->toBeArray()->toHaveCount(1)
+        ->data->each->toBeInstanceOf(CreateResponseData::class)
+        ->usage->toBeInstanceOf(ImageResponseUsage::class)
+        ->usage->totalTokens->toBe(100)
+        ->usage->inputTokens->toBe(50)
+        ->usage->outputTokens->toBe(50)
+        ->usage->inputTokensDetails->toBeInstanceOf(ImageResponseUsageInputTokensDetails::class)
+        ->usage->inputTokensDetails->textTokens->toBe(10)
+        ->usage->inputTokensDetails->imageTokens->toBe(40);
 
     expect($result->data[0])
         ->url->toBe('https://openai.com/image.png');
@@ -59,7 +97,47 @@ test('edit', function () {
         ->toBeInstanceOf(EditResponse::class)
         ->created->toBe(1664136088)
         ->data->toBeArray()->toHaveCount(1)
-        ->data->each->toBeInstanceOf(EditResponseData::class);
+        ->data->each->toBeInstanceOf(EditResponseData::class)
+        ->usage->toBeNull();
+
+    expect($result->data[0])
+        ->url->toBe('https://openai.com/image.png');
+
+    expect($result->meta())
+        ->toBeInstanceOf(MetaInformation::class);
+});
+
+test('edit with usage', function () {
+    $client = mockClient('POST', 'images/edits', [
+        'image' => fileResourceResource(),
+        'mask' => fileResourceResource(),
+        'prompt' => 'A sunlit indoor lounge area with a pool containing a flamingo',
+        'n' => 1,
+        'size' => '256x256',
+        'response_format' => 'url',
+    ], \OpenAI\ValueObjects\Transporter\Response::from(imageEditWithUsage(), metaHeaders()), validateParams: false);
+
+    $result = $client->images()->edit([
+        'image' => fileResourceResource(),
+        'mask' => fileResourceResource(),
+        'prompt' => 'A sunlit indoor lounge area with a pool containing a flamingo',
+        'n' => 1,
+        'size' => '256x256',
+        'response_format' => 'url',
+    ]);
+
+    expect($result)
+        ->toBeInstanceOf(EditResponse::class)
+        ->created->toBe(1664136088)
+        ->data->toBeArray()->toHaveCount(1)
+        ->data->each->toBeInstanceOf(EditResponseData::class)
+        ->usage->toBeInstanceOf(ImageResponseUsage::class)
+        ->usage->totalTokens->toBe(100)
+        ->usage->inputTokens->toBe(50)
+        ->usage->outputTokens->toBe(50)
+        ->usage->inputTokensDetails->toBeInstanceOf(ImageResponseUsageInputTokensDetails::class)
+        ->usage->inputTokensDetails->textTokens->toBe(10)
+        ->usage->inputTokensDetails->imageTokens->toBe(40);
 
     expect($result->data[0])
         ->url->toBe('https://openai.com/image.png');
@@ -87,7 +165,43 @@ test('variation', function () {
         ->toBeInstanceOf(VariationResponse::class)
         ->created->toBe(1664136088)
         ->data->toBeArray()->toHaveCount(1)
-        ->data->each->toBeInstanceOf(VariationResponseData::class);
+        ->data->each->toBeInstanceOf(VariationResponseData::class)
+        ->usage->toBeNull();
+
+    expect($result->data[0])
+        ->url->toBe('https://openai.com/image.png');
+
+    expect($result->meta())
+        ->toBeInstanceOf(MetaInformation::class);
+});
+
+test('variation with usage', function () {
+    $client = mockClient('POST', 'images/variations', [
+        'image' => fileResourceResource(),
+        'n' => 1,
+        'size' => '256x256',
+        'response_format' => 'url',
+    ], \OpenAI\ValueObjects\Transporter\Response::from(imageVariationWithUsage(), metaHeaders()), validateParams: false);
+
+    $result = $client->images()->variation([
+        'image' => fileResourceResource(),
+        'n' => 1,
+        'size' => '256x256',
+        'response_format' => 'url',
+    ]);
+
+    expect($result)
+        ->toBeInstanceOf(VariationResponse::class)
+        ->created->toBe(1664136088)
+        ->data->toBeArray()->toHaveCount(1)
+        ->data->each->toBeInstanceOf(VariationResponseData::class)
+        ->usage->toBeInstanceOf(ImageResponseUsage::class)
+        ->usage->totalTokens->toBe(100)
+        ->usage->inputTokens->toBe(50)
+        ->usage->outputTokens->toBe(50)
+        ->usage->inputTokensDetails->toBeInstanceOf(ImageResponseUsageInputTokensDetails::class)
+        ->usage->inputTokensDetails->textTokens->toBe(10)
+        ->usage->inputTokensDetails->imageTokens->toBe(40);
 
     expect($result->data[0])
         ->url->toBe('https://openai.com/image.png');

--- a/tests/Responses/Images/CreateResponse.php
+++ b/tests/Responses/Images/CreateResponse.php
@@ -2,6 +2,8 @@
 
 use OpenAI\Responses\Images\CreateResponse;
 use OpenAI\Responses\Images\CreateResponseData;
+use OpenAI\Responses\Images\ImageResponseUsage;
+use OpenAI\Responses\Images\ImageResponseUsageInputTokensDetails;
 use OpenAI\Responses\Meta\MetaInformation;
 
 test('from with url', function () {
@@ -12,7 +14,8 @@ test('from with url', function () {
         ->created->toBe(1664136088)
         ->data->toBeArray()->toHaveCount(1)
         ->data->each->toBeInstanceOf(CreateResponseData::class)
-        ->meta()->toBeInstanceOf(MetaInformation::class);
+        ->meta()->toBeInstanceOf(MetaInformation::class)
+        ->usage->toBeNull();
 });
 
 test('as array accessible with url', function () {
@@ -37,7 +40,8 @@ test('from with b64_json', function () {
         ->created->toBe(1664136088)
         ->data->toBeArray()->toHaveCount(1)
         ->data->each->toBeInstanceOf(CreateResponseData::class)
-        ->meta()->toBeInstanceOf(MetaInformation::class);
+        ->meta()->toBeInstanceOf(MetaInformation::class)
+        ->usage->toBeNull();
 });
 
 test('as array accessible with b64_json', function () {
@@ -52,6 +56,32 @@ test('to array with b64_json', function () {
     expect($response->toArray())
         ->toBeArray()
         ->toBe(imageCreateWithB46Json());
+});
+
+test('from with usage', function () {
+    $response = CreateResponse::from(imageCreateWithUsage(), meta());
+
+    expect($response)
+        ->toBeInstanceOf(CreateResponse::class)
+        ->created->toBe(1664136088)
+        ->data->toBeArray()->toHaveCount(1)
+        ->data->each->toBeInstanceOf(CreateResponseData::class)
+        ->meta()->toBeInstanceOf(MetaInformation::class)
+        ->usage->toBeInstanceOf(ImageResponseUsage::class)
+        ->usage->totalTokens->toBe(100)
+        ->usage->inputTokens->toBe(50)
+        ->usage->outputTokens->toBe(50)
+        ->usage->inputTokensDetails->toBeInstanceOf(ImageResponseUsageInputTokensDetails::class)
+        ->usage->inputTokensDetails->textTokens->toBe(10)
+        ->usage->inputTokensDetails->imageTokens->toBe(40);
+});
+
+test('to array with usage', function () {
+    $response = CreateResponse::from(imageCreateWithUsage(), meta());
+
+    expect($response->toArray())
+        ->toBeArray()
+        ->toBe(imageCreateWithUsage());
 });
 
 test('fake', function () {

--- a/tests/Responses/Images/EditResponse.php
+++ b/tests/Responses/Images/EditResponse.php
@@ -2,6 +2,8 @@
 
 use OpenAI\Responses\Images\EditResponse;
 use OpenAI\Responses\Images\EditResponseData;
+use OpenAI\Responses\Images\ImageResponseUsage;
+use OpenAI\Responses\Images\ImageResponseUsageInputTokensDetails;
 use OpenAI\Responses\Meta\MetaInformation;
 
 test('from with url', function () {
@@ -12,7 +14,8 @@ test('from with url', function () {
         ->created->toBe(1664136088)
         ->data->toBeArray()->toHaveCount(1)
         ->data->each->toBeInstanceOf(EditResponseData::class)
-        ->meta()->toBeInstanceOf(MetaInformation::class);
+        ->meta()->toBeInstanceOf(MetaInformation::class)
+        ->usage->toBeNull();
 });
 
 test('as array accessible with url', function () {
@@ -37,7 +40,8 @@ test('from with b64_json', function () {
         ->created->toBe(1664136088)
         ->data->toBeArray()->toHaveCount(1)
         ->data->each->toBeInstanceOf(EditResponseData::class)
-        ->meta()->toBeInstanceOf(MetaInformation::class);
+        ->meta()->toBeInstanceOf(MetaInformation::class)
+        ->usage->toBeNull();
 });
 
 test('as array accessible with b64_json', function () {
@@ -52,6 +56,32 @@ test('to array with b64_json', function () {
     expect($response->toArray())
         ->toBeArray()
         ->toBe(imageEditWithB46Json());
+});
+
+test('from with usage', function () {
+    $response = EditResponse::from(imageEditWithUsage(), meta());
+
+    expect($response)
+        ->toBeInstanceOf(EditResponse::class)
+        ->created->toBe(1664136088)
+        ->data->toBeArray()->toHaveCount(1)
+        ->data->each->toBeInstanceOf(EditResponseData::class)
+        ->meta()->toBeInstanceOf(MetaInformation::class)
+        ->usage->toBeInstanceOf(ImageResponseUsage::class)
+        ->usage->totalTokens->toBe(100)
+        ->usage->inputTokens->toBe(50)
+        ->usage->outputTokens->toBe(50)
+        ->usage->inputTokensDetails->toBeInstanceOf(ImageResponseUsageInputTokensDetails::class)
+        ->usage->inputTokensDetails->textTokens->toBe(10)
+        ->usage->inputTokensDetails->imageTokens->toBe(40);
+});
+
+test('to array with usage', function () {
+    $response = EditResponse::from(imageEditWithUsage(), meta());
+
+    expect($response->toArray())
+        ->toBeArray()
+        ->toBe(imageEditWithUsage());
 });
 
 test('fake', function () {

--- a/tests/Responses/Images/VariationResponse.php
+++ b/tests/Responses/Images/VariationResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+use OpenAI\Responses\Images\ImageResponseUsage;
+use OpenAI\Responses\Images\ImageResponseUsageInputTokensDetails;
 use OpenAI\Responses\Images\VariationResponse;
 use OpenAI\Responses\Images\VariationResponseData;
 use OpenAI\Responses\Meta\MetaInformation;
@@ -12,7 +14,8 @@ test('from with url', function () {
         ->created->toBe(1664136088)
         ->data->toBeArray()->toHaveCount(1)
         ->data->each->toBeInstanceOf(VariationResponseData::class)
-        ->meta()->toBeInstanceOf(MetaInformation::class);
+        ->meta()->toBeInstanceOf(MetaInformation::class)
+        ->usage->toBeNull();
 });
 
 test('as array accessible with url', function () {
@@ -37,7 +40,8 @@ test('from with b64_json', function () {
         ->created->toBe(1664136088)
         ->data->toBeArray()->toHaveCount(1)
         ->data->each->toBeInstanceOf(VariationResponseData::class)
-        ->meta()->toBeInstanceOf(MetaInformation::class);
+        ->meta()->toBeInstanceOf(MetaInformation::class)
+        ->usage->toBeNull();
 });
 
 test('as array accessible with b64_json', function () {
@@ -52,6 +56,32 @@ test('to array with b64_json', function () {
     expect($response->toArray())
         ->toBeArray()
         ->toBe(imageVariationWithB46Json());
+});
+
+test('from with usage', function () {
+    $response = VariationResponse::from(imageVariationWithUsage(), meta());
+
+    expect($response)
+        ->toBeInstanceOf(VariationResponse::class)
+        ->created->toBe(1664136088)
+        ->data->toBeArray()->toHaveCount(1)
+        ->data->each->toBeInstanceOf(VariationResponseData::class)
+        ->meta()->toBeInstanceOf(MetaInformation::class)
+        ->usage->toBeInstanceOf(ImageResponseUsage::class)
+        ->usage->totalTokens->toBe(100)
+        ->usage->inputTokens->toBe(50)
+        ->usage->outputTokens->toBe(50)
+        ->usage->inputTokensDetails->toBeInstanceOf(ImageResponseUsageInputTokensDetails::class)
+        ->usage->inputTokensDetails->textTokens->toBe(10)
+        ->usage->inputTokensDetails->imageTokens->toBe(40);
+});
+
+test('to array with usage', function () {
+    $response = VariationResponse::from(imageVariationWithUsage(), meta());
+
+    expect($response->toArray())
+        ->toBeArray()
+        ->toBe(imageVariationWithUsage());
 });
 
 test('fake', function () {


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the OpenAI PHP team to understand the PR and also work on it.
-->

### What:

- [x] New Feature

### Description:

This PR adds support for tracking token usage in image generation, editing, and variation responses that got introduced in `gpt-image-1`  (https://platform.openai.com/docs/api-reference/images/object). 

The changes include:

1. Added new response classes `ImageResponseUsage` and `ImageResponseUsageInputTokensDetails` to handle usage data
2. Updated existing image response classes (`CreateResponse`, `EditResponse`, and `VariationResponse`) to include usage information
3. Added comprehensive test coverage for the new usage tracking functionality
4. Updated type definitions and documentation to reflect the new usage fields

The usage information includes:
- Total tokens used
- Input tokens
- Output tokens
- Detailed breakdown of input tokens (text tokens and image tokens)

This feature allows developers to track and monitor token consumption when working with OpenAI's image generation endpoints.

### Related:

This PR addresses the need to track token usage in image-related operations, similar to how it's already implemented for text-based operations. It helps developers better understand and optimize their usage of OpenAI's image generation capabilities.

fixes: #569 (issue)
closes: #570 (dupe)
