### PR TITLE
Add `sequence_number` support to `OutputTextDelta`.

### DIFF
--- a/src/Responses/Responses/Streaming/OutputTextDelta.php
+++ b/src/Responses/Responses/Streaming/OutputTextDelta.php
@@ -12,7 +12,7 @@ use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
- * @phpstan-type OutputTextType array{content_index: int, delta: string, item_id: string, output_index: int}
+ * @phpstan-type OutputTextType array{content_index: int, delta: string, item_id: string, output_index: int, sequence_number: int}
  *
  * @implements ResponseContract<OutputTextType>
  */
@@ -31,6 +31,7 @@ final class OutputTextDelta implements ResponseContract, ResponseHasMetaInformat
         public readonly string $delta,
         public readonly string $itemId,
         public readonly int $outputIndex,
+        public readonly int $sequenceNumber,
         private readonly MetaInformation $meta,
     ) {}
 
@@ -44,6 +45,7 @@ final class OutputTextDelta implements ResponseContract, ResponseHasMetaInformat
             delta: $attributes['delta'],
             itemId: $attributes['item_id'],
             outputIndex: $attributes['output_index'],
+            sequenceNumber: $attributes['sequence_number'],
             meta: $meta,
         );
     }
@@ -58,6 +60,7 @@ final class OutputTextDelta implements ResponseContract, ResponseHasMetaInformat
             'delta' => $this->delta,
             'item_id' => $this->itemId,
             'output_index' => $this->outputIndex,
+            'sequence_number' => $this->sequenceNumber,
         ];
     }
 }


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Adds support for the `sequence_number` feature in the `OutputTextDelta` component. This enhances the functionality by allowing tracking of output sequences.

Docs: https://platform.openai.com/docs/api-reference/responses_streaming/response/output_text/delta