### PR TITLE
fix(OpenAI): support mcp error objects in response api

### DIFF
--- a/src/Responses/Responses/GenericResponseError.php
+++ b/src/Responses/Responses/GenericResponseError.php
@@ -9,11 +9,11 @@ use OpenAI\Responses\Concerns\ArrayAccessible;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
- * @phpstan-type ErrorType array{code: string|int, message: string}
+ * @phpstan-type ErrorType array{code?: string|int, message?: string}
  *
  * @implements ResponseContract<ErrorType>
  */
-final class GenericResponseError implements ResponseContract
+class GenericResponseError implements ResponseContract
 {
     /**
      * @use ArrayAccessible<ErrorType>
@@ -22,7 +22,7 @@ final class GenericResponseError implements ResponseContract
 
     use Fakeable;
 
-    private function __construct(
+    protected function __construct(
         public readonly string $code,
         public readonly string $message
     ) {}
@@ -33,8 +33,8 @@ final class GenericResponseError implements ResponseContract
     public static function from(array $attributes): self
     {
         return new self(
-            code: (string) $attributes['code'],
-            message: $attributes['message'],
+            code: (string) ($attributes['code'] ?? 'unknown_error'),
+            message: $attributes['message'] ?? 'An unknown error occurred.',
         );
     }
 

--- a/src/Responses/Responses/McpGenericResponseError.php
+++ b/src/Responses/Responses/McpGenericResponseError.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Responses\Responses;
+
+use OpenAI\Contracts\ResponseContract;
+
+/**
+ * @phpstan-type McpErrorType array{type: string, content?: array<string, mixed>|null}
+ *
+ * @implements ResponseContract<McpErrorType>
+ */
+final class McpGenericResponseError extends GenericResponseError implements ResponseContract
+{
+    /**
+     * @param  array<string, mixed>|null  $content
+     */
+    protected function __construct(
+        string $code,
+        string $message,
+        public readonly ?array $content = null,
+    ) {
+        parent::__construct($code, $message);
+    }
+
+    /**
+     * @param  McpErrorType  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            code: (string) $attributes['type'],
+            message: 'An error occurred during the execution of an MCP call.',
+            content: $attributes['content'] ?? null,
+        );
+    }
+}

--- a/src/Responses/Responses/Output/OutputMcpCall.php
+++ b/src/Responses/Responses/Output/OutputMcpCall.php
@@ -7,12 +7,14 @@ namespace OpenAI\Responses\Responses\Output;
 use OpenAI\Contracts\ResponseContract;
 use OpenAI\Responses\Concerns\ArrayAccessible;
 use OpenAI\Responses\Responses\GenericResponseError;
+use OpenAI\Responses\Responses\McpGenericResponseError;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
  * @phpstan-import-type ErrorType from GenericResponseError
+ * @phpstan-import-type McpErrorType from McpGenericResponseError
  *
- * @phpstan-type OutputMcpCallType array{id: string, server_label: string, type: 'mcp_call', approval_request_id: ?string, arguments: string, error: string|ErrorType|null, name: string, output: ?string}
+ * @phpstan-type OutputMcpCallType array{id: string, server_label: string, type: 'mcp_call', approval_request_id: ?string, arguments: string, error: string|McpErrorType|ErrorType|null, name: string, output: ?string}
  *
  * @implements ResponseContract<OutputMcpCallType>
  */
@@ -35,7 +37,7 @@ final class OutputMcpCall implements ResponseContract
         public readonly string $arguments,
         public readonly string $name,
         public readonly ?string $approvalRequestId = null,
-        public readonly ?GenericResponseError $error = null,
+        public readonly McpGenericResponseError|GenericResponseError|null $error = null,
         public readonly ?string $output = null,
     ) {}
 
@@ -45,10 +47,13 @@ final class OutputMcpCall implements ResponseContract
     public static function from(array $attributes): self
     {
         // OpenAI has odd structure (presumably a bug) where the errorType can sometimes be a full-fledged HTTP error object.
-        // As MCP calls are valid HTTP requests - we need to handle strings & objects here.
+        // They can also be a full-fledged MCP error object.
+        // They can also just be a string message. So we need to handle all three cases.
         $errorType = null;
         if (isset($attributes['error'])) {
-            if (is_array($attributes['error'])) {
+            if (is_array($attributes['error']) && isset($attributes['error']['content'])) {
+                $errorType = McpGenericResponseError::from($attributes['error']);
+            } elseif (is_array($attributes['error'])) {
                 $errorType = GenericResponseError::from($attributes['error']);
             } elseif (is_string($attributes['error'])) {
                 $errorType = GenericResponseError::from([

--- a/tests/Fixtures/Responses.php
+++ b/tests/Fixtures/Responses.php
@@ -367,6 +367,33 @@ function outputMcpListTools(): array
 /**
  * @return array<string, mixed>
  */
+function outputMcpErrorCallToolExecution(): array
+{
+    return [
+        'id' => 'mcp_68ae0539ede081a096e9cc4526aadc8200b5e200d643ebad',
+        'type' => 'mcp_call',
+        'approval_request_id' => null,
+        'arguments' => '{"value":"test"}',
+        'error' => [
+            'type' => 'mcp_tool_execution_error',
+            'content' => [
+                [
+                    'type' => 'text',
+                    'text' => '[POST] "undefined": <no response> Invalid URL: undefined',
+                    'annotations' => null,
+                    'meta' => null,
+                ],
+            ],
+        ],
+        'name' => 'deploy-html',
+        'output' => null,
+        'server_label' => 'deploy-html',
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
 function outputComputerToolCall(): array
 {
     return [

--- a/tests/Responses/Responses/Output/OutputMcpCall.php
+++ b/tests/Responses/Responses/Output/OutputMcpCall.php
@@ -1,6 +1,7 @@
 <?php
 
 use OpenAI\Responses\Responses\GenericResponseError;
+use OpenAI\Responses\Responses\McpGenericResponseError;
 use OpenAI\Responses\Responses\Output\OutputMcpCall;
 
 test('from', function () {
@@ -39,6 +40,23 @@ test('from error as string', function () {
         ->code->toBe('unknown_error')
         ->message->toBe('Missing or invalid authorization token.');
 
+});
+
+test('from error as mcp tool execution error', function () {
+    $response = OutputMcpCall::from(outputMcpErrorCallToolExecution());
+
+    expect($response)
+        ->toBeInstanceOf(OutputMcpCall::class)
+        ->id->toBe('mcp_68ae0539ede081a096e9cc4526aadc8200b5e200d643ebad')
+        ->type->toBe('mcp_call')
+        ->approvalRequestId->toBeNull()
+        ->arguments->toBe('{"value":"test"}')
+        ->name->toBe('deploy-html')
+        ->output->toBeNull()
+        ->serverLabel->toBe('deploy-html')
+        ->error->toBeInstanceOf(McpGenericResponseError::class)
+        ->and($response->error)
+        ->code->toBe('mcp_tool_execution_error');
 });
 
 test('as array accessible', function () {


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

MCP is messy. OpenAI presently uses `error` tag in 3 different ways.

 1. A basic string
 2. An array of `code` and `message` (OpenAI structured error)
 3. An array of `type` and `content` (mcp structured error)
 
It would seem odd for end user to be responsible for 3 different error returns, but I didn't know 2/3 of these formats existed until after first implementation was written. To reduce shift in userland code we map all exceptions back to a Generic exception. This seems like best path until we have more results and usage as Response API gains adoption to figure out how to refine further.

### Related:

fixes: #660 
