### PR TITLE
Fix: Add Throwable type to ClientFake response annotations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,13 +24,6 @@ Clone your fork, then install the dev dependencies:
 composer install
 ```
 
-## Refactor
-
-Refactor your code:
-```bash
-composer refactor
-```
-
 ## Lint
 
 Lint your code:
@@ -43,11 +36,6 @@ composer lint
 Run all tests:
 ```bash
 composer test
-```
-
-Check code quality:
-```bash
-composer test:refactor
 ```
 
 Check types:

--- a/README.md
+++ b/README.md
@@ -2419,7 +2419,7 @@ $client = new ClientFake([
         'message' => 'The model `gpt-1` does not exist',
         'type' => 'invalid_request_error',
         'code' => null,
-    ])
+    ], 404)
 ]);
 
 // the `ErrorException` will be thrown

--- a/src/Testing/ClientFake.php
+++ b/src/Testing/ClientFake.php
@@ -34,12 +34,12 @@ class ClientFake implements ClientContract
     private array $requests = [];
 
     /**
-     * @param  array<array-key, ResponseContract|StreamResponse|string>  $responses
+     * @param  array<array-key, ResponseContract|StreamResponse|Throwable|string>  $responses
      */
     public function __construct(protected array $responses = []) {}
 
     /**
-     * @param  array<array-key, ResponseContract|StreamResponse|string>  $responses
+     * @param  array<array-key, ResponseContract|StreamResponse|Throwable|string>  $responses
      */
     public function addResponses(array $responses): void
     {


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

1. The `Throwable` annotation type is missing in `ClientFake::$responses`, so PHPStan reports an error

PHPStan level >= 5

Example code:
```
$client = new ClientFake([
    new \OpenAI\Exceptions\ErrorException([
        'message' => 'The model `gpt-1` does not exist',
        'type' => 'invalid_request_error',
        'code' => null,
    ], 404)
]);
```

Error message:
```
------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   FakeNamespace/ExampleClass.php                                                                                                                                                                                        
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  16     Parameter #1 $responses of class OpenAI\Testing\ClientFake constructor expects array<OpenAI\Contracts\ResponseContract|OpenAI\Responses\StreamResponse|string>, array<int, OpenAI\Exceptions\ErrorException> given.  
         🪪  argument.type
```

2. Removed non-existing `composer refactor` & `composer test:refactor` commands from `CONTRIBUTING.md` doc file.
3. Added missing (and required) status code in `README.md` (Testing section)