### PR TITLE
Error handling from GrokAI API

### DIFF
--- a/src/Exceptions/ErrorException.php
+++ b/src/Exceptions/ErrorException.php
@@ -11,11 +11,13 @@ final class ErrorException extends Exception
     /**
      * Creates a new Exception instance.
      *
-     * @param  array{message: string|array<int, string>, type: ?string, code: string|int|null}  $contents
+     * @param  string|array{message: string|array<int, string>, type: ?string, code: string|int|null}  $contents
      */
-    public function __construct(private readonly array $contents, private readonly int $statusCode)
+    public function __construct(private readonly string|array $contents, private readonly int $statusCode)
     {
-        $message = ($contents['message'] ?: (string) $this->contents['code']) ?: 'Unknown error';
+        $message = is_array($this->contents)
+            ? (($contents['message'] ?: (string) $this->contents['code']) ?: 'Unknown error')
+            : $this->contents;
 
         if (is_array($message)) {
             $message = implode(PHP_EOL, $message);

--- a/src/Responses/StreamResponse.php
+++ b/src/Responses/StreamResponse.php
@@ -53,7 +53,7 @@ final class StreamResponse implements ResponseHasMetaInformationContract, Respon
                 break;
             }
 
-            /** @var array{error?: array{message: string|array<int, string>, type: string, code: string}, type?: string} $response */
+            /** @var array{error?: string|array{message: string|array<int, string>, type: string, code: string}, type?: string} $response */
             $response = json_decode($data, true, flags: JSON_THROW_ON_ERROR);
 
             if (isset($response['error'])) {

--- a/src/Transporters/HttpTransporter.php
+++ b/src/Transporters/HttpTransporter.php
@@ -57,7 +57,7 @@ final class HttpTransporter implements TransporterContract
         $this->throwIfJsonError($response, $contents);
 
         try {
-            /** @var array{error?: array{message: string, type: string, code: string}} $data */
+            /** @var array{error?: string|array{message: string, type: string, code: string}} $data */
             $data = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
         } catch (JsonException $jsonException) {
             throw new UnserializableResponse($jsonException);
@@ -126,7 +126,7 @@ final class HttpTransporter implements TransporterContract
         }
 
         try {
-            /** @var array{error?: array{message: string|array<int, string>, type: string, code: string}} $response */
+            /** @var array{error?: string|array{message: string|array<int, string>, type: string, code: string}} $response */
             $response = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
 
             if (isset($response['error'])) {


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

GrokAI API returns an error as a string, rather than as an object, as the original OpenAI API does. I propose this adjustment to make the library compatible with the GrokAI API.
