### PR TITLE
fix(meta): handle 429 (rate limit) gracefully

### DIFF
--- a/src/Exceptions/RateLimitException.php
+++ b/src/Exceptions/RateLimitException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Exceptions;
+
+use Exception;
+use Psr\Http\Message\ResponseInterface;
+
+final class RateLimitException extends Exception
+{
+    public function __construct(public ResponseInterface $response)
+    {
+        parent::__construct('Request rate limit has been exceeded.');
+    }
+}


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Every provider has a different error format which we don't really have a unified parsing mechanism for. However all major players in the scene agree that an HTTP 429 is a rate limit, so we can leverage that. During #643 I believe I missed the non-OpenAI rate limit errors as no direct HTTP status code checking occurs (with exception of a few cases).

This means a rate limit bubbles through to an ErrorException (in case of OpenAI) or in case of another provider - goes onward to the concrete class and crashes.

This adds a tiny check for only HTTP 429 as the payload structure is wildly different between all providers. Userland implementations can use the exception (for backoff/retries) and dig into the include Response for more in-depth handling.

### Related:

fixes: #587 
