### PR TITLE
docs: add vision example using image URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,25 @@ $response->usage->completionTokens; // 18,
 $response->usage->totalTokens; // 100
 ```
 
+Creates a chat completion with image input via `image_url`.  
+Useful for describing and analyzing visual content.
+
+```php
+$response = $client->chat()->create([
+    'model' => 'gpt-4o',
+    'messages' => [
+        [
+            'role' => 'user',
+            'content' => [
+                ['type' => 'text', 'text' => 'What is in this image?'],
+                // Replace with a real, accessible image
+                ['type' => 'image_url', 'image_url' => ['url' => 'https://example.com/image.jpg']], 
+            ]
+        ]
+    ]
+]);
+```
+
 #### `create streamed`
 
 Creates a streamed completion for the chat message.


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the OpenAI PHP team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [ ] New Feature
- [x] Docs

### Description:
This pull request adds a new usage example to the README demonstrating how to use the OpenAI to understand and describe images using GPT-4o and an accessible image URL.
<!-- describe what your PR is solving -->

###  Example Included

The example shows how to:
- Provide both a text prompt and an image URL
- Output GPT-4o's vision capabilities in a friendly way

###  Why It's Useful
- Showcases advanced GPT-4o usag
- Makes it easy for developers to test image understanding via chat
- Builds on the existing text-only examples by adding multimodal support

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
