### PR TITLE
feat(OpenAI): add updateAttributes method to VectorStoresFiles

### DIFF
--- a/src/Resources/VectorStoresFiles.php
+++ b/src/Resources/VectorStoresFiles.php
@@ -65,6 +65,23 @@ final class VectorStoresFiles implements VectorStoresFilesContract
     }
 
     /**
+     * Update attributes on a vector store file.
+     *
+     * @see https://platform.openai.com/docs/api-reference/vector-stores-files/updateFile
+     *
+     * @param  array<string, mixed>  $parameters
+     */
+    public function updateAttributes(string $vectorStoreId, string $fileId, array $parameters): VectorStoreFileResponse
+    {
+        $payload = Payload::modify("vector_stores/$vectorStoreId/files", $fileId, $parameters);
+
+        /** @var Response<array{id: string, object: string, usage_bytes: int, created_at: int, vector_store_id: string, status: string, attributes: array<string, string>, last_error: ?array{code: string, message: string}, chunking_strategy: array{type: 'static', static: array{max_chunk_size_tokens: int, chunk_overlap_tokens: int}}|array{type: 'other'}}> $response */
+        $response = $this->transporter->requestObject($payload);
+
+        return VectorStoreFileResponse::from($response->data(), $response->meta());
+    }
+
+    /**
      * Delete a file within a vector store.
      *
      * https://platform.openai.com/docs/api-reference/vector-stores/delete

--- a/tests/Resources/VectorStoresFiles.php
+++ b/tests/Resources/VectorStoresFiles.php
@@ -62,6 +62,35 @@ test('retrieve', function () {
         ->toBeInstanceOf(MetaInformation::class);
 });
 
+test('updateAttributes', function () {
+    $client = mockClient('POST', 'vector_stores/vs_8VE2cQq1jTFlH7FizhYCzUz0/files/file-HuwUghQzWasTZeX3uRRawY5R', [
+        'attributes' => [
+            'key1' => 'value1',
+            'key2' => 2,
+        ],
+    ], Response::from(vectorStoreFileResource(), metaHeaders()));
+
+    $result = $client->vectorStores()->files()->updateAttributes('vs_8VE2cQq1jTFlH7FizhYCzUz0', 'file-HuwUghQzWasTZeX3uRRawY5R', [
+        'attributes' => [
+            'key1' => 'value1',
+            'key2' => 2,
+        ],
+    ]);
+
+    expect($result)
+        ->toBeInstanceOf(VectorStoreFileResponse::class)
+        ->id->toBe('file-HuwUghQzWasTZeX3uRRawY5R')
+        ->object->toBe('vector_store.file')
+        ->usageBytes->toBe(29882)
+        ->createdAt->toBe(1715956697)
+        ->vectorStoreId->toBe('vs_xds05V7ep0QMGI5JmYnWsJwb')
+        ->status->toBe('completed')
+        ->lastError->toBeNull();
+
+    expect($result->meta())
+        ->toBeInstanceOf(MetaInformation::class);
+});
+
 test('delete', function () {
     $client = mockClient('DELETE', 'vector_stores/vs_xzlnkCbIQE50B9A8RzmcFmtP/files/file-HuwUghQzWasTZeX3uRRawY5R', [], Response::from(vectorStoreFileDeleteResource(), metaHeaders()));
 


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the OpenAI PHP team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

<!-- describe what your PR is solving -->
Implements the `updateAttributes` method for Vector Store Files to allow updating file attributes via the OpenAI API. This method enables users to modify the key-value pairs attached to vector store files.

Changes include:
- Added `updateAttributes` method to `VectorStoresFiles` class
- Added test for the new method

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
#620