### PR TITLE
Provide default image reponse usage values, if they are not returned by the API

### DIFF
--- a/src/Responses/Images/ImageResponseUsage.php
+++ b/src/Responses/Images/ImageResponseUsage.php
@@ -19,10 +19,10 @@ final class ImageResponseUsage
     public static function from(array $attributes): self
     {
         return new self(
-            $attributes['total_tokens'],
-            $attributes['input_tokens'],
-            $attributes['output_tokens'],
-            ImageResponseUsageInputTokensDetails::from($attributes['input_tokens_details']),
+            $attributes['total_tokens'] ?? 0,
+            $attributes['input_tokens'] ?? 0,
+            $attributes['output_tokens'] ?? 0,
+            ImageResponseUsageInputTokensDetails::from($attributes['input_tokens_details'] ?? []),
         );
     }
 

--- a/src/Responses/Images/ImageResponseUsageInputTokensDetails.php
+++ b/src/Responses/Images/ImageResponseUsageInputTokensDetails.php
@@ -17,8 +17,8 @@ final class ImageResponseUsageInputTokensDetails
     public static function from(array $attributes): self
     {
         return new self(
-            $attributes['text_tokens'],
-            $attributes['image_tokens'],
+            $attributes['text_tokens'] ?? 0,
+            $attributes['image_tokens'] ?? 0,
         );
     }
 


### PR DESCRIPTION
Provide default image reponse usage values, if they are not returned by the API (e.g. for LiteLLM)

### What:

- [X] Bug Fix
- [ ] New Feature

### Description:

We are using LiteLLM as an AI provider. Supposedly this software would provide the same API as OpenAI.
However, we are encountering issues with image response usage statistics.
The PHP client expects various token usage stats to be returned (such as `total_tokens`, `input_tokens`, ...).
In our default setup of LiteLLM we only retrieve ["total_tokens" => 0], not the other expected data.
Therefore, it would probably be best not to rely on these values always being there, and providing default values in case they are not, instead of crashing.

Other responses seem to work fine for us for now, but we haven't tested all types yet...
