### PR TITLE
chore(meta): rework exception handling

### DIFF
--- a/src/Contracts/TransporterContract.php
+++ b/src/Contracts/TransporterContract.php
@@ -7,6 +7,7 @@ namespace OpenAI\Contracts;
 use OpenAI\Exceptions\ErrorException;
 use OpenAI\Exceptions\TransporterException;
 use OpenAI\Exceptions\UnserializableResponse;
+use OpenAI\ValueObjects\Transporter\AdaptableResponse;
 use OpenAI\ValueObjects\Transporter\Payload;
 use OpenAI\ValueObjects\Transporter\Response;
 use Psr\Http\Message\ResponseInterface;
@@ -17,7 +18,7 @@ use Psr\Http\Message\ResponseInterface;
 interface TransporterContract
 {
     /**
-     * Sends a request to a server.
+     * Sends a request to a server expecting an object back.
      *
      * @return Response<array<array-key, mixed>>
      *
@@ -26,7 +27,16 @@ interface TransporterContract
     public function requestObject(Payload $payload): Response;
 
     /**
-     * Sends a content request to a server.
+     * Sends a request to a server expecting an adaptable response (object/string) back.
+     *
+     * @return AdaptableResponse<array<array-key, mixed>|string>
+     *
+     * @throws ErrorException|UnserializableResponse|TransporterException
+     */
+    public function requestStringOrObject(Payload $payload): AdaptableResponse;
+
+    /**
+     * Sends a content request to a server expecting a string back.
      *
      * @throws ErrorException|TransporterException
      */

--- a/src/Contracts/TransporterContract.php
+++ b/src/Contracts/TransporterContract.php
@@ -19,7 +19,7 @@ interface TransporterContract
     /**
      * Sends a request to a server.
      *
-     * @return Response<array<array-key, mixed>|string>
+     * @return Response<array<array-key, mixed>>
      *
      * @throws ErrorException|UnserializableResponse|TransporterException
      */

--- a/src/Exceptions/UnserializableResponse.php
+++ b/src/Exceptions/UnserializableResponse.php
@@ -6,13 +6,11 @@ namespace OpenAI\Exceptions;
 
 use Exception;
 use JsonException;
+use Psr\Http\Message\ResponseInterface;
 
 final class UnserializableResponse extends Exception
 {
-    /**
-     * Creates a new Exception instance.
-     */
-    public function __construct(JsonException $exception)
+    public function __construct(JsonException $exception, public ResponseInterface $response)
     {
         parent::__construct($exception->getMessage(), 0, $exception);
     }

--- a/src/Resources/Audio.php
+++ b/src/Resources/Audio.php
@@ -64,7 +64,7 @@ final class Audio implements AudioContract
         $payload = Payload::upload('audio/transcriptions', $parameters);
 
         /** @var Response<array{task: ?string, language: ?string, duration: ?float, segments: array<int, array{id: int, seek: int, start: float, end: float, text: string, tokens: array<int, int>, temperature: float, avg_logprob: float, compression_ratio: float, no_speech_prob: float, transient?: bool}>, words: array<int, array{word: string, start: float, end: float}>, text: string}> $response */
-        $response = $this->transporter->requestObject($payload);
+        $response = $this->transporter->requestStringOrObject($payload);
 
         return TranscriptionResponse::from($response->data(), $response->meta());
     }
@@ -100,7 +100,7 @@ final class Audio implements AudioContract
         $payload = Payload::upload('audio/translations', $parameters);
 
         /** @var Response<array{task: ?string, language: ?string, duration: ?float, segments: array<int, array{id: int, seek: int, start: float, end: float, text: string, tokens: array<int, int>, temperature: float, avg_logprob: float, compression_ratio: float, no_speech_prob: float, transient?: bool}>, text: string}> $response */
-        $response = $this->transporter->requestObject($payload);
+        $response = $this->transporter->requestStringOrObject($payload);
 
         return TranslationResponse::from($response->data(), $response->meta());
     }

--- a/src/Responses/Audio/SpeechStreamResponse.php
+++ b/src/Responses/Audio/SpeechStreamResponse.php
@@ -32,7 +32,6 @@ final class SpeechStreamResponse implements ResponseHasMetaInformationContract, 
 
     public function meta(): MetaInformation
     {
-        // @phpstan-ignore-next-line
         return MetaInformation::from($this->response->getHeaders());
     }
 
@@ -44,7 +43,9 @@ final class SpeechStreamResponse implements ResponseHasMetaInformationContract, 
 
         if ($meta instanceof \OpenAI\Responses\Meta\MetaInformation) {
             foreach ($meta->toArray() as $key => $value) {
-                $response = $response->withHeader($key, (string) $value);
+                if (is_scalar($value)) {
+                    $response = $response->withHeader($key, (string) $value);
+                }
             }
         }
 

--- a/src/Responses/Meta/MetaInformation.php
+++ b/src/Responses/Meta/MetaInformation.php
@@ -6,12 +6,12 @@ use OpenAI\Contracts\MetaInformationContract;
 use OpenAI\Responses\Concerns\ArrayAccessible;
 
 /**
- * @implements MetaInformationContract<array{x-request-id?: string, openai-model?: string, openai-organization?: string, openai-processing-ms?: int, openai-version?: string, x-ratelimit-limit-requests?: int, x-ratelimit-limit-tokens?: int, x-ratelimit-remaining-requests?: int, x-ratelimit-remaining-tokens?: int, x-ratelimit-reset-requests?: string, x-ratelimit-reset-tokens?: string}>
+ * @implements MetaInformationContract<array{x-request-id?: string, openai-model?: string, openai-organization?: string, openai-project?: string, openai-processing-ms?: int, openai-version?: string, x-ratelimit-limit-requests?: int, x-ratelimit-limit-tokens?: int, x-ratelimit-remaining-requests?: int, x-ratelimit-remaining-tokens?: int, x-ratelimit-reset-requests?: string, x-ratelimit-reset-tokens?: string, custom?: array<string, string>}>
  */
 final class MetaInformation implements MetaInformationContract
 {
     /**
-     * @use ArrayAccessible<array{x-request-id?: string, openai-model?: string, openai-organization?: string, openai-processing-ms?: int, openai-version?: string, x-ratelimit-limit-requests?: int, x-ratelimit-limit-tokens?: int, x-ratelimit-remaining-requests?: int, x-ratelimit-remaining-tokens?: int, x-ratelimit-reset-requests?: string, x-ratelimit-reset-tokens?: string}>
+     * @use ArrayAccessible<array{x-request-id?: string, openai-model?: string, openai-organization?: string, openai-project?: string, openai-processing-ms?: int, openai-version?: string, x-ratelimit-limit-requests?: int, x-ratelimit-limit-tokens?: int, x-ratelimit-remaining-requests?: int, x-ratelimit-remaining-tokens?: int, x-ratelimit-reset-requests?: string, x-ratelimit-reset-tokens?: string, custom?: array<string, string>}>
      */
     use ArrayAccessible;
 
@@ -20,13 +20,29 @@ final class MetaInformation implements MetaInformationContract
         public readonly MetaInformationOpenAI $openai,
         public readonly ?MetaInformationRateLimit $requestLimit,
         public readonly ?MetaInformationRateLimit $tokenLimit,
+        public readonly MetaInformationCustom $custom,
     ) {}
 
     /**
-     * @param  array{x-request-id: string[], openai-model: string[], openai-organization: string[], openai-version: string[], openai-processing-ms: string[], x-ratelimit-limit-requests: string[], x-ratelimit-remaining-requests: string[], x-ratelimit-reset-requests: string[], x-ratelimit-limit-tokens: string[], x-ratelimit-remaining-tokens: string[], x-ratelimit-reset-tokens: string[]}  $headers
+     * @param  array<string, array<int, string>>  $headers
      */
     public static function from(array $headers): self
     {
+        $knownHeaders = [
+            'x-request-id',
+            'openai-model',
+            'openai-organization',
+            'openai-project',
+            'openai-version',
+            'openai-processing-ms',
+            'x-ratelimit-limit-requests',
+            'x-ratelimit-remaining-requests',
+            'x-ratelimit-reset-requests',
+            'x-ratelimit-limit-tokens',
+            'x-ratelimit-remaining-tokens',
+            'x-ratelimit-reset-tokens',
+        ];
+
         $headers = array_change_key_case($headers, CASE_LOWER);
 
         $requestId = $headers['x-request-id'][0] ?? null;
@@ -34,6 +50,7 @@ final class MetaInformation implements MetaInformationContract
         $openai = MetaInformationOpenAI::from([
             'model' => $headers['openai-model'][0] ?? null,
             'organization' => $headers['openai-organization'][0] ?? null,
+            'project' => $headers['openai-project'][0] ?? null,
             'version' => $headers['openai-version'][0] ?? null,
             'processingMs' => isset($headers['openai-processing-ms'][0]) ? (int) $headers['openai-processing-ms'][0] : null,
         ]);
@@ -58,11 +75,25 @@ final class MetaInformation implements MetaInformationContract
             $tokenLimit = null;
         }
 
+        $customHeaders = [];
+        foreach ($headers as $name => $values) {
+            if (in_array($name, $knownHeaders, true)) {
+                continue;
+            }
+            if (! is_array($values) || ! isset($values[0])) {
+                continue;
+            }
+            $customHeaders[$name] = $values[0];
+        }
+
+        $custom = MetaInformationCustom::from($customHeaders);
+
         return new self(
             $requestId,
             $openai,
             $requestLimit,
             $tokenLimit,
+            $custom,
         );
     }
 
@@ -74,6 +105,7 @@ final class MetaInformation implements MetaInformationContract
         return array_filter([
             'openai-model' => $this->openai->model,
             'openai-organization' => $this->openai->organization,
+            'openai-project' => $this->openai->project,
             'openai-processing-ms' => $this->openai->processingMs,
             'openai-version' => $this->openai->version,
             'x-ratelimit-limit-requests' => $this->requestLimit->limit ?? null,
@@ -83,6 +115,7 @@ final class MetaInformation implements MetaInformationContract
             'x-ratelimit-reset-requests' => $this->requestLimit->reset ?? null,
             'x-ratelimit-reset-tokens' => $this->tokenLimit->reset ?? null,
             'x-request-id' => $this->requestId,
-        ], fn (string|int|null $value): bool => ! is_null($value));
+            'custom' => ! $this->custom->isEmpty() ? $this->custom->toArray() : null,
+        ], fn ($value): bool => ! is_null($value));
     }
 }

--- a/src/Responses/Meta/MetaInformation.php
+++ b/src/Responses/Meta/MetaInformation.php
@@ -114,6 +114,6 @@ final class MetaInformation implements MetaInformationContract
             'x-ratelimit-reset-tokens' => $this->tokenLimit->reset ?? null,
             'x-request-id' => $this->requestId,
             'custom' => ! $this->custom->isEmpty() ? $this->custom->toArray() : null,
-        ], fn (mixed $value): bool => ! is_null($value));
+        ], fn (array|string|int|null $value): bool => ! is_null($value));
     }
 }

--- a/src/Responses/Meta/MetaInformation.php
+++ b/src/Responses/Meta/MetaInformation.php
@@ -80,10 +80,8 @@ final class MetaInformation implements MetaInformationContract
             if (in_array($name, $knownHeaders, true)) {
                 continue;
             }
-            if (! is_array($values) || ! isset($values[0])) {
-                continue;
-            }
-            $customHeaders[$name] = $values[0];
+
+            $customHeaders[$name] = $values[0] ?? null;
         }
 
         $custom = MetaInformationCustom::from($customHeaders);
@@ -116,6 +114,6 @@ final class MetaInformation implements MetaInformationContract
             'x-ratelimit-reset-tokens' => $this->tokenLimit->reset ?? null,
             'x-request-id' => $this->requestId,
             'custom' => ! $this->custom->isEmpty() ? $this->custom->toArray() : null,
-        ], fn ($value): bool => ! is_null($value));
+        ], fn (mixed $value): bool => ! is_null($value));
     }
 }

--- a/src/Responses/Meta/MetaInformationCustom.php
+++ b/src/Responses/Meta/MetaInformationCustom.php
@@ -12,11 +12,11 @@ final readonly class MetaInformationCustom
     ) {}
 
     /**
-     * @param  array<string, string>  $headers
+     * @param  array<string, string|null>  $headers
      */
     public static function from(array $headers): self
     {
-        return new self($headers);
+        return new self(array_filter($headers));
     }
 
     /**

--- a/src/Responses/Meta/MetaInformationCustom.php
+++ b/src/Responses/Meta/MetaInformationCustom.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace OpenAI\Responses\Meta;
+
+final readonly class MetaInformationCustom
+{
+    /**
+     * @param  array<string, string>  $headers
+     */
+    private function __construct(
+        public array $headers
+    ) {}
+
+    /**
+     * @param  array<string, string>  $headers
+     */
+    public static function from(array $headers): self
+    {
+        return new self($headers);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function toArray(): array
+    {
+        return $this->headers;
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->headers === [];
+    }
+}

--- a/src/Responses/Meta/MetaInformationOpenAI.php
+++ b/src/Responses/Meta/MetaInformationOpenAI.php
@@ -7,18 +7,20 @@ final class MetaInformationOpenAI
     private function __construct(
         public readonly ?string $model,
         public readonly ?string $organization,
+        public readonly ?string $project,
         public readonly ?string $version,
         public readonly ?int $processingMs,
     ) {}
 
     /**
-     * @param  array{model: ?string, organization: ?string, version: ?string, processingMs: ?int}  $attributes
+     * @param  array{model: ?string, organization: ?string, project: ?string, version: ?string, processingMs: ?int}  $attributes
      */
     public static function from(array $attributes): self
     {
         return new self(
             $attributes['model'],
             $attributes['organization'],
+            $attributes['project'],
             $attributes['version'],
             $attributes['processingMs'],
         );

--- a/src/Responses/StreamResponse.php
+++ b/src/Responses/StreamResponse.php
@@ -95,7 +95,6 @@ final class StreamResponse implements ResponseHasMetaInformationContract, Respon
 
     public function meta(): MetaInformation
     {
-        // @phpstan-ignore-next-line
         return MetaInformation::from($this->response->getHeaders());
     }
 }

--- a/src/Transporters/HttpTransporter.php
+++ b/src/Transporters/HttpTransporter.php
@@ -50,17 +50,13 @@ final class HttpTransporter implements TransporterContract
 
         $contents = (string) $response->getBody();
 
-        if (str_contains($response->getHeaderLine('Content-Type'), ContentType::TEXT_PLAIN->value)) {
-            return Response::from($contents, $response->getHeaders());
-        }
-
         $this->throwIfJsonError($response, $contents);
 
         try {
             /** @var array{error?: array{message: string, type: string, code: string}} $data */
             $data = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
         } catch (JsonException $jsonException) {
-            throw new UnserializableResponse($jsonException);
+            throw new UnserializableResponse($jsonException, $response);
         }
 
         return Response::from($data, $response->getHeaders());

--- a/src/ValueObjects/Transporter/AdaptableResponse.php
+++ b/src/ValueObjects/Transporter/AdaptableResponse.php
@@ -7,32 +7,32 @@ namespace OpenAI\ValueObjects\Transporter;
 use OpenAI\Responses\Meta\MetaInformation;
 
 /**
- * @template-covariant TData of array
+ * @template-covariant TData of array|string
  *
  * @internal
  */
-final readonly class Response
+final readonly class AdaptableResponse
 {
     /**
-     * Creates a new Response value object.
+     * Creates a new AdaptableResponse value object.
      *
      * @param  TData  $data
      */
     private function __construct(
-        private array $data,
+        private array|string $data,
         private MetaInformation $meta
     ) {
         // ..
     }
 
     /**
-     * Creates a new Response value object from the given data and meta information.
+     * Creates a new AdaptableResponse value object from the given data and meta information.
      *
      * @param  TData  $data
      * @param  array<string, array<int, string>>  $headers
-     * @return Response<TData>
+     * @return AdaptableResponse<TData>
      */
-    public static function from(array $data, array $headers): self
+    public static function from(array|string $data, array $headers): self
     {
         // @phpstan-ignore-next-line
         $meta = MetaInformation::from($headers);
@@ -45,7 +45,7 @@ final readonly class Response
      *
      * @return TData
      */
-    public function data(): array
+    public function data(): array|string
     {
         return $this->data;
     }

--- a/src/ValueObjects/Transporter/AdaptableResponse.php
+++ b/src/ValueObjects/Transporter/AdaptableResponse.php
@@ -34,7 +34,6 @@ final readonly class AdaptableResponse
      */
     public static function from(array|string $data, array $headers): self
     {
-        // @phpstan-ignore-next-line
         $meta = MetaInformation::from($headers);
 
         return new self($data, $meta);

--- a/src/ValueObjects/Transporter/Response.php
+++ b/src/ValueObjects/Transporter/Response.php
@@ -34,7 +34,6 @@ final readonly class Response
      */
     public static function from(array $data, array $headers): self
     {
-        // @phpstan-ignore-next-line
         $meta = MetaInformation::from($headers);
 
         return new self($data, $meta);

--- a/src/ValueObjects/Transporter/Response.php
+++ b/src/ValueObjects/Transporter/Response.php
@@ -7,7 +7,7 @@ namespace OpenAI\ValueObjects\Transporter;
 use OpenAI\Responses\Meta\MetaInformation;
 
 /**
- * @template-covariant TData of array|string
+ * @template-covariant TData of array
  *
  * @internal
  */
@@ -19,7 +19,7 @@ final class Response
      * @param  TData  $data
      */
     private function __construct(
-        private readonly array|string $data,
+        private readonly array $data,
         private readonly MetaInformation $meta
     ) {
         // ..
@@ -32,7 +32,7 @@ final class Response
      * @param  array<string, array<int, string>>  $headers
      * @return Response<TData>
      */
-    public static function from(array|string $data, array $headers): self
+    public static function from(array $data, array $headers): self
     {
         // @phpstan-ignore-next-line
         $meta = MetaInformation::from($headers);
@@ -45,7 +45,7 @@ final class Response
      *
      * @return TData
      */
-    public function data(): array|string
+    public function data(): array
     {
         return $this->data;
     }

--- a/tests/Arch.php
+++ b/tests/Arch.php
@@ -19,6 +19,7 @@ test('exceptions')
     ->expect('OpenAI\Exceptions')
     ->toOnlyUse([
         'Psr\Http\Client',
+        'Psr\Http\Message\ResponseInterface',
     ])->toImplement(Throwable::class);
 
 test('resources')->expect('OpenAI\Resources')->toOnlyUse([

--- a/tests/Datasets/RequestMethods.php
+++ b/tests/Datasets/RequestMethods.php
@@ -1,0 +1,6 @@
+<?php
+
+dataset('request methods', [
+    'requestObject',
+    'requestStringOrObject',
+]);

--- a/tests/Fixtures/Meta.php
+++ b/tests/Fixtures/Meta.php
@@ -47,6 +47,7 @@ function metaHeadersWithCustomCases(): array
     return array_merge(metaHeaders(), [
         'Custom-Header-One' => ['custom-value-1'],
         'Custom-Header-Two' => ['custom-value-2'],
+        'Custom-Blank-Header' => [null],
     ]);
 }
 

--- a/tests/Fixtures/Meta.php
+++ b/tests/Fixtures/Meta.php
@@ -7,6 +7,7 @@ function metaHeaders(): array
     return [
         'openai-model' => ['gpt-3.5-turbo-instruct'],
         'openai-organization' => ['org-1234'],
+        'openai-project' => ['project-5678'],
         'openai-processing-ms' => [410],
         'openai-version' => ['2020-10-01'],
         'x-ratelimit-limit-requests' => [3000],
@@ -39,6 +40,14 @@ function metaHeadersWithDifferentCases(): array
         'openai-version' => ['2020-10-01'],
         'x-request-id' => ['3813fa4fa3f17bdf0d7654f0f49ebab4'],
     ];
+}
+
+function metaHeadersWithCustomCases(): array
+{
+    return array_merge(metaHeaders(), [
+        'Custom-Header-One' => ['custom-value-1'],
+        'Custom-Header-Two' => ['custom-value-2'],
+    ]);
 }
 
 function meta(): MetaInformation

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -3,6 +3,7 @@
 use OpenAI\Client;
 use OpenAI\Contracts\TransporterContract;
 use OpenAI\ValueObjects\ApiKey;
+use OpenAI\ValueObjects\Transporter\AdaptableResponse;
 use OpenAI\ValueObjects\Transporter\BaseUri;
 use OpenAI\ValueObjects\Transporter\Headers;
 use OpenAI\ValueObjects\Transporter\Payload;
@@ -10,7 +11,7 @@ use OpenAI\ValueObjects\Transporter\QueryParams;
 use OpenAI\ValueObjects\Transporter\Response;
 use Psr\Http\Message\ResponseInterface;
 
-function mockClient(string $method, string $resource, array $params, Response|ResponseInterface|string $response, $methodName = 'requestObject', bool $validateParams = true)
+function mockClient(string $method, string $resource, array $params, Response|AdaptableResponse|ResponseInterface|string $response, $methodName = 'requestObject', bool $validateParams = true)
 {
     $transporter = Mockery::mock(TransporterContract::class);
 

--- a/tests/Resources/Audio.php
+++ b/tests/Resources/Audio.php
@@ -10,13 +10,14 @@ use OpenAI\Responses\Audio\TranslationResponse;
 use OpenAI\Responses\Audio\TranslationResponseSegment;
 use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Responses\StreamResponse;
+use OpenAI\ValueObjects\Transporter\AdaptableResponse;
 
 test('transcribe to text', function () {
     $client = mockClient('POST', 'audio/transcriptions', [
         'file' => audioFileResource(),
         'model' => 'whisper-1',
         'response_format' => 'text',
-    ], \OpenAI\ValueObjects\Transporter\Response::from(audioTranscriptionText(), metaHeaders()), validateParams: false);
+    ], AdaptableResponse::from(audioTranscriptionText(), metaHeaders()), methodName: 'requestStringOrObject', validateParams: false);
 
     $result = $client->audio()->transcribe([
         'file' => audioFileResource(),
@@ -41,7 +42,7 @@ test('transcribe to json', function () {
         'file' => audioFileResource(),
         'model' => 'whisper-1',
         'response_format' => 'json',
-    ], \OpenAI\ValueObjects\Transporter\Response::from(audioTranscriptionJson(), metaHeaders()), validateParams: false);
+    ], AdaptableResponse::from(audioTranscriptionJson(), metaHeaders()), methodName: 'requestStringOrObject', validateParams: false);
 
     $result = $client->audio()->transcribe([
         'file' => audioFileResource(),
@@ -66,7 +67,7 @@ test('transcribe to verbose json', function () {
         'file' => audioFileResource(),
         'model' => 'whisper-1',
         'response_format' => 'verbose_json',
-    ], \OpenAI\ValueObjects\Transporter\Response::from(audioTranscriptionVerboseJson(), metaHeaders()), validateParams: false);
+    ], AdaptableResponse::from(audioTranscriptionVerboseJson(), metaHeaders()), methodName: 'requestStringOrObject', validateParams: false);
 
     $result = $client->audio()->transcribe([
         'file' => audioFileResource(),
@@ -138,7 +139,7 @@ test('translate to text', function () {
         'file' => audioFileResource(),
         'model' => 'whisper-1',
         'response_format' => 'text',
-    ], \OpenAI\ValueObjects\Transporter\Response::from(audioTranslationText(), metaHeaders()), validateParams: false);
+    ], AdaptableResponse::from(audioTranslationText(), metaHeaders()), methodName: 'requestStringOrObject', validateParams: false);
 
     $result = $client->audio()->translate([
         'file' => audioFileResource(),
@@ -163,7 +164,7 @@ test('translate to json', function () {
         'file' => audioFileResource(),
         'model' => 'whisper-1',
         'response_format' => 'json',
-    ], \OpenAI\ValueObjects\Transporter\Response::from(audioTranslationJson(), metaHeaders()), validateParams: false);
+    ], AdaptableResponse::from(audioTranslationJson(), metaHeaders()), methodName: 'requestStringOrObject', validateParams: false);
 
     $result = $client->audio()->translate([
         'file' => audioFileResource(),
@@ -188,7 +189,7 @@ test('translate to verbose json', function () {
         'file' => audioFileResource(),
         'model' => 'whisper-1',
         'response_format' => 'verbose_json',
-    ], \OpenAI\ValueObjects\Transporter\Response::from(audioTranslationVerboseJson(), metaHeaders()), validateParams: false);
+    ], AdaptableResponse::from(audioTranslationVerboseJson(), metaHeaders()), methodName: 'requestStringOrObject', validateParams: false);
 
     $result = $client->audio()->translate([
         'file' => audioFileResource(),

--- a/tests/Transporters/HttpTransporter.php
+++ b/tests/Transporters/HttpTransporter.php
@@ -407,7 +407,7 @@ test('request plain text', function () {
         ->once()
         ->andReturn($response);
 
-    $response = $this->http->requestObject($payload);
+    $response = $this->http->requestStringOrObject($payload);
 
     expect($response->data())->toBe('Hello, how are you?');
 });

--- a/tests/Transporters/HttpTransporter.php
+++ b/tests/Transporters/HttpTransporter.php
@@ -7,6 +7,7 @@ use OpenAI\Enums\Transporter\ContentType;
 use OpenAI\Exceptions\ErrorException;
 use OpenAI\Exceptions\TransporterException;
 use OpenAI\Exceptions\UnserializableResponse;
+use OpenAI\Responses\Models\ListResponse;
 use OpenAI\Transporters\HttpTransporter;
 use OpenAI\ValueObjects\ApiKey;
 use OpenAI\ValueObjects\Transporter\BaseUri;
@@ -380,6 +381,20 @@ test('request object serialization errors', function () {
         ->andReturn($response);
 
     $this->http->requestObject($payload);
+})->throws(UnserializableResponse::class, 'Syntax error', 0);
+
+test('request object server 404 html', function () {
+    $payload = Payload::list('models');
+
+    $response = new Response(404, ['Content-Type' => 'text/plain; charset=utf-8'], '404 page not found');
+
+    $this->client
+        ->shouldReceive('sendRequest')
+        ->once()
+        ->andReturn($response);
+
+    $response = $this->http->requestObject($payload);
+    ListResponse::from($response->data(), $response->meta());
 })->throws(UnserializableResponse::class, 'Syntax error', 0);
 
 test('request plain text', function () {

--- a/tests/Transporters/HttpTransporter.php
+++ b/tests/Transporters/HttpTransporter.php
@@ -32,7 +32,7 @@ beforeEach(function () {
     );
 });
 
-test('request object', function () {
+test('request object', function (string $requestMethod) {
     $payload = Payload::list('models');
 
     $response = new Response(200, ['Content-Type' => 'application/json; charset=utf-8', ...metaHeaders()], json_encode([
@@ -52,10 +52,10 @@ test('request object', function () {
             return true;
         })->andReturn($response);
 
-    $this->http->requestObject($payload);
-});
+    $this->http->$requestMethod($payload);
+})->with('request methods');
 
-test('request object response', function () {
+test('request object response', function (string $requestMethod) {
     $payload = Payload::list('models');
 
     $response = new Response(200, ['Content-Type' => 'application/json; charset=utf-8', ...metaHeaders()], json_encode([
@@ -72,7 +72,7 @@ test('request object response', function () {
         ->once()
         ->andReturn($response);
 
-    $response = $this->http->requestObject($payload);
+    $response = $this->http->$requestMethod($payload);
 
     expect($response->data())->toBe([
         [
@@ -82,9 +82,9 @@ test('request object response', function () {
             'finish_reason' => 'length',
         ],
     ]);
-});
+})->with('request methods');
 
-test('request object server user errors', function () {
+test('request object server user errors', function (string $requestMethod) {
     $payload = Payload::list('models');
 
     $response = new Response(401, ['Content-Type' => 'application/json; charset=utf-8'], json_encode([
@@ -101,7 +101,7 @@ test('request object server user errors', function () {
         ->once()
         ->andReturn($response);
 
-    expect(fn () => $this->http->requestObject($payload))
+    expect(fn () => $this->http->$requestMethod($payload))
         ->toThrow(function (ErrorException $e) {
             expect($e->getMessage())->toBe('Incorrect API key provided: foo. You can find your API key at https://platform.openai.com.')
                 ->and($e->getErrorMessage())->toBe('Incorrect API key provided: foo. You can find your API key at https://platform.openai.com.')
@@ -109,7 +109,7 @@ test('request object server user errors', function () {
                 ->and($e->getErrorType())->toBe('invalid_request_error')
                 ->and($e->getStatusCode())->toBe(401);
         });
-});
+})->with('request methods');
 
 test('request object server errors', function () {
     $payload = Payload::create('completions', ['model' => 'gpt-4']);
@@ -137,7 +137,7 @@ test('request object server errors', function () {
         });
 });
 
-test('error code may be null', function () {
+test('error code may be null', function (string $requestMethod) {
     $payload = Payload::create('completions', ['model' => 'gpt-42']);
 
     $response = new Response(404, ['Content-Type' => 'application/json; charset=utf-8'], json_encode([
@@ -154,16 +154,16 @@ test('error code may be null', function () {
         ->once()
         ->andReturn($response);
 
-    expect(fn () => $this->http->requestObject($payload))
+    expect(fn () => $this->http->$requestMethod($payload))
         ->toThrow(function (ErrorException $e) {
             expect($e->getMessage())->toBe('The model `gpt-42` does not exist')
                 ->and($e->getErrorMessage())->toBe('The model `gpt-42` does not exist')
                 ->and($e->getErrorCode())->toBeNull()
                 ->and($e->getErrorType())->toBe('invalid_request_error');
         });
-});
+})->with('request methods');
 
-test('error code may be integer', function () {
+test('error code may be integer', function (string $requestMethod) {
     $payload = Payload::create('completions', ['model' => 'gpt-42']);
 
     $response = new Response(404, ['Content-Type' => 'application/json; charset=utf-8'], json_encode([
@@ -180,16 +180,16 @@ test('error code may be integer', function () {
         ->once()
         ->andReturn($response);
 
-    expect(fn () => $this->http->requestObject($payload))
+    expect(fn () => $this->http->$requestMethod($payload))
         ->toThrow(function (ErrorException $e) {
             expect($e->getMessage())->toBe('The model `gpt-42` does not exist')
                 ->and($e->getErrorMessage())->toBe('The model `gpt-42` does not exist')
                 ->and($e->getErrorCode())->toBe(123)
                 ->and($e->getErrorType())->toBe('invalid_request_error');
         });
-});
+})->with('request methods');
 
-test('error type may be null', function () {
+test('error type may be null', function (string $requestMethod) {
     $payload = Payload::list('models');
 
     $response = new Response(429, ['Content-Type' => 'application/json; charset=utf-8'], json_encode([
@@ -206,16 +206,16 @@ test('error type may be null', function () {
         ->once()
         ->andReturn($response);
 
-    expect(fn () => $this->http->requestObject($payload))
+    expect(fn () => $this->http->$requestMethod($payload))
         ->toThrow(function (ErrorException $e) {
             expect($e->getMessage())->toBe('You exceeded your current quota, please check')
                 ->and($e->getErrorMessage())->toBe('You exceeded your current quota, please check')
                 ->and($e->getErrorCode())->toBe('quota_exceeded')
                 ->and($e->getErrorType())->toBeNull();
         });
-});
+})->with('request methods');
 
-test('error message may be an array', function () {
+test('error message may be an array', function (string $requestMethod) {
     $payload = Payload::create('completions', ['model' => 'gpt-4']);
 
     $response = new Response(404, ['Content-Type' => 'application/json; charset=utf-8'], json_encode([
@@ -235,16 +235,16 @@ test('error message may be an array', function () {
         ->once()
         ->andReturn($response);
 
-    expect(fn () => $this->http->requestObject($payload))
+    expect(fn () => $this->http->$requestMethod($payload))
         ->toThrow(function (ErrorException $e) {
             expect($e->getMessage())->toBe('Invalid schema for function \'get_current_weather\':'.PHP_EOL.'In context=(\'properties\', \'location\'), array schema missing items')
                 ->and($e->getErrorMessage())->toBe('Invalid schema for function \'get_current_weather\':'.PHP_EOL.'In context=(\'properties\', \'location\'), array schema missing items')
                 ->and($e->getErrorCode())->toBeNull()
                 ->and($e->getErrorType())->toBe('invalid_request_error');
         });
-});
+})->with('request methods');
 
-test('error message may be empty', function () {
+test('error message may be empty', function (string $requestMethod) {
     $payload = Payload::create('completions', ['model' => 'gpt-4']);
 
     $response = new Response(404, ['Content-Type' => 'application/json; charset=utf-8'], json_encode([
@@ -261,16 +261,16 @@ test('error message may be empty', function () {
         ->once()
         ->andReturn($response);
 
-    expect(fn () => $this->http->requestObject($payload))
+    expect(fn () => $this->http->$requestMethod($payload))
         ->toThrow(function (ErrorException $e) {
             expect($e->getMessage())->toBe('invalid_api_key')
                 ->and($e->getErrorMessage())->toBe('invalid_api_key')
                 ->and($e->getErrorCode())->toBe('invalid_api_key')
                 ->and($e->getErrorType())->toBe('invalid_request_error');
         });
-});
+})->with('request methods');
 
-test('error message may be empty and code is an integer', function () {
+test('error message may be empty and code is an integer', function (string $requestMethod) {
     $payload = Payload::create('completions', ['model' => 'gpt-4']);
 
     $response = new Response(404, ['Content-Type' => 'application/json; charset=utf-8'], json_encode([
@@ -287,16 +287,16 @@ test('error message may be empty and code is an integer', function () {
         ->once()
         ->andReturn($response);
 
-    expect(fn () => $this->http->requestObject($payload))
+    expect(fn () => $this->http->$requestMethod($payload))
         ->toThrow(function (ErrorException $e) {
             expect($e->getMessage())->toBe('123')
                 ->and($e->getErrorMessage())->toBe('123')
                 ->and($e->getErrorCode())->toBe(123)
                 ->and($e->getErrorType())->toBe('invalid_request_error');
         });
-});
+})->with('request methods');
 
-test('error message and code may be empty', function () {
+test('error message and code may be empty', function (string $requestMethod) {
     $payload = Payload::create('completions', ['model' => 'gpt-4']);
 
     $response = new Response(404, ['Content-Type' => 'application/json; charset=utf-8'], json_encode([
@@ -313,16 +313,16 @@ test('error message and code may be empty', function () {
         ->once()
         ->andReturn($response);
 
-    expect(fn () => $this->http->requestObject($payload))
+    expect(fn () => $this->http->$requestMethod($payload))
         ->toThrow(function (ErrorException $e) {
             expect($e->getMessage())->toBe('Unknown error')
                 ->and($e->getErrorMessage())->toBe('Unknown error')
                 ->and($e->getErrorCode())->toBeNull()
                 ->and($e->getErrorType())->toBe('invalid_request_error');
         });
-});
+})->with('request methods');
 
-test('request object client errors', function () {
+test('request object client errors', function (string $requestMethod) {
     $payload = Payload::list('models');
 
     $baseUri = BaseUri::from('api.openai.com');
@@ -334,14 +334,14 @@ test('request object client errors', function () {
         ->once()
         ->andThrow(new ConnectException('Could not resolve host.', $payload->toRequest($baseUri, $headers, $queryParams)));
 
-    expect(fn () => $this->http->requestObject($payload))->toThrow(function (TransporterException $e) {
+    expect(fn () => $this->http->$requestMethod($payload))->toThrow(function (TransporterException $e) {
         expect($e->getMessage())->toBe('Could not resolve host.')
             ->and($e->getCode())->toBe(0)
             ->and($e->getPrevious())->toBeInstanceOf(ConnectException::class);
     });
-});
+})->with('request methods');
 
-test('request object client error in response', function () {
+test('request object client error in response', function (string $requestMethod) {
     $payload = Payload::list('models');
 
     $baseUri = BaseUri::from('api.openai.com');
@@ -364,13 +364,13 @@ test('request object client error in response', function () {
             ]))
         ));
 
-    expect(fn () => $this->http->requestObject($payload))->toThrow(function (ErrorException $e) {
+    expect(fn () => $this->http->$requestMethod($payload))->toThrow(function (ErrorException $e) {
         expect($e->getMessage())
             ->toBe('Incorrect API key provided: foo. You can find your API key at https://platform.openai.com.');
     });
-});
+})->with('request methods');
 
-test('request object serialization errors', function () {
+test('request object serialization errors', function (string $requestMethod) {
     $payload = Payload::list('models');
 
     $response = new Response(200, ['Content-Type' => 'application/json; charset=utf-8'], 'err');
@@ -380,10 +380,10 @@ test('request object serialization errors', function () {
         ->once()
         ->andReturn($response);
 
-    $this->http->requestObject($payload);
-})->throws(UnserializableResponse::class, 'Syntax error', 0);
+    $this->http->$requestMethod($payload);
+})->with('request methods')->throws(UnserializableResponse::class, 'Syntax error', 0);
 
-test('request object server 404 html', function () {
+test('request object invalid server 404 html', function () {
     $payload = Payload::list('models');
 
     $response = new Response(404, ['Content-Type' => 'text/plain; charset=utf-8'], '404 page not found');
@@ -397,7 +397,7 @@ test('request object server 404 html', function () {
     ListResponse::from($response->data(), $response->meta());
 })->throws(UnserializableResponse::class, 'Syntax error', 0);
 
-test('request plain text', function () {
+test('request string or object text', function () {
     $payload = Payload::upload('audio/transcriptions', []);
 
     $response = new Response(200, ['Content-Type' => 'text/plain; charset=utf-8', ...metaHeaders()], 'Hello, how are you?');


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [x] New Feature

### Description:
People have been complaining about phantom issues for awhile that parsers get strings, but expect objects. This has been reported a lot of times.

Folks have tried to fix this many times by either overhauling exceptions, detecting http status codes, introducing many new exceptions and all of this is not addressing the root problem.

A long time ago an issue was created to support audio transcription api (https://github.com/openai-php/client/issues/59) and that endpoint has a powerhouse of a feature.

> Select the format of the output, in one of these options: json, text, srt, verbose_json, or vtt

The endpoint can change its return to a variety of types. So base Response classes were adapted to support string/array to handle all of those. The problem however that every single other endpoint only supports json/array. So now that the base class supports a string (the other types) they can crash in odd situations - like when get an internal error (string) that is then expected to be handled by every single entity, when only Audio is prepped for it.

You'll probably get a 404 not found in pure text from some OpenAI load balancer at some point. At thousands of OpenAI calls a day we get roughly 0-3 of these errors every single day. Its an ugly error - its not a structured OpenAI return. Since the base classes support strings after #59 - it moves onward to any other non-audio class and crashes. This exception is ugly

> Argument #1 ($contents) must be of type array, string given

Been reported for years. So I'm on a journey to resolve this at the root.

### Steps
 - [x] Remove string as a valid type for Base Response
 - [x] Introduce Audio Base Response (string/array)
 - [x] Augment real life tests in my test repo for all different formats for audio/transcription to prevent regressions (https://github.com/iBotPeaches/openai-php-laravel-test/commit/a9be8878112b67bb990d7a9277536102fddcc232)
 - [x] Add ResponseInterface to exceptions to catch raw response easier
 - [x] Correct Audio class with all these changes
 - [x] Tests for sampled 404 issue
 - [x] Tests for Response included in exceptions
 - [x] Capture unknown headers in a new meta class
 - [ ] (Stretch) Add a PSR-18 Laravel HTTP/Client implementation into Laravel repo to aid in tracing these calls.

### Related:

fixes https://github.com/openai-php/client/issues/326
fixes https://github.com/openai-php/client/issues/339
fixes https://github.com/openai-php/client/issues/341
fixes https://github.com/openai-php/client/issues/402
fixes https://github.com/openai-php/client/issues/549

closes https://github.com/openai-php/client/pull/553
closes https://github.com/openai-php/client/pull/440
closes https://github.com/openai-php/client/pull/429
closes https://github.com/openai-php/client/pull/359
