### PR TITLE
feat(OpenAI) - Add helper method 'output_text' to Responses API

### DIFF
--- a/src/Responses/Responses/CreateResponse.php
+++ b/src/Responses/Responses/CreateResponse.php
@@ -157,7 +157,7 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
             maxOutputTokens: $attributes['max_output_tokens'],
             model: $attributes['model'],
             output: $output,
-            outputText: implode(' ', $texts),
+            outputText: empty($texts) ? null : implode(' ', $texts),
             parallelToolCalls: $attributes['parallel_tool_calls'],
             previousResponseId: $attributes['previous_response_id'],
             reasoning: isset($attributes['reasoning'])

--- a/tests/Fixtures/Responses.php
+++ b/tests/Fixtures/Responses.php
@@ -293,6 +293,25 @@ function outputMessage(): array
 /**
  * @return array<string, mixed>
  */
+function outputMessageOnlyRefusal(): array
+{
+    return [
+        'content' => [
+            [
+                'refusal' => 'The assistant refused to answer.',
+                'type' => 'refusal',
+            ],
+        ],
+        'id' => 'msg_67ccf190ca3881909d433c50b1f6357e087bb177ab789d5c',
+        'role' => 'assistant',
+        'status' => 'completed',
+        'type' => 'message',
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
 function toolWebSearchPreview(): array
 {
     return [

--- a/tests/Responses/Responses/CreateResponse.php
+++ b/tests/Responses/Responses/CreateResponse.php
@@ -56,6 +56,19 @@ test('to array', function () {
         ->toBe($expected);
 });
 
+test('to array with no messages', function () {
+    $payload = createResponseResource();
+    $payload['output'] = [
+        outputMessageOnlyRefusal(),
+    ];
+
+    $response = CreateResponse::from($payload, meta());
+
+    expect($response->toArray())
+        ->toBeArray()
+        ->outputText->toBeNull();
+});
+
 test('fake', function () {
     $response = CreateResponse::fake();
 

--- a/tests/Responses/Responses/CreateResponse.php
+++ b/tests/Responses/Responses/CreateResponse.php
@@ -48,9 +48,12 @@ test('as array accessible', function () {
 test('to array', function () {
     $response = CreateResponse::from(createResponseResource(), meta());
 
+    $expected = createResponseResource();
+    $expected['output_text'] = 'As of today, March 9, 2025, one notable positive news story...';
+
     expect($response->toArray())
         ->toBeArray()
-        ->toBe(createResponseResource());
+        ->toBe($expected);
 });
 
 test('fake', function () {


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

The Python/JavaScript official SDKs offer `output_text` since its kinda a PITA to get the text from Responses API amongst all the other return types. I've followed the [implementation](https://github.com/openai/openai-node/blob/master/src/lib/ResponsesParser.ts#L247) in the Node SDK to guide the PHP one.

<img width="673" alt="Screenshot 2025-05-16 at 4 52 19 PM" src="https://github.com/user-attachments/assets/36c69d7b-2212-4fae-a561-ccb78dfe8593" />

https://platform.openai.com/docs/api-reference/responses/object

