### PR TITLE
fix(OpenAI): add testing for response cancel

### DIFF
--- a/src/Contracts/Resources/ResponsesContract.php
+++ b/src/Contracts/Resources/ResponsesContract.php
@@ -43,6 +43,13 @@ interface ResponsesContract
     public function retrieve(string $id): RetrieveResponse;
 
     /**
+     * Cancels a model response with the given ID. Must be marked as 'background' to be cancellable.
+     *
+     * @see https://platform.openai.com/docs/api-reference/responses/cancel
+     */
+    public function cancel(string $id): RetrieveResponse;
+
+    /**
      * Deletes a model response with the given ID.
      *
      * @see https://platform.openai.com/docs/api-reference/responses/delete

--- a/src/Testing/Resources/ResponsesTestResource.php
+++ b/src/Testing/Resources/ResponsesTestResource.php
@@ -40,6 +40,11 @@ final class ResponsesTestResource implements ResponsesContract
         return $this->record(__FUNCTION__, func_get_args());
     }
 
+    public function cancel(string $id): RetrieveResponse
+    {
+        return $this->record(__FUNCTION__, func_get_args());
+    }
+
     public function delete(string $id): DeleteResponse
     {
         return $this->record(__FUNCTION__, func_get_args());

--- a/src/Testing/Responses/Fixtures/Responses/CancelResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Responses/CancelResponseFixture.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace OpenAI\Testing\Responses\Fixtures\Responses;
+
+final class CancelResponseFixture
+{
+    public const ATTRIBUTES = [
+        'id' => 'resp_67ccf18ef5fc8190b16dbee19bc54e5f087bb177ab789d5c',
+        'object' => 'response',
+        'created_at' => 1741484430,
+        'status' => 'completed',
+        'error' => null,
+        'incomplete_details' => null,
+        'instructions' => null,
+        'max_output_tokens' => null,
+        'model' => 'gpt-4o-2024-08-06',
+        'output' => [
+            [
+                'type' => 'web_search_call',
+                'id' => 'ws_67ccf18f64008190a39b619f4c8455ef087bb177ab789d5c',
+                'status' => 'completed',
+            ],
+            [
+                'type' => 'message',
+                'id' => 'msg_67ccf190ca3881909d433c50b1f6357e087bb177ab789d5c',
+                'status' => 'completed',
+                'role' => 'assistant',
+                'content' => [
+                    [
+                        'type' => 'output_text',
+                        'text' => 'As of today, March 9, 2025, one notable positive news story...',
+                        'annotations' => [
+                            [
+                                'type' => 'url_citation',
+                                'start_index' => 442,
+                                'end_index' => 557,
+                                'url' => 'https://.../?utm_source=chatgpt.com',
+                                'title' => '...',
+                            ],
+                            [
+                                'type' => 'url_citation',
+                                'start_index' => 962,
+                                'end_index' => 1077,
+                                'url' => 'https://.../?utm_source=chatgpt.com',
+                                'title' => '...',
+                            ],
+                            [
+                                'type' => 'url_citation',
+                                'start_index' => 1336,
+                                'end_index' => 1451,
+                                'url' => 'https://.../?utm_source=chatgpt.com',
+                                'title' => '...',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+        'parallel_tool_calls' => true,
+        'previous_response_id' => null,
+        'reasoning' => [
+            'effort' => null,
+            'generate_summary' => null,
+        ],
+        'store' => true,
+        'temperature' => 1.0,
+        'text' => [
+            'format' => [
+                'type' => 'text',
+            ],
+        ],
+        'tool_choice' => 'auto',
+        'tools' => [
+            [
+                'type' => 'web_search_preview',
+                'domains' => [],
+                'search_context_size' => 'medium',
+                'user_location' => [
+                    'type' => 'approximate',
+                    'city' => 'San Francisco',
+                    'country' => 'US',
+                    'region' => 'California',
+                    'timezone' => 'America/Los_Angeles',
+                ],
+            ],
+        ],
+        'top_p' => 1.0,
+        'truncation' => 'disabled',
+        'usage' => [
+            'input_tokens' => 328,
+            'input_tokens_details' => [
+                'cached_tokens' => 0,
+            ],
+            'output_tokens' => 356,
+            'output_tokens_details' => [
+                'reasoning_tokens' => 0,
+            ],
+            'total_tokens' => 684,
+        ],
+        'user' => null,
+        'metadata' => [],
+    ];
+}

--- a/tests/Testing/Resources/ResponsesTestResource.php
+++ b/tests/Testing/Resources/ResponsesTestResource.php
@@ -47,6 +47,19 @@ it('records a response retrieve request', function () {
     });
 });
 
+it('records a response cancel request', function () {
+    $fake = new ClientFake([
+        RetrieveResponse::fake(),
+    ]);
+
+    $fake->responses()->cancel('asst_SMzoVX8XmCZEg1EbMHoAm8tc');
+
+    $fake->assertSent(Responses::class, function ($method, $responseId) {
+        return $method === 'cancel' &&
+            $responseId === 'asst_SMzoVX8XmCZEg1EbMHoAm8tc';
+    });
+});
+
 it('records a response delete request', function () {
     $fake = new ClientFake([
         DeleteResponse::fake(),


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

This adds missing tests from https://github.com/openai-php/client/commit/59e27ca6008ab8b8bd0430699732fcf56b309dfd

### Related:

#588 
