### PR TITLE
feat(OpenAI) - Add support for Image Generation Tool (Responses)

### DIFF
--- a/src/Responses/Responses/CreateResponse.php
+++ b/src/Responses/Responses/CreateResponse.php
@@ -19,6 +19,7 @@ use OpenAI\Responses\Responses\Output\OutputWebSearchToolCall;
 use OpenAI\Responses\Responses\Tool\ComputerUseTool;
 use OpenAI\Responses\Responses\Tool\FileSearchTool;
 use OpenAI\Responses\Responses\Tool\FunctionTool;
+use OpenAI\Responses\Responses\Tool\ImageGenerationTool;
 use OpenAI\Responses\Responses\Tool\WebSearchTool;
 use OpenAI\Responses\Responses\ToolChoice\FunctionToolChoice;
 use OpenAI\Responses\Responses\ToolChoice\HostedToolChoice;
@@ -34,6 +35,7 @@ use OpenAI\Testing\Responses\Concerns\Fakeable;
  * @phpstan-import-type OutputWebSearchToolCallType from OutputWebSearchToolCall
  * @phpstan-import-type ComputerUseToolType from ComputerUseTool
  * @phpstan-import-type FileSearchToolType from FileSearchTool
+ * @phpstan-import-type ImageGenerationToolType from ImageGenerationTool
  * @phpstan-import-type FunctionToolType from FunctionTool
  * @phpstan-import-type WebSearchToolType from WebSearchTool
  * @phpstan-import-type ErrorType from CreateResponseError
@@ -44,7 +46,7 @@ use OpenAI\Testing\Responses\Concerns\Fakeable;
  * @phpstan-import-type ReasoningType from CreateResponseReasoning
  *
  * @phpstan-type ToolChoiceType 'none'|'auto'|'required'|FunctionToolChoiceType|HostedToolChoiceType
- * @phpstan-type ToolsType array<int, ComputerUseToolType|FileSearchToolType|FunctionToolType|WebSearchToolType>
+ * @phpstan-type ToolsType array<int, ComputerUseToolType|FileSearchToolType|FunctionToolType|WebSearchToolType|ImageGenerationToolType>
  * @phpstan-type OutputType array<int, OutputComputerToolCallType|OutputFileSearchToolCallType|OutputFunctionToolCallType|OutputMessageType|OutputReasoningType|OutputWebSearchToolCallType>
  * @phpstan-type CreateResponseType array{id: string, object: 'response', created_at: int, status: 'completed'|'failed'|'in_progress'|'incomplete', error: ErrorType|null, incomplete_details: IncompleteDetailsType|null, instructions: string|null, max_output_tokens: int|null, model: string, output: OutputType, output_text: string|null, parallel_tool_calls: bool, previous_response_id: string|null, reasoning: ReasoningType|null, store: bool, temperature: float|null, text: ResponseFormatType, tool_choice: ToolChoiceType, tools: ToolsType, top_p: float|null, truncation: 'auto'|'disabled'|null, usage: UsageType|null, user: string|null, metadata: array<string, string>|null}
  *
@@ -64,7 +66,7 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
      * @param  'response'  $object
      * @param  'completed'|'failed'|'in_progress'|'incomplete'  $status
      * @param  array<int, OutputMessage|OutputComputerToolCall|OutputFileSearchToolCall|OutputWebSearchToolCall|OutputFunctionToolCall|OutputReasoning>  $output
-     * @param  array<int, ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool>  $tools
+     * @param  array<int, ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool>  $tools
      * @param  'auto'|'disabled'|null  $truncation
      * @param  array<string, string>  $metadata
      */
@@ -121,11 +123,12 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
         : $attributes['tool_choice'];
 
         $tools = array_map(
-            fn (array $tool): ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool => match ($tool['type']) {
+            fn (array $tool): ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool => match ($tool['type']) {
                 'file_search' => FileSearchTool::from($tool),
                 'web_search_preview', 'web_search_preview_2025_03_11' => WebSearchTool::from($tool),
                 'function' => FunctionTool::from($tool),
                 'computer_use_preview' => ComputerUseTool::from($tool),
+                'image_generation' => ImageGenerationTool::from($tool),
             },
             $attributes['tools'],
         );
@@ -211,7 +214,7 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
                 ? $this->toolChoice
                 : $this->toolChoice->toArray(),
             'tools' => array_map(
-                fn (ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool $tool): array => $tool->toArray(),
+                fn (ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool $tool): array => $tool->toArray(),
                 $this->tools
             ),
             'top_p' => $this->topP,

--- a/src/Responses/Responses/RetrieveResponse.php
+++ b/src/Responses/Responses/RetrieveResponse.php
@@ -18,6 +18,7 @@ use OpenAI\Responses\Responses\Output\OutputWebSearchToolCall;
 use OpenAI\Responses\Responses\Tool\ComputerUseTool;
 use OpenAI\Responses\Responses\Tool\FileSearchTool;
 use OpenAI\Responses\Responses\Tool\FunctionTool;
+use OpenAI\Responses\Responses\Tool\ImageGenerationTool;
 use OpenAI\Responses\Responses\Tool\WebSearchTool;
 use OpenAI\Responses\Responses\ToolChoice\FunctionToolChoice;
 use OpenAI\Responses\Responses\ToolChoice\HostedToolChoice;
@@ -33,6 +34,7 @@ use OpenAI\Testing\Responses\Concerns\Fakeable;
  * @phpstan-import-type OutputWebSearchToolCallType from OutputWebSearchToolCall
  * @phpstan-import-type ComputerUseToolType from ComputerUseTool
  * @phpstan-import-type FileSearchToolType from FileSearchTool
+ * @phpstan-import-type ImageGenerationToolType from ImageGenerationTool
  * @phpstan-import-type FunctionToolType from FunctionTool
  * @phpstan-import-type WebSearchToolType from WebSearchTool
  * @phpstan-import-type ErrorType from CreateResponseError
@@ -43,7 +45,7 @@ use OpenAI\Testing\Responses\Concerns\Fakeable;
  * @phpstan-import-type ReasoningType from CreateResponseReasoning
  *
  * @phpstan-type ToolChoiceType 'none'|'auto'|'required'|FunctionToolChoiceType|HostedToolChoiceType
- * @phpstan-type ToolsType array<int, ComputerUseToolType|FileSearchToolType|FunctionToolType|WebSearchToolType>
+ * @phpstan-type ToolsType array<int, ComputerUseToolType|FileSearchToolType|FunctionToolType|WebSearchToolType|ImageGenerationToolType>
  * @phpstan-type OutputType array<int, OutputComputerToolCallType|OutputFileSearchToolCallType|OutputFunctionToolCallType|OutputMessageType|OutputReasoningType|OutputWebSearchToolCallType>
  * @phpstan-type RetrieveResponseType array{id: string, object: 'response', created_at: int, status: 'completed'|'failed'|'in_progress'|'incomplete', error: ErrorType|null, incomplete_details: IncompleteDetailsType|null, instructions: string|null, max_output_tokens: int|null, model: string, output: OutputType, parallel_tool_calls: bool, previous_response_id: string|null, reasoning: ReasoningType|null, store: bool, temperature: float|null, text: ResponseFormatType, tool_choice: ToolChoiceType, tools: ToolsType, top_p: float|null, truncation: 'auto'|'disabled'|null, usage: UsageType|null, user: string|null, metadata: array<string, string>|null}
  *
@@ -63,7 +65,7 @@ final class RetrieveResponse implements ResponseContract, ResponseHasMetaInforma
      * @param  'response'  $object
      * @param  'completed'|'failed'|'in_progress'|'incomplete'  $status
      * @param  array<int, OutputMessage|OutputComputerToolCall|OutputFileSearchToolCall|OutputWebSearchToolCall|OutputFunctionToolCall|OutputReasoning>  $output
-     * @param  array<int, ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool>  $tools
+     * @param  array<int, ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool>  $tools
      * @param  'auto'|'disabled'|null  $truncation
      * @param  array<string, string>  $metadata
      */
@@ -119,11 +121,12 @@ final class RetrieveResponse implements ResponseContract, ResponseHasMetaInforma
         : $attributes['tool_choice'];
 
         $tools = array_map(
-            fn (array $tool): ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool => match ($tool['type']) {
+            fn (array $tool): ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool => match ($tool['type']) {
                 'file_search' => FileSearchTool::from($tool),
                 'web_search_preview', 'web_search_preview_2025_03_11' => WebSearchTool::from($tool),
                 'function' => FunctionTool::from($tool),
                 'computer_use_preview' => ComputerUseTool::from($tool),
+                'image_generation' => ImageGenerationTool::from($tool),
             },
             $attributes['tools'],
         );
@@ -196,7 +199,7 @@ final class RetrieveResponse implements ResponseContract, ResponseHasMetaInforma
                 ? $this->toolChoice
                 : $this->toolChoice->toArray(),
             'tools' => array_map(
-                fn (ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool $tool): array => $tool->toArray(),
+                fn (ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool $tool): array => $tool->toArray(),
                 $this->tools
             ),
             'top_p' => $this->topP,

--- a/src/Responses/Responses/Tool/ImageGenerationInputImageMask.php
+++ b/src/Responses/Responses/Tool/ImageGenerationInputImageMask.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Responses\Responses\Tool;
+
+use OpenAI\Contracts\ResponseContract;
+use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * @phpstan-type InputImageMaskType array{file_id: string|null, image_url: string|null}
+ *
+ * @implements ResponseContract<InputImageMaskType>
+ */
+final class ImageGenerationInputImageMask implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<InputImageMaskType>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+
+    private function __construct(
+        public readonly ?string $fileId,
+        public readonly ?string $imageUrl,
+    ) {}
+
+    /**
+     * @param  InputImageMaskType  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            fileId: $attributes['file_id'] ?? null,
+            imageUrl: $attributes['image_url'] ?? null,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'file_id' => $this->fileId,
+            'image_url' => $this->imageUrl,
+        ];
+    }
+}

--- a/src/Responses/Responses/Tool/ImageGenerationTool.php
+++ b/src/Responses/Responses/Tool/ImageGenerationTool.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Responses\Responses\Tool;
+
+use OpenAI\Contracts\ResponseContract;
+use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * @phpstan-import-type InputImageMaskType from ImageGenerationInputImageMask
+ *
+ * @phpstan-type ImageGenerationToolType array{type: 'image_generation', background: 'transparent'|'opaque'|'auto', input_image_mask: InputImageMaskType|null, model: string, moderation: string, output_compression: integer, output_format: 'png'|'webp'|'jpeg', partial_images: int, quality: 'low'|'medium'|'high'|'auto', size: '1024x1024'|'1024x1536'|'1536x1024'|'auto'}
+ *
+ * @implements ResponseContract<ImageGenerationToolType>
+ */
+final class ImageGenerationTool implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<ImageGenerationToolType>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+
+    /**
+     * @param  'image_generation'  $type
+     * @param  'transparent'|'opaque'|'auto'  $background
+     * @param  'jpeg'|'png'|'webp'  $outputFormat
+     * @param  'low'|'medium'|'high'|'auto'  $quality
+     * @param  "1024x1024"|"1024x1536"|"1536x1024"|'auto'  $size
+     */
+    private function __construct(
+        public readonly string $type,
+        public readonly string $background,
+        public readonly ?ImageGenerationInputImageMask $inputImageMask,
+        public readonly string $model,
+        public readonly string $moderation,
+        public readonly int $outputCompression,
+        public readonly string $outputFormat,
+        public readonly int $partialImages,
+        public readonly string $quality,
+        public readonly string $size,
+    ) {}
+
+    /**
+     * @param  ImageGenerationToolType  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            type: $attributes['type'],
+            background: $attributes['background'],
+            inputImageMask: isset($attributes['input_image_mask'])
+                ? ImageGenerationInputImageMask::from($attributes['input_image_mask'])
+                : null,
+            model: $attributes['model'],
+            moderation: $attributes['moderation'],
+            outputCompression: $attributes['output_compression'],
+            outputFormat: $attributes['output_format'],
+            partialImages: $attributes['partial_images'],
+            quality: $attributes['quality'],
+            size: $attributes['size'],
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'type' => $this->type,
+            'background' => $this->background,
+            'input_image_mask' => $this->inputImageMask?->toArray(),
+            'model' => $this->model,
+            'moderation' => $this->moderation,
+            'output_compression' => $this->outputCompression,
+            'output_format' => $this->outputFormat,
+            'partial_images' => $this->partialImages,
+            'quality' => $this->quality,
+            'size' => $this->size,
+        ];
+    }
+}

--- a/tests/Fixtures/Responses.php
+++ b/tests/Fixtures/Responses.php
@@ -40,6 +40,7 @@ function createResponseResource(): array
         'tools' => [
             toolWebSearchPreview(),
             toolFileSearch(),
+            toolImageGeneration(),
         ],
         'top_p' => 1.0,
         'truncation' => 'disabled',
@@ -95,6 +96,7 @@ function retrieveResponseResource(): array
         'tools' => [
             toolWebSearchPreview(),
             toolFileSearch(),
+            toolImageGeneration(),
         ],
         'top_p' => 1.0,
         'truncation' => 'disabled',
@@ -324,6 +326,25 @@ function toolWebSearchPreview(): array
             'region' => 'California',
             'timezone' => 'America/Los_Angeles',
         ],
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function toolImageGeneration(): array
+{
+    return [
+        'type' => 'image_generation',
+        'background' => 'transparent',
+        'input_image_mask' => null,
+        'model' => 'gpt-image-1',
+        'moderation' => 'auto',
+        'output_compression' => 100,
+        'output_format' => 'png',
+        'partial_images' => 0,
+        'quality' => 'auto',
+        'size' => 'auto',
     ];
 }
 

--- a/tests/Responses/Responses/RetrieveResponse.php
+++ b/tests/Responses/Responses/RetrieveResponse.php
@@ -30,7 +30,7 @@ test('from', function () {
         ->text->toBeInstanceOf(CreateResponseFormat::class)
         ->toolChoice->toBe('auto')
         ->tools->toBeArray()
-        ->tools->toHaveCount(2)
+        ->tools->toHaveCount(3)
         ->topP->toBe(1.0)
         ->truncation->toBe('disabled')
         ->usage->toBeInstanceOf(CreateResponseUsage::class)

--- a/tests/Responses/Responses/Tool/ImageGenerationTool.php
+++ b/tests/Responses/Responses/Tool/ImageGenerationTool.php
@@ -1,0 +1,56 @@
+<?php
+
+use OpenAI\Responses\Responses\Tool\ImageGenerationInputImageMask;
+use OpenAI\Responses\Responses\Tool\ImageGenerationTool;
+
+test('from', function () {
+    $response = ImageGenerationTool::from(toolImageGeneration());
+
+    expect($response)
+        ->toBeInstanceOf(ImageGenerationTool::class)
+        ->type->toBe('image_generation')
+        ->background->toBe('transparent')
+        ->inputImageMask->toBeNull()
+        ->model->toBe('gpt-image-1')
+        ->moderation->toBe('auto')
+        ->outputCompression->toBe(100)
+        ->outputFormat->toBe('png')
+        ->partialImages->toBe(0)
+        ->quality->toBe('auto')
+        ->size->toBe('auto');
+});
+
+test('from non-null input_image_mask', function () {
+    $payload = toolImageGeneration();
+    $payload['input_image_mask'] = [
+        'image_url' => 'https://example.com/mask.png',
+        'file_id' => 'file_1234567890abcdef',
+    ];
+    $response = ImageGenerationTool::from($payload);
+
+    expect($response)
+        ->toBeInstanceOf(ImageGenerationTool::class)
+        ->inputImageMask->toBeInstanceOf(ImageGenerationInputImageMask::class);
+});
+
+test('from results', function () {
+    $response = ImageGenerationTool::from(toolImageGeneration());
+
+    expect($response)
+        ->toBeInstanceOf(ImageGenerationTool::class)
+        ->type->toBe('image_generation');
+});
+
+test('as array accessible', function () {
+    $response = ImageGenerationTool::from(toolImageGeneration());
+
+    expect($response['type'])->toBe('image_generation');
+});
+
+test('to array', function () {
+    $response = ImageGenerationTool::from(toolImageGeneration());
+
+    expect($response->toArray())
+        ->toBeArray()
+        ->toBe(toolImageGeneration());
+});


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Types responses from Responses API that contain `image_generation` tool usage.

### Related:

fixes: #585 
