### PR TITLE
chore(OpenAI) fix: use proper order of parameters for Response construct

### DIFF
--- a/tests/Resources/Chat.php
+++ b/tests/Resources/Chat.php
@@ -57,8 +57,8 @@ test('create throws an exception if stream option is true', function () {
 
 test('create streamed', function () {
     $response = new Response(
-        body: new Stream(chatCompletionStream()),
         headers: metaHeaders(),
+        body: new Stream(chatCompletionStream()),
     );
 
     $client = mockStreamClient('POST', 'chat/completions', [
@@ -102,8 +102,8 @@ test('create streamed', function () {
 
 test('handles ping messages in stream', function () {
     $response = new Response(
-        body: new Stream(chatCompletionStreamPing()),
         headers: metaHeaders(),
+        body: new Stream(chatCompletionStreamPing()),
     );
 
     $client = mockStreamClient('POST', 'chat/completions', [

--- a/tests/Resources/Completions.php
+++ b/tests/Resources/Completions.php
@@ -56,8 +56,8 @@ test('create throws an exception if stream option is true', function () {
 
 test('create streamed', function () {
     $response = new Response(
-        body: new Stream(completionStream()),
         headers: metaHeaders(),
+        body: new Stream(completionStream()),
     );
 
     $client = mockStreamClient('POST', 'completions', [

--- a/tests/Resources/FineTunes.php
+++ b/tests/Resources/FineTunes.php
@@ -185,8 +185,8 @@ test('list events', function () {
 
 test('list events streamed', function () {
     $response = new Response(
-        body: new Stream(fineTuneListEventsStream()),
         headers: metaHeaders(),
+        body: new Stream(fineTuneListEventsStream()),
     );
 
     $client = mockStreamClient('GET', 'fine-tunes/ft-MaoEAULREoazpupm8uB7qoIl/events', ['stream' => 'true'], $response);

--- a/tests/Resources/Responses.php
+++ b/tests/Resources/Responses.php
@@ -83,8 +83,8 @@ test('create throws an exception if stream option is true', function () {
 
 test('create streamed', function () {
     $response = new Response(
-        body: new Stream(responseCompletionStream()),
         headers: metaHeaders(),
+        body: new Stream(responseCompletionStream()),
     );
 
     $client = mockStreamClient('POST', 'responses', [
@@ -153,8 +153,8 @@ test('create streamed', function () {
 
 test('create streamed image generation', function () {
     $response = new Response(
-        body: new Stream(responseImageGenerationStream()),
         headers: metaHeaders(),
+        body: new Stream(responseImageGenerationStream()),
     );
 
     $client = mockStreamClient('POST', 'responses', [
@@ -199,8 +199,8 @@ test('create streamed image generation', function () {
 
 test('create streamed code interpreter', function () {
     $response = new Response(
-        body: new Stream(responseCodeInterpreterStream()),
         headers: metaHeaders(),
+        body: new Stream(responseCodeInterpreterStream()),
     );
 
     $client = mockStreamClient('POST', 'responses', [

--- a/tests/Responses/Audio/SpeechStreamResponse.php
+++ b/tests/Responses/Audio/SpeechStreamResponse.php
@@ -7,8 +7,8 @@ use OpenAI\Responses\Meta\MetaInformation;
 
 test('from response', function () {
     $response = new Response(
-        body: new Stream(speechStream()),
         headers: metaHeaders(),
+        body: new Stream(speechStream()),
     );
 
     $speech = new SpeechStreamResponse($response);


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Named parameters still need to be in order of the parameters. This fixes that.
