### PR TITLE
Add model field to CreateResponse for embeddings

### DIFF
--- a/src/Responses/Embeddings/CreateResponse.php
+++ b/src/Responses/Embeddings/CreateResponse.php
@@ -29,6 +29,7 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
      */
     private function __construct(
         public readonly string $object,
+        public readonly string $model,
         public readonly array $embeddings,
         public readonly ?CreateResponseUsage $usage,
         private readonly MetaInformation $meta,
@@ -47,6 +48,7 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
 
         return new self(
             $attributes['object'],
+            $attributes['model'],
             $embeddings,
             isset($attributes['usage']) ? CreateResponseUsage::from($attributes['usage']) : null,
             $meta,
@@ -60,6 +62,7 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
     {
         return array_filter([
             'object' => $this->object,
+            'model' => $this->model,
             'data' => array_map(
                 static fn (CreateResponseEmbedding $result): array => $result->toArray(),
                 $this->embeddings,

--- a/src/Testing/Responses/Fixtures/Embeddings/CreateResponseFixture.php
+++ b/src/Testing/Responses/Fixtures/Embeddings/CreateResponseFixture.php
@@ -6,6 +6,7 @@ final class CreateResponseFixture
 {
     public const ATTRIBUTES = [
         'object' => 'list',
+        'model' => 'text-embedding-3-small',
         'data' => [
             [
                 'object' => 'embedding',

--- a/tests/Fixtures/Embedding.php
+++ b/tests/Fixtures/Embedding.php
@@ -38,6 +38,7 @@ function embeddingList(): array
 {
     return [
         'object' => 'list',
+        'model' => 'text-embedding-3-small', // Añadido para testear el campo model
         'data' => [
             embedding(),
             embedding(),
@@ -56,6 +57,7 @@ function embeddingListWithoutUsage(): array
 {
     return [
         'object' => 'list',
+        'model' => 'text-embedding-3-small', // Añadido para testear el campo model
         'data' => [
             embedding(),
             embedding(),

--- a/tests/Responses/Embeddings/CreateResponse.php
+++ b/tests/Responses/Embeddings/CreateResponse.php
@@ -11,6 +11,7 @@ test('from', function () {
     expect($response)
         ->toBeInstanceOf(CreateResponse::class)
         ->object->toBe('list')
+        ->model->toBe('text-embedding-3-small') // Verifica el campo model
         ->embeddings->toBeArray()->toHaveCount(2)
         ->embeddings->each->toBeInstanceOf(CreateResponseEmbedding::class)
         ->usage->toBeInstanceOf(CreateResponseUsage::class)
@@ -23,6 +24,7 @@ test('from without usage', function () {
     expect($response)
         ->toBeInstanceOf(CreateResponse::class)
         ->object->toBe('list')
+        ->model->toBe('text-embedding-3-small') // Verifica el campo model
         ->embeddings->toBeArray()->toHaveCount(2)
         ->embeddings->each->toBeInstanceOf(CreateResponseEmbedding::class)
         ->usage->toBeNull()


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x ] New Feature

### Description:

This pull request adds support for the model field in the CreateResponse class for embeddings.

The OpenAI API's embeddings response includes a model property, but it wasn’t being exposed in the PHP client. This update fixes that by adding the model field to the response class, so users can now access it directly—just like the API intends.

- Added the model property to the CreateResponse class.
- Updated the constructor, from method, and toArray method to handle the model field.
- Adjusted related tests to check for the presence of the model property.

https://platform.openai.com/docs/api-reference/embeddings/create

reposnse 

```
{
  "object": "list",
  "data": [
    {
      "object": "embedding",
      "embedding": [
        0.0023064255,
        -0.009327292,
        .... (1536 floats total for ada-002)
        -0.0028842222,
      ],
      "index": 0
    }
  ],
  "model": "text-embedding-ada-002",
  "usage": {
    "prompt_tokens": 8,
    "total_tokens": 8
  }
}

```
