### PR TITLE
chore(meta): use pest throws instead of internal phpunit methods

### DIFF
--- a/tests/Resources/Completions.php
+++ b/tests/Resources/Completions.php
@@ -52,7 +52,7 @@ test('create throws an exception if stream option is true', function () {
         'prompt' => 'hi',
         'stream' => true,
     ]);
-})->expectException(InvalidArgumentException::class);
+})->throws(InvalidArgumentException::class);
 
 test('create streamed', function () {
     $response = new Response(

--- a/tests/Testing/ClientFake.php
+++ b/tests/Testing/ClientFake.php
@@ -61,7 +61,7 @@ it('throws fake exceptions', function () {
         'model' => 'gpt-3.5-turbo-instruct',
         'prompt' => 'PHP is ',
     ]);
-})->expectExceptionMessage('The model `gpt-1` does not exist');
+})->throws(\OpenAI\Exceptions\ErrorException::class, 'The model `gpt-1` does not exist');
 
 it('throws an exception if there is no more fake response', function () {
     $fake = new ClientFake([
@@ -77,7 +77,7 @@ it('throws an exception if there is no more fake response', function () {
         'model' => 'gpt-3.5-turbo-instruct',
         'prompt' => 'PHP is ',
     ]);
-})->expectExceptionMessage('No fake responses left');
+})->throws('No fake responses left');
 
 it('allows to add more responses', function () {
     $fake = new ClientFake([
@@ -136,7 +136,7 @@ it('throws an exception if a request was not sent', function () {
             $parameters['model'] === 'gpt-3.5-turbo-instruct' &&
             $parameters['prompt'] === 'PHP is ';
     });
-})->expectException(ExpectationFailedException::class);
+})->throws(ExpectationFailedException::class);
 
 it('asserts a request was sent on the resource', function () {
     $fake = new ClientFake([
@@ -186,7 +186,7 @@ it('throws an exception if a request was not sent n times', function () {
     ]);
 
     $fake->assertSent(Completions::class, 2);
-})->expectException(ExpectationFailedException::class);
+})->throws(ExpectationFailedException::class);
 
 it('asserts a request was not sent', function () {
     $fake = new ClientFake;
@@ -205,7 +205,7 @@ it('throws an exception if an unexpected request was sent', function () {
     ]);
 
     $fake->assertNotSent(Completions::class);
-})->expectException(ExpectationFailedException::class);
+})->throws(ExpectationFailedException::class);
 
 it('asserts a request was not sent on the resource', function () {
     $fake = new ClientFake([
@@ -232,4 +232,4 @@ it('throws an exception if any request was sent when non was expected', function
     ]);
 
     $fake->assertNothingSent();
-})->expectException(ExpectationFailedException::class);
+})->throws(ExpectationFailedException::class);

--- a/tests/Testing/ClientFakeResponses.php
+++ b/tests/Testing/ClientFakeResponses.php
@@ -145,7 +145,7 @@ it('throws an exception if there are no more fake responses', function () {
         ],
         'input' => 'what was a positive news story from today?',
     ]);
-})->expectExceptionMessage('No fake responses left');
+})->throws('No fake responses left');
 
 it('throws an exception if a request was not sent', function () {
     $fake = new ClientFake([
@@ -155,4 +155,4 @@ it('throws an exception if a request was not sent', function () {
     $fake->assertSent(Responses::class, function ($method, $parameters) {
         return $method === 'create';
     });
-})->expectException(ExpectationFailedException::class);
+})->throws(ExpectationFailedException::class);


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Solves IDE warnings saying methods don't exist and instead uses native Pest methods.
