### PR TITLE
feat(OpenAI): add support for response cancel

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,19 @@ $response->truncation; // 'disabled'
 $response->toArray(); // ['id' => 'resp_67ccd2bed1ec8190b14f964abc054267', ...]
 ```
 
+### `cancel`
+
+Cancel a model response (background request) with the given ID.
+
+```php
+$response = $client->responses()->cancel('resp_67ccd2bed1ec8190b14f964abc054267');
+
+$response->id; // 'resp_67ccd2bed1ec8190b14f964abc054267'
+$response->status; // 'canceled'
+
+$response->toArray(); // ['id' => 'resp_67ccd2bed1ec8190b14f964abc054267', 'status' => 'canceled', ...]
+```
+
 ### `delete`
 
 Deletes a model response with the given ID.

--- a/src/Resources/Responses.php
+++ b/src/Resources/Responses.php
@@ -81,6 +81,21 @@ final class Responses implements ResponsesContract
     }
 
     /**
+     * Cancels a model response with the given ID. Must be marked as 'background' to be cancellable.
+     *
+     * @see https://platform.openai.com/docs/api-reference/responses/cancel
+     */
+    public function cancel(string $id): RetrieveResponse
+    {
+        $payload = Payload::cancel('responses', $id);
+
+        /** @var Response<RetrieveResponseType> $response */
+        $response = $this->transporter->requestObject($payload);
+
+        return RetrieveResponse::from($response->data(), $response->meta());
+    }
+
+    /**
      * Deletes a model response with the given ID.
      *
      * @see https://platform.openai.com/docs/api-reference/responses/delete

--- a/tests/Resources/Responses.php
+++ b/tests/Resources/Responses.php
@@ -201,3 +201,20 @@ test('retrieve', function () {
     expect($result->meta())
         ->toBeInstanceOf(MetaInformation::class);
 });
+
+test('cancel', function () {
+    $client = mockClient('POST', 'responses/resp_67ccf18ef5fc8190b16dbee19bc54e5f087bb177ab789d5c/cancel', [
+    ], \OpenAI\ValueObjects\Transporter\Response::from(retrieveResponseResource(), metaHeaders()));
+
+    $result = $client->responses()->cancel('resp_67ccf18ef5fc8190b16dbee19bc54e5f087bb177ab789d5c');
+
+    expect($result)
+        ->toBeInstanceOf(RetrieveResponse::class)
+        ->id->toBe('resp_67ccf18ef5fc8190b16dbee19bc54e5f087bb177ab789d5c')
+        ->object->toBe('response')
+        ->createdAt->toBe(1741484430)
+        ->status->toBe('completed');
+
+    expect($result->meta())
+        ->toBeInstanceOf(MetaInformation::class);
+});


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Adds support for cancelling an asynchronous response call. This must be invoked via `background=true` on the creation to be cancel-able. Tested with real calls here: https://github.com/iBotPeaches/openai-php-laravel-test/commit/05d9f4aa53c5b61155d9040ecc215a1dd9e46e47

### Related:

fixes: #582 
