### PR TITLE
fix(OpenAI): support reused prompts / instructions in Responses

### DIFF
--- a/src/Responses/Responses/CreateResponse.php
+++ b/src/Responses/Responses/CreateResponse.php
@@ -58,11 +58,13 @@ use OpenAI\Testing\Responses\Concerns\Fakeable;
  * @phpstan-import-type FunctionToolChoiceType from FunctionToolChoice
  * @phpstan-import-type HostedToolChoiceType from HostedToolChoice
  * @phpstan-import-type ReasoningType from CreateResponseReasoning
+ * @phpstan-import-type ReferencePromptObjectType from ReferencePromptObject
  *
+ * @phpstan-type InstructionsType array<int, mixed>|string|null
  * @phpstan-type ToolChoiceType 'none'|'auto'|'required'|FunctionToolChoiceType|HostedToolChoiceType
  * @phpstan-type ToolsType array<int, ComputerUseToolType|FileSearchToolType|FunctionToolType|WebSearchToolType|ImageGenerationToolType|RemoteMcpToolType|CodeInterpreterToolType>
  * @phpstan-type OutputType array<int, OutputComputerToolCallType|OutputFileSearchToolCallType|OutputFunctionToolCallType|OutputMessageType|OutputReasoningType|OutputWebSearchToolCallType|OutputMcpListToolsType|OutputMcpApprovalRequestType|OutputMcpCallType|OutputImageGenerationToolCallType|OutputCodeInterpreterToolCallType>
- * @phpstan-type CreateResponseType array{id: string, object: 'response', created_at: int, status: 'completed'|'failed'|'in_progress'|'incomplete', error: ErrorType|null, incomplete_details: IncompleteDetailsType|null, instructions: string|null, max_output_tokens: int|null, model: string, output: OutputType, output_text: string|null, parallel_tool_calls: bool, previous_response_id: string|null, reasoning: ReasoningType|null, store: bool, temperature: float|null, text: ResponseFormatType, tool_choice: ToolChoiceType, tools: ToolsType, top_p: float|null, truncation: 'auto'|'disabled'|null, usage: UsageType|null, user: string|null, metadata: array<string, string>|null}
+ * @phpstan-type CreateResponseType array{id: string, object: 'response', created_at: int, status: 'completed'|'failed'|'in_progress'|'incomplete', error: ErrorType|null, incomplete_details: IncompleteDetailsType|null, instructions: InstructionsType, max_output_tokens: int|null, model: string, output: OutputType, output_text: string|null, parallel_tool_calls: bool, previous_response_id: string|null, prompt: ReferencePromptObjectType|null, reasoning: ReasoningType|null, store: bool, temperature: float|null, text: ResponseFormatType, tool_choice: ToolChoiceType, tools: ToolsType, top_p: float|null, truncation: 'auto'|'disabled'|null, usage: UsageType|null, user: string|null, metadata: array<string, string>|null}
  *
  * @implements ResponseContract<CreateResponseType>
  */
@@ -79,6 +81,7 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
     /**
      * @param  'response'  $object
      * @param  'completed'|'failed'|'in_progress'|'incomplete'  $status
+     * @param  array<int, mixed>|string|null  $instructions
      * @param  array<int, OutputMessage|OutputComputerToolCall|OutputFileSearchToolCall|OutputWebSearchToolCall|OutputFunctionToolCall|OutputReasoning|OutputMcpListTools|OutputMcpApprovalRequest|OutputMcpCall|OutputImageGenerationToolCall|OutputCodeInterpreterToolCall>  $output
      * @param  array<int, ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool|RemoteMcpTool|ImageGenerationTool|CodeInterpreterTool>  $tools
      * @param  'auto'|'disabled'|null  $truncation
@@ -91,13 +94,14 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
         public readonly string $status,
         public readonly ?CreateResponseError $error,
         public readonly ?CreateResponseIncompleteDetails $incompleteDetails,
-        public readonly ?string $instructions,
+        public readonly array|string|null $instructions,
         public readonly ?int $maxOutputTokens,
         public readonly string $model,
         public readonly array $output,
         public readonly ?string $outputText,
         public readonly bool $parallelToolCalls,
         public readonly ?string $previousResponseId,
+        public readonly ?ReferencePromptObject $prompt,
         public readonly ?CreateResponseReasoning $reasoning,
         public readonly bool $store,
         public readonly ?float $temperature,
@@ -184,6 +188,9 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
             outputText: empty($texts) ? null : implode(' ', $texts),
             parallelToolCalls: $attributes['parallel_tool_calls'],
             previousResponseId: $attributes['previous_response_id'],
+            prompt: isset($attributes['prompt'])
+                ? ReferencePromptObject::from($attributes['prompt'])
+                : null,
             reasoning: isset($attributes['reasoning'])
                 ? CreateResponseReasoning::from($attributes['reasoning'])
                 : null,
@@ -227,6 +234,7 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
             ),
             'parallel_tool_calls' => $this->parallelToolCalls,
             'previous_response_id' => $this->previousResponseId,
+            'prompt' => $this->prompt?->toArray(),
             'reasoning' => $this->reasoning?->toArray(),
             'store' => $this->store,
             'temperature' => $this->temperature,

--- a/src/Responses/Responses/ReferencePromptObject.php
+++ b/src/Responses/Responses/ReferencePromptObject.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Responses\Responses;
+
+use OpenAI\Contracts\ResponseContract;
+use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * @phpstan-type ReferencePromptObjectType array{id: string, variables?: array<string, string>|null, version?: string|null}
+ *
+ * @implements ResponseContract<ReferencePromptObjectType>
+ */
+final class ReferencePromptObject implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<ReferencePromptObjectType>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+
+    /**
+     * @param  array<string, string>|null  $variables
+     */
+    private function __construct(
+        public readonly string $id,
+        public readonly ?array $variables = null,
+        public readonly ?string $version = null,
+    ) {}
+
+    /**
+     * @param  ReferencePromptObjectType  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            id: $attributes['id'],
+            variables: $attributes['variables'] ?? null,
+            version: $attributes['version'] ?? null,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'variables' => $this->variables,
+            'version' => $this->version,
+        ];
+    }
+}

--- a/src/Responses/Responses/RetrieveResponse.php
+++ b/src/Responses/Responses/RetrieveResponse.php
@@ -58,11 +58,13 @@ use OpenAI\Testing\Responses\Concerns\Fakeable;
  * @phpstan-import-type FunctionToolChoiceType from FunctionToolChoice
  * @phpstan-import-type HostedToolChoiceType from HostedToolChoice
  * @phpstan-import-type ReasoningType from CreateResponseReasoning
+ * @phpstan-import-type ReferencePromptObjectType from ReferencePromptObject
  *
+ * @phpstan-type InstructionsType array<int, mixed>|string|null
  * @phpstan-type ToolChoiceType 'none'|'auto'|'required'|FunctionToolChoiceType|HostedToolChoiceType
  * @phpstan-type ToolsType array<int, ComputerUseToolType|FileSearchToolType|FunctionToolType|WebSearchToolType|ImageGenerationToolType|RemoteMcpToolType|CodeInterpreterToolType>
  * @phpstan-type OutputType array<int, OutputComputerToolCallType|OutputFileSearchToolCallType|OutputFunctionToolCallType|OutputMessageType|OutputReasoningType|OutputWebSearchToolCallType|OutputMcpListToolsType|OutputMcpApprovalRequestType|OutputMcpCallType|OutputImageGenerationToolCallType>
- * @phpstan-type RetrieveResponseType array{id: string, object: 'response', created_at: int, status: 'completed'|'failed'|'in_progress'|'incomplete', error: ErrorType|null, incomplete_details: IncompleteDetailsType|null, instructions: string|null, max_output_tokens: int|null, model: string, output: OutputType, parallel_tool_calls: bool, previous_response_id: string|null, reasoning: ReasoningType|null, store: bool, temperature: float|null, text: ResponseFormatType, tool_choice: ToolChoiceType, tools: ToolsType, top_p: float|null, truncation: 'auto'|'disabled'|null, usage: UsageType|null, user: string|null, metadata: array<string, string>|null}
+ * @phpstan-type RetrieveResponseType array{id: string, object: 'response', created_at: int, status: 'completed'|'failed'|'in_progress'|'incomplete', error: ErrorType|null, incomplete_details: IncompleteDetailsType|null, instructions: InstructionsType, max_output_tokens: int|null, model: string, output: OutputType, parallel_tool_calls: bool, previous_response_id: string|null, prompt: ReferencePromptObjectType|null, reasoning: ReasoningType|null, store: bool, temperature: float|null, text: ResponseFormatType, tool_choice: ToolChoiceType, tools: ToolsType, top_p: float|null, truncation: 'auto'|'disabled'|null, usage: UsageType|null, user: string|null, metadata: array<string, string>|null}
  *
  * @implements ResponseContract<RetrieveResponseType>
  */
@@ -79,6 +81,7 @@ final class RetrieveResponse implements ResponseContract, ResponseHasMetaInforma
     /**
      * @param  'response'  $object
      * @param  'completed'|'failed'|'in_progress'|'incomplete'  $status
+     * @param  array<int, mixed>|string|null  $instructions
      * @param  array<int, OutputMessage|OutputComputerToolCall|OutputFileSearchToolCall|OutputWebSearchToolCall|OutputFunctionToolCall|OutputReasoning|OutputMcpListTools|OutputMcpApprovalRequest|OutputMcpCall|OutputImageGenerationToolCall>  $output
      * @param  array<int, ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool|RemoteMcpTool|CodeInterpreterTool>  $tools
      * @param  'auto'|'disabled'|null  $truncation
@@ -91,12 +94,13 @@ final class RetrieveResponse implements ResponseContract, ResponseHasMetaInforma
         public readonly string $status,
         public readonly ?CreateResponseError $error,
         public readonly ?CreateResponseIncompleteDetails $incompleteDetails,
-        public readonly ?string $instructions,
+        public readonly array|string|null $instructions,
         public readonly ?int $maxOutputTokens,
         public readonly string $model,
         public readonly array $output,
         public readonly bool $parallelToolCalls,
         public readonly ?string $previousResponseId,
+        public readonly ?ReferencePromptObject $prompt,
         public readonly ?CreateResponseReasoning $reasoning,
         public readonly bool $store,
         public readonly ?float $temperature,
@@ -169,6 +173,9 @@ final class RetrieveResponse implements ResponseContract, ResponseHasMetaInforma
             output: $output,
             parallelToolCalls: $attributes['parallel_tool_calls'],
             previousResponseId: $attributes['previous_response_id'],
+            prompt: isset($attributes['prompt'])
+                ? ReferencePromptObject::from($attributes['prompt'])
+                : null,
             reasoning: isset($attributes['reasoning'])
                 ? CreateResponseReasoning::from($attributes['reasoning'])
                 : null,
@@ -212,6 +219,7 @@ final class RetrieveResponse implements ResponseContract, ResponseHasMetaInforma
             ),
             'parallel_tool_calls' => $this->parallelToolCalls,
             'previous_response_id' => $this->previousResponseId,
+            'prompt' => $this->prompt?->toArray(),
             'reasoning' => $this->reasoning?->toArray(),
             'store' => $this->store,
             'temperature' => $this->temperature,

--- a/tests/Fixtures/Responses.php
+++ b/tests/Fixtures/Responses.php
@@ -26,6 +26,7 @@ function createResponseResource(): array
         ],
         'parallel_tool_calls' => true,
         'previous_response_id' => null,
+        'prompt' => null,
         'reasoning' => [
             'effort' => null,
             'generate_summary' => null,
@@ -44,6 +45,75 @@ function createResponseResource(): array
             toolImageGeneration(),
             toolRemoteMcp(),
         ],
+        'top_p' => 1.0,
+        'truncation' => 'disabled',
+        'usage' => [
+            'input_tokens' => 328,
+            'input_tokens_details' => [
+                'cached_tokens' => 0,
+            ],
+            'output_tokens' => 356,
+            'output_tokens_details' => [
+                'reasoning_tokens' => 0,
+            ],
+            'total_tokens' => 684,
+        ],
+        'user' => null,
+    ];
+}
+
+function createResponseStoredPromptResource(): array
+{
+    return [
+        'id' => 'resp_67ccf18ef5fc8190b16dbee19bc54e5f087bb177ab789d5c',
+        'object' => 'response',
+        'created_at' => 1741484430,
+        'status' => 'completed',
+        'error' => null,
+        'incomplete_details' => null,
+        'instructions' => [
+            [
+                'type' => 'message',
+                'content' => [
+                    [
+                        'type' => 'input_text',
+                        'text' => 'What is the weather in Tampa?',
+                    ],
+                ],
+                'role' => 'system',
+            ],
+        ],
+        'max_output_tokens' => null,
+        'model' => 'gpt-4.1-nano-2025-04-14',
+        'output' => [
+            outputBasicMessage(),
+        ],
+        'outputText' => 'The weather in Tampa is sunny with a high of 85°F.',
+        'prompt' => [
+            'id' => 'prompt_67ccf18ef5fc8190b16dbee19bc54e5f087bb177ab789d5c',
+            'variables' => [
+                'city' => [
+                    'type' => 'input_text',
+                    'text' => 'Tampa',
+                ],
+            ],
+            'version' => '1',
+        ],
+        'parallel_tool_calls' => true,
+        'previous_response_id' => null,
+        'reasoning' => [
+            'effort' => null,
+            'generate_summary' => null,
+        ],
+        'store' => true,
+        'temperature' => 1.0,
+        'text' => [
+            'format' => [
+                'type' => 'text',
+            ],
+        ],
+        'tool_choice' => 'auto',
+        'tools' => [],
         'top_p' => 1.0,
         'truncation' => 'disabled',
         'usage' => [

--- a/tests/Fixtures/Responses.php
+++ b/tests/Fixtures/Responses.php
@@ -153,6 +153,7 @@ function retrieveResponseResource(): array
         ],
         'parallel_tool_calls' => true,
         'previous_response_id' => null,
+        'prompt' => null,
         'reasoning' => [
             'effort' => null,
             'generate_summary' => null,

--- a/tests/Resources/Responses.php
+++ b/tests/Resources/Responses.php
@@ -7,6 +7,7 @@ use OpenAI\Responses\Responses\CreateResponse;
 use OpenAI\Responses\Responses\CreateStreamedResponse;
 use OpenAI\Responses\Responses\DeleteResponse;
 use OpenAI\Responses\Responses\ListInputItems;
+use OpenAI\Responses\Responses\ReferencePromptObject;
 use OpenAI\Responses\Responses\RetrieveResponse;
 use OpenAI\Responses\StreamResponse;
 
@@ -71,6 +72,23 @@ test('create', function () {
 
     expect($result->meta())
         ->toBeInstanceOf(MetaInformation::class);
+});
+
+test('create with stored prompt.', function () {
+    $client = mockClient('POST', 'responses', [
+        'model' => 'gpt-4o',
+        'input' => 'what was a positive news story from today?',
+    ], \OpenAI\ValueObjects\Transporter\Response::from(createResponseStoredPromptResource(), metaHeaders()));
+
+    $result = $client->responses()->create([
+        'model' => 'gpt-4o',
+        'input' => 'what was a positive news story from today?',
+    ]);
+
+    expect($result)
+        ->toBeInstanceOf(CreateResponse::class)
+        ->instructions->toBeArray()
+        ->prompt->toBeInstanceOf(ReferencePromptObject::class);
 });
 
 test('create throws an exception if stream option is true', function () {

--- a/tests/Responses/Responses/RetrieveResponse.php
+++ b/tests/Responses/Responses/RetrieveResponse.php
@@ -24,6 +24,7 @@ test('from', function () {
         ->output->toHaveCount(2)
         ->parallelToolCalls->toBeTrue()
         ->previousResponseId->toBeNull()
+        ->prompt->toBeNull()
         ->reasoning->toBeInstanceOf(CreateResponseReasoning::class)
         ->store->toBeTrue()
         ->temperature->toBe(1.0)


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

If you manage your prompts in OpenAI you have `instructions` (array) and `prompt` (object) returned. We previously only supported a string for `instructions`. Now we have an untyped mixed array of instructions - while we work to type that. This also adds a typed `prompt` object.

### Related:

fixes: #614 
