### PR TITLE
fix(Azure): support azure model.list

### DIFF
--- a/src/Responses/Models/ListResponse.php
+++ b/src/Responses/Models/ListResponse.php
@@ -12,12 +12,12 @@ use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
- * @implements ResponseContract<array{object: string, data: array<int, array{id: string, object: string, created: ?int, owned_by: string}>}>
+ * @implements ResponseContract<array{object: string, data: array<int, array{id: string, object: string, created: ?int, created_at?: ?int, owned_by: ?string}>}>
  */
 final class ListResponse implements ResponseContract, ResponseHasMetaInformationContract
 {
     /**
-     * @use ArrayAccessible<array{object: string, data: array<int, array{id: string, object: string, created: ?int, owned_by: string}>}>
+     * @use ArrayAccessible<array{object: string, data: array<int, array{id: string, object: string, created: ?int, created_at?: ?int, owned_by: ?string}>}>
      */
     use ArrayAccessible;
 
@@ -34,9 +34,7 @@ final class ListResponse implements ResponseContract, ResponseHasMetaInformation
     ) {}
 
     /**
-     * Acts as static factory, and returns a new Response instance.
-     *
-     * @param  array{object: string, data: array<int, array{id: string, object: string, created: ?int, owned_by: string}>}  $attributes
+     * @param  array{object: string, data: array<int, array{id: string, object: string, created: ?int, created_at?: ?int, owned_by: ?string}>}  $attributes
      */
     public static function from(array $attributes, MetaInformation $meta): self
     {

--- a/src/Responses/Models/RetrieveResponse.php
+++ b/src/Responses/Models/RetrieveResponse.php
@@ -12,12 +12,12 @@ use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
- * @implements ResponseContract<array{id: string, object: string, created: ?int, owned_by: string}>
+ * @implements ResponseContract<array{id: string, object: string, created: ?int, created_at?: ?int, owned_by: ?string}>
  */
 final class RetrieveResponse implements ResponseContract, ResponseHasMetaInformationContract
 {
     /**
-     * @use ArrayAccessible<array{id: string, object: string, created: ?int, owned_by: string}>
+     * @use ArrayAccessible<array{id: string, object: string, created: ?int, owned_by: ?string}>
      */
     use ArrayAccessible;
 
@@ -28,23 +28,21 @@ final class RetrieveResponse implements ResponseContract, ResponseHasMetaInforma
         public readonly string $id,
         public readonly string $object,
         public readonly ?int $created,
-        public readonly string $ownedBy,
+        public readonly ?string $ownedBy,
         private readonly MetaInformation $meta,
     ) {}
 
     /**
-     * Acts as static factory, and returns a new Response instance.
-     *
-     * @param  array{id: string, object: string, created: ?int, owned_by: string}  $attributes
+     * @param  array{id: string, object: string, created: ?int, created_at?: ?int, owned_by: ?string}  $attributes
      */
     public static function from(array $attributes, MetaInformation $meta): self
     {
         return new self(
-            $attributes['id'],
-            $attributes['object'],
-            $attributes['created'] ?? null,
-            $attributes['owned_by'],
-            $meta,
+            id: $attributes['id'],
+            object: $attributes['object'],
+            created: $attributes['created'] ?? $attributes['created_at'] ?? null,
+            ownedBy: $attributes['owned_by'] ?? null,
+            meta: $meta,
         );
     }
 

--- a/tests/Fixtures/Model.php
+++ b/tests/Fixtures/Model.php
@@ -28,6 +28,18 @@ function googleModel(): array
 /**
  * @return array<string, mixed>
  */
+function azureModel(): array
+{
+    return [
+        'id' => 'gpt-35-turbo',
+        'object' => 'model',
+        'created_at' => 1700000000,
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
 function modelList(): array
 {
     return [

--- a/tests/Responses/Models/RetrieveResponse.php
+++ b/tests/Responses/Models/RetrieveResponse.php
@@ -26,6 +26,18 @@ test('from google', function () {
         ->meta()->toBeInstanceOf(MetaInformation::class);
 });
 
+test('from azure', function () {
+    $result = RetrieveResponse::from(azureModel(), meta());
+
+    expect($result)
+        ->toBeInstanceOf(RetrieveResponse::class)
+        ->id->toBe('gpt-35-turbo')
+        ->object->toBe('model')
+        ->created->toBe(1700000000)
+        ->ownedBy->toBeNull()
+        ->meta()->toBeInstanceOf(MetaInformation::class);
+});
+
 test('as array accessible', function () {
     $result = RetrieveResponse::from(model(), meta());
 


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Adds support for Azure model listing, which uses `created_at` and removes `owned_by`.

### Related:

fixes: #598
