### PR TITLE
Fix: Add JSON_UNESCAPED_UNICODE to preserve UTF-8 characters

### DIFF
--- a/src/ValueObjects/Transporter/Payload.php
+++ b/src/ValueObjects/Transporter/Payload.php
@@ -187,7 +187,7 @@ final class Payload
 
                 $headers = $headers->withContentType($this->contentType, '; boundary='.$streamBuilder->getBoundary());
             } else {
-                $body = $psr17Factory->createStream(json_encode($this->parameters, JSON_THROW_ON_ERROR));
+                $body = $psr17Factory->createStream(json_encode($this->parameters, JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE));
             }
         }
 


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

This PR fixes a bug where non-ASCII characters (e.g., German umlauts like `ü` and `Ö`) were being incorrectly escaped in the JSON request body (e.g., to `\u00fc` and `\u00d6`).

### Related:

### How to Test
1. Create a request with parameters containing special UTF-8 characters. For example:
   ```php
   $client->chat()->create([
       'model' => 'gpt-4o',
       'messages' => [
           ['role' => 'user', 'content' => 'Was bedeuten die Umlaute ü und Ö?'],
       ],
   ]);
Intercept the request body before it is sent.

Before this fix: The body would contain "... \u00fc und \u00d6".

After this fix: The body now correctly contains "... ü und Ö".