### PR TITLE
fix(OpenAI): handle null require_approval in Response API

### DIFF
--- a/src/Responses/Responses/Tool/RemoteMcpTool.php
+++ b/src/Responses/Responses/Tool/RemoteMcpTool.php
@@ -49,9 +49,12 @@ final class RemoteMcpTool implements ResponseContract
     {
         $requireApproval = $attributes['require_approval'] ?? null;
         if (is_array($requireApproval)) {
-            $requireApproval = array_map(function (array $approvalAttributes): McpToolNamesFilter {
-                return McpToolNamesFilter::from($approvalAttributes);
-            }, $requireApproval);
+            $requireApproval = array_map(
+                function (array $approvalAttributes): McpToolNamesFilter {
+                    return McpToolNamesFilter::from($approvalAttributes);
+                },
+                array_filter($requireApproval, fn ($item) => $item !== null)
+            );
         }
 
         $allowedTools = $attributes['allowed_tools'] ?? null;

--- a/src/Responses/Responses/Tool/RemoteMcpTool.php
+++ b/src/Responses/Responses/Tool/RemoteMcpTool.php
@@ -53,7 +53,7 @@ final class RemoteMcpTool implements ResponseContract
                 function (array $approvalAttributes): McpToolNamesFilter {
                     return McpToolNamesFilter::from($approvalAttributes);
                 },
-                array_filter($requireApproval, fn ($item) => $item !== null)
+                array_filter($requireApproval, fn (array|null $item) => $item !== null)
             );
         }
 

--- a/src/Responses/Responses/Tool/RemoteMcpTool.php
+++ b/src/Responses/Responses/Tool/RemoteMcpTool.php
@@ -53,7 +53,7 @@ final class RemoteMcpTool implements ResponseContract
                 function (array $approvalAttributes): McpToolNamesFilter {
                     return McpToolNamesFilter::from($approvalAttributes);
                 },
-                array_filter($requireApproval, fn (array|null $item) => $item !== null)
+                array_filter($requireApproval, fn (?array $item) => $item !== null)
             );
         }
 

--- a/tests/Fixtures/Responses.php
+++ b/tests/Fixtures/Responses.php
@@ -629,6 +629,28 @@ function toolRemoteMcp(): array
 /**
  * @return array<string, mixed>
  */
+function toolRemoveMcpRequireApproval(): array
+{
+    return [
+        'type' => 'mcp',
+        'server_label' => 'My test MCP server',
+        'server_url' => 'https://server.example.com/mcp',
+        'require_approval' => [
+            'never' => [
+                'read_only' => null,
+                'tool_names' => ['ask_question', 'read_wiki_structure'],
+            ],
+            'always' => null,
+        ],
+        'allowed_tools' => null,
+        'headers' => null,
+        'server_description' => null,
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
 function toolConnectorMcp(): array
 {
     return [

--- a/tests/Responses/Responses/Tool/RemoteMcpTool.php
+++ b/tests/Responses/Responses/Tool/RemoteMcpTool.php
@@ -45,6 +45,14 @@ test('from object as require_approval', function () {
         ->requireApproval->toBeArray();
 });
 
+test('from object as specific approved tools', function () {
+    $response = RemoteMcpTool::from(toolRemoveMcpRequireApproval());
+
+    expect($response)
+        ->toBeInstanceOf(RemoteMcpTool::class)
+        ->requireApproval->toBeArray();
+});
+
 test('from object as allowed_tools', function () {
     $payload = toolRemoteMcp();
     $payload['allowed_tools'] = [


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Support when a `require_approval` object comes in as null. Real life test: https://github.com/iBotPeaches/openai-php-laravel-test/commit/5692d0fb26346b8cbbd76b8aa437a0c5c8e3d4b5 

### Related:

fixes: #666 :imp: 
