### PR TITLE
refactor(meta): unify response types into Actions

### DIFF
--- a/src/Actions/Responses/ItemObjects.php
+++ b/src/Actions/Responses/ItemObjects.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Actions\Responses;
+
+use OpenAI\Responses\Responses\Input\ComputerToolCallOutput;
+use OpenAI\Responses\Responses\Input\FunctionToolCallOutput;
+use OpenAI\Responses\Responses\Input\InputMessage;
+use OpenAI\Responses\Responses\Output\OutputCodeInterpreterToolCall;
+use OpenAI\Responses\Responses\Output\OutputComputerToolCall;
+use OpenAI\Responses\Responses\Output\OutputFileSearchToolCall;
+use OpenAI\Responses\Responses\Output\OutputFunctionToolCall;
+use OpenAI\Responses\Responses\Output\OutputImageGenerationToolCall;
+use OpenAI\Responses\Responses\Output\OutputMcpApprovalRequest;
+use OpenAI\Responses\Responses\Output\OutputMcpCall;
+use OpenAI\Responses\Responses\Output\OutputMcpListTools;
+use OpenAI\Responses\Responses\Output\OutputMessage;
+use OpenAI\Responses\Responses\Output\OutputReasoning;
+use OpenAI\Responses\Responses\Output\OutputWebSearchToolCall;
+
+/**
+ * @phpstan-import-type InputMessageType from InputMessage
+ * @phpstan-import-type ComputerToolCallOutputType from ComputerToolCallOutput
+ * @phpstan-import-type FunctionToolCallOutputType from FunctionToolCallOutput
+ * @phpstan-import-type OutputComputerToolCallType from OutputComputerToolCall
+ * @phpstan-import-type OutputFileSearchToolCallType from OutputFileSearchToolCall
+ * @phpstan-import-type OutputFunctionToolCallType from OutputFunctionToolCall
+ * @phpstan-import-type OutputMessageType from OutputMessage
+ * @phpstan-import-type OutputReasoningType from OutputReasoning
+ * @phpstan-import-type OutputWebSearchToolCallType from OutputWebSearchToolCall
+ * @phpstan-import-type OutputMcpListToolsType from OutputMcpListTools
+ * @phpstan-import-type OutputMcpApprovalRequestType from OutputMcpApprovalRequest
+ * @phpstan-import-type OutputMcpCallType from OutputMcpCall
+ * @phpstan-import-type OutputImageGenerationToolCallType from OutputImageGenerationToolCall
+ * @phpstan-import-type OutputCodeInterpreterToolCallType from OutputCodeInterpreterToolCall
+ *
+ * @phpstan-type ResponseItemObjectTypes array<int, InputMessageType|ComputerToolCallOutputType|FunctionToolCallOutputType|OutputComputerToolCallType|OutputFileSearchToolCallType|OutputFunctionToolCallType|OutputMessageType|OutputReasoningType|OutputWebSearchToolCallType|OutputMcpListToolsType|OutputMcpApprovalRequestType|OutputMcpCallType|OutputImageGenerationToolCallType|OutputCodeInterpreterToolCallType>
+ * @phpstan-type ResponseItemObjectReturnType array<int, InputMessage|ComputerToolCallOutput|FunctionToolCallOutput|OutputMessage|OutputComputerToolCall|OutputFileSearchToolCall|OutputWebSearchToolCall|OutputFunctionToolCall|OutputReasoning|OutputMcpListTools|OutputMcpApprovalRequest|OutputMcpCall|OutputImageGenerationToolCall|OutputCodeInterpreterToolCall>
+ */
+final class ItemObjects
+{
+    /**
+     * @param  ResponseItemObjectTypes  $outputItems
+     * @return ResponseItemObjectReturnType
+     */
+    public static function parse(array $outputItems): array
+    {
+        return array_map(
+            fn (array $item): InputMessage|ComputerToolCallOutput|FunctionToolCallOutput|OutputMessage|OutputComputerToolCall|OutputFileSearchToolCall|OutputWebSearchToolCall|OutputFunctionToolCall|OutputReasoning|OutputMcpListTools|OutputMcpApprovalRequest|OutputMcpCall|OutputImageGenerationToolCall|OutputCodeInterpreterToolCall => match ($item['type']) {
+                'message' => $item['role'] === 'assistant' ? OutputMessage::from($item) : InputMessage::from($item),
+                'file_search_call' => OutputFileSearchToolCall::from($item),
+                'function_call' => OutputFunctionToolCall::from($item),
+                'function_call_output' => FunctionToolCallOutput::from($item),
+                'web_search_call' => OutputWebSearchToolCall::from($item),
+                'computer_call' => OutputComputerToolCall::from($item),
+                'computer_call_output' => ComputerToolCallOutput::from($item),
+                'reasoning' => OutputReasoning::from($item),
+                'mcp_list_tools' => OutputMcpListTools::from($item),
+                'mcp_approval_request' => OutputMcpApprovalRequest::from($item),
+                'mcp_call' => OutputMcpCall::from($item),
+                'image_generation_call' => OutputImageGenerationToolCall::from($item),
+                'code_interpreter_call' => OutputCodeInterpreterToolCall::from($item),
+            },
+            $outputItems,
+        );
+    }
+}

--- a/src/Actions/Responses/OutputObjects.php
+++ b/src/Actions/Responses/OutputObjects.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Actions\Responses;
+
+use OpenAI\Responses\Responses\Output\OutputCodeInterpreterToolCall;
+use OpenAI\Responses\Responses\Output\OutputComputerToolCall;
+use OpenAI\Responses\Responses\Output\OutputFileSearchToolCall;
+use OpenAI\Responses\Responses\Output\OutputFunctionToolCall;
+use OpenAI\Responses\Responses\Output\OutputImageGenerationToolCall;
+use OpenAI\Responses\Responses\Output\OutputMcpApprovalRequest;
+use OpenAI\Responses\Responses\Output\OutputMcpCall;
+use OpenAI\Responses\Responses\Output\OutputMcpListTools;
+use OpenAI\Responses\Responses\Output\OutputMessage;
+use OpenAI\Responses\Responses\Output\OutputReasoning;
+use OpenAI\Responses\Responses\Output\OutputWebSearchToolCall;
+
+/**
+ * @phpstan-import-type OutputComputerToolCallType from OutputComputerToolCall
+ * @phpstan-import-type OutputFileSearchToolCallType from OutputFileSearchToolCall
+ * @phpstan-import-type OutputFunctionToolCallType from OutputFunctionToolCall
+ * @phpstan-import-type OutputMessageType from OutputMessage
+ * @phpstan-import-type OutputReasoningType from OutputReasoning
+ * @phpstan-import-type OutputWebSearchToolCallType from OutputWebSearchToolCall
+ * @phpstan-import-type OutputMcpListToolsType from OutputMcpListTools
+ * @phpstan-import-type OutputMcpApprovalRequestType from OutputMcpApprovalRequest
+ * @phpstan-import-type OutputMcpCallType from OutputMcpCall
+ * @phpstan-import-type OutputImageGenerationToolCallType from OutputImageGenerationToolCall
+ * @phpstan-import-type OutputCodeInterpreterToolCallType from OutputCodeInterpreterToolCall
+ *
+ * @phpstan-type ResponseOutputObjectTypes array<int, OutputComputerToolCallType|OutputFileSearchToolCallType|OutputFunctionToolCallType|OutputMessageType|OutputReasoningType|OutputWebSearchToolCallType|OutputMcpListToolsType|OutputMcpApprovalRequestType|OutputMcpCallType|OutputImageGenerationToolCallType|OutputCodeInterpreterToolCallType>
+ * @phpstan-type ResponseOutputObjectReturnType array<int, OutputMessage|OutputComputerToolCall|OutputFileSearchToolCall|OutputWebSearchToolCall|OutputFunctionToolCall|OutputReasoning|OutputMcpListTools|OutputMcpApprovalRequest|OutputMcpCall|OutputImageGenerationToolCall|OutputCodeInterpreterToolCall>
+ */
+final class OutputObjects
+{
+    /**
+     * @param  ResponseOutputObjectTypes  $outputItems
+     * @return ResponseOutputObjectReturnType
+     */
+    public static function parse(array $outputItems): array
+    {
+        return array_map(
+            fn (array $item): OutputMessage|OutputComputerToolCall|OutputFileSearchToolCall|OutputWebSearchToolCall|OutputFunctionToolCall|OutputReasoning|OutputMcpListTools|OutputMcpApprovalRequest|OutputMcpCall|OutputImageGenerationToolCall|OutputCodeInterpreterToolCall => match ($item['type']) {
+                'message' => OutputMessage::from($item),
+                'file_search_call' => OutputFileSearchToolCall::from($item),
+                'function_call' => OutputFunctionToolCall::from($item),
+                'web_search_call' => OutputWebSearchToolCall::from($item),
+                'computer_call' => OutputComputerToolCall::from($item),
+                'reasoning' => OutputReasoning::from($item),
+                'mcp_list_tools' => OutputMcpListTools::from($item),
+                'mcp_approval_request' => OutputMcpApprovalRequest::from($item),
+                'mcp_call' => OutputMcpCall::from($item),
+                'image_generation_call' => OutputImageGenerationToolCall::from($item),
+                'code_interpreter_call' => OutputCodeInterpreterToolCall::from($item),
+            },
+            $outputItems,
+        );
+    }
+}

--- a/src/Actions/Responses/OutputText.php
+++ b/src/Actions/Responses/OutputText.php
@@ -4,28 +4,18 @@ declare(strict_types=1);
 
 namespace OpenAI\Actions\Responses;
 
-use OpenAI\Responses\Responses\Output\OutputCodeInterpreterToolCall;
-use OpenAI\Responses\Responses\Output\OutputComputerToolCall;
-use OpenAI\Responses\Responses\Output\OutputFileSearchToolCall;
-use OpenAI\Responses\Responses\Output\OutputFunctionToolCall;
-use OpenAI\Responses\Responses\Output\OutputImageGenerationToolCall;
-use OpenAI\Responses\Responses\Output\OutputMcpApprovalRequest;
-use OpenAI\Responses\Responses\Output\OutputMcpCall;
-use OpenAI\Responses\Responses\Output\OutputMcpListTools;
 use OpenAI\Responses\Responses\Output\OutputMessage;
 use OpenAI\Responses\Responses\Output\OutputMessageContentOutputText;
-use OpenAI\Responses\Responses\Output\OutputReasoning;
-use OpenAI\Responses\Responses\Output\OutputWebSearchToolCall;
 
 /**
  * An SDK-only property (output_text) that concatenates all text content from output messages.
  *
- * @phpstan-type ResponseOutputTextTypes array<int, OutputMessage|OutputComputerToolCall|OutputFileSearchToolCall|OutputWebSearchToolCall|OutputFunctionToolCall|OutputReasoning|OutputMcpListTools|OutputMcpApprovalRequest|OutputMcpCall|OutputImageGenerationToolCall|OutputCodeInterpreterToolCall>
+ * @phpstan-import-type ResponseOutputObjectReturnType from OutputObjects
  */
 final class OutputText
 {
     /**
-     * @param  ResponseOutputTextTypes  $outputItems
+     * @param  ResponseOutputObjectReturnType  $outputItems
      */
     public static function parse(array $outputItems): ?string
     {

--- a/src/Actions/Responses/OutputText.php
+++ b/src/Actions/Responses/OutputText.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Actions\Responses;
+
+use OpenAI\Responses\Responses\Output\OutputCodeInterpreterToolCall;
+use OpenAI\Responses\Responses\Output\OutputComputerToolCall;
+use OpenAI\Responses\Responses\Output\OutputFileSearchToolCall;
+use OpenAI\Responses\Responses\Output\OutputFunctionToolCall;
+use OpenAI\Responses\Responses\Output\OutputImageGenerationToolCall;
+use OpenAI\Responses\Responses\Output\OutputMcpApprovalRequest;
+use OpenAI\Responses\Responses\Output\OutputMcpCall;
+use OpenAI\Responses\Responses\Output\OutputMcpListTools;
+use OpenAI\Responses\Responses\Output\OutputMessage;
+use OpenAI\Responses\Responses\Output\OutputMessageContentOutputText;
+use OpenAI\Responses\Responses\Output\OutputReasoning;
+use OpenAI\Responses\Responses\Output\OutputWebSearchToolCall;
+
+/**
+ * An SDK-only property (output_text) that concatenates all text content from output messages.
+ *
+ * @phpstan-type ResponseOutputTextTypes array<int, OutputMessage|OutputComputerToolCall|OutputFileSearchToolCall|OutputWebSearchToolCall|OutputFunctionToolCall|OutputReasoning|OutputMcpListTools|OutputMcpApprovalRequest|OutputMcpCall|OutputImageGenerationToolCall|OutputCodeInterpreterToolCall>
+ */
+final class OutputText
+{
+    /**
+     * @param  ResponseOutputTextTypes  $outputItems
+     */
+    public static function parse(array $outputItems): ?string
+    {
+        $texts = [];
+        foreach ($outputItems as $item) {
+            if ($item instanceof OutputMessage) {
+                foreach ($item->content as $content) {
+                    if ($content instanceof OutputMessageContentOutputText) {
+                        $texts[] = $content->text;
+                    }
+                }
+            }
+        }
+
+        return empty($texts) ? null : implode(' ', $texts);
+    }
+}

--- a/src/Actions/Responses/ToolChoiceObjects.php
+++ b/src/Actions/Responses/ToolChoiceObjects.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Actions\Responses;
+
+use OpenAI\Responses\Responses\ToolChoice\FunctionToolChoice;
+use OpenAI\Responses\Responses\ToolChoice\HostedToolChoice;
+
+/**
+ * @phpstan-import-type FunctionToolChoiceType from FunctionToolChoice
+ * @phpstan-import-type HostedToolChoiceType from HostedToolChoice
+ *
+ * @phpstan-type ResponseToolChoiceTypes 'none'|'auto'|'required'|FunctionToolChoiceType|HostedToolChoiceType
+ * @phpstan-type ResponseToolChoiceReturnType 'none'|'auto'|'required'|FunctionToolChoice|HostedToolChoice
+ */
+final class ToolChoiceObjects
+{
+    /**
+     * @param  ResponseToolChoiceTypes  $toolChoice
+     * @return ResponseToolChoiceReturnType
+     */
+    public static function parse(array|string $toolChoice): string|FunctionToolChoice|HostedToolChoice
+    {
+        return is_array($toolChoice)
+            ? match ($toolChoice['type']) {
+                'file_search', 'web_search', 'web_search_preview', 'computer_use_preview' => HostedToolChoice::from($toolChoice),
+                'function' => FunctionToolChoice::from($toolChoice),
+            }
+        : $toolChoice;
+    }
+}

--- a/src/Actions/Responses/ToolObjects.php
+++ b/src/Actions/Responses/ToolObjects.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Actions\Responses;
+
+use OpenAI\Responses\Responses\Tool\CodeInterpreterTool;
+use OpenAI\Responses\Responses\Tool\ComputerUseTool;
+use OpenAI\Responses\Responses\Tool\FileSearchTool;
+use OpenAI\Responses\Responses\Tool\FunctionTool;
+use OpenAI\Responses\Responses\Tool\ImageGenerationTool;
+use OpenAI\Responses\Responses\Tool\RemoteMcpTool;
+use OpenAI\Responses\Responses\Tool\WebSearchTool;
+
+/**
+ * @phpstan-import-type ComputerUseToolType from ComputerUseTool
+ * @phpstan-import-type FileSearchToolType from FileSearchTool
+ * @phpstan-import-type ImageGenerationToolType from ImageGenerationTool
+ * @phpstan-import-type RemoteMcpToolType from RemoteMcpTool
+ * @phpstan-import-type FunctionToolType from FunctionTool
+ * @phpstan-import-type WebSearchToolType from WebSearchTool
+ * @phpstan-import-type CodeInterpreterToolType from CodeInterpreterTool
+ *
+ * @phpstan-type ResponseToolObjectTypes array<int, ComputerUseToolType|FileSearchToolType|FunctionToolType|WebSearchToolType|ImageGenerationToolType|RemoteMcpToolType|CodeInterpreterToolType>
+ * @phpstan-type ResponseToolObjectReturnType array<int, ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool|RemoteMcpTool|CodeInterpreterTool>
+ */
+final class ToolObjects
+{
+    /**
+     * @param  ResponseToolObjectTypes  $toolItems
+     * @return ResponseToolObjectReturnType
+     */
+    public static function parse(array $toolItems): array
+    {
+        return array_map(
+            fn (array $tool): ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool|RemoteMcpTool|CodeInterpreterTool => match ($tool['type']) {
+                'file_search' => FileSearchTool::from($tool),
+                'web_search', 'web_search_preview', 'web_search_preview_2025_03_11' => WebSearchTool::from($tool),
+                'function' => FunctionTool::from($tool),
+                'computer_use_preview' => ComputerUseTool::from($tool),
+                'image_generation' => ImageGenerationTool::from($tool),
+                'mcp' => RemoteMcpTool::from($tool),
+                'code_interpreter' => CodeInterpreterTool::from($tool),
+            },
+            $toolItems,
+        );
+    }
+}

--- a/src/Responses/Responses/CreateResponse.php
+++ b/src/Responses/Responses/CreateResponse.php
@@ -37,28 +37,17 @@ use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
  * @phpstan-import-type ResponseFormatType from CreateResponseFormat
- * @phpstan-import-type OutputComputerToolCallType from OutputComputerToolCall
- * @phpstan-import-type OutputFileSearchToolCallType from OutputFileSearchToolCall
- * @phpstan-import-type OutputFunctionToolCallType from OutputFunctionToolCall
- * @phpstan-import-type OutputMessageType from OutputMessage
- * @phpstan-import-type OutputReasoningType from OutputReasoning
- * @phpstan-import-type OutputWebSearchToolCallType from OutputWebSearchToolCall
- * @phpstan-import-type OutputMcpListToolsType from OutputMcpListTools
- * @phpstan-import-type OutputMcpApprovalRequestType from OutputMcpApprovalRequest
- * @phpstan-import-type OutputMcpCallType from OutputMcpCall
- * @phpstan-import-type OutputImageGenerationToolCallType from OutputImageGenerationToolCall
- * @phpstan-import-type OutputCodeInterpreterToolCallType from OutputCodeInterpreterToolCall
  * @phpstan-import-type ErrorType from GenericResponseError
  * @phpstan-import-type IncompleteDetailsType from CreateResponseIncompleteDetails
  * @phpstan-import-type UsageType from CreateResponseUsage
  * @phpstan-import-type ReasoningType from CreateResponseReasoning
  * @phpstan-import-type ReferencePromptObjectType from ReferencePromptObject
+ * @phpstan-import-type ResponseOutputObjectTypes from OutputObjects
  * @phpstan-import-type ResponseToolChoiceTypes from ToolChoiceObjects
  * @phpstan-import-type ResponseToolObjectTypes from ToolObjects
  *
  * @phpstan-type InstructionsType array<int, mixed>|string|null
- * @phpstan-type OutputType array<int, OutputComputerToolCallType|OutputFileSearchToolCallType|OutputFunctionToolCallType|OutputMessageType|OutputReasoningType|OutputWebSearchToolCallType|OutputMcpListToolsType|OutputMcpApprovalRequestType|OutputMcpCallType|OutputImageGenerationToolCallType|OutputCodeInterpreterToolCallType>
- * @phpstan-type CreateResponseType array{id: string, background?: bool|null, object: 'response', created_at: int, status: 'completed'|'failed'|'in_progress'|'incomplete', error: ErrorType|null, incomplete_details: IncompleteDetailsType|null, instructions: InstructionsType, max_output_tokens: int|null, max_tool_calls?: int|null, model: string, output: OutputType, output_text: string|null, parallel_tool_calls: bool, previous_response_id: string|null, prompt: ReferencePromptObjectType|null, prompt_cache_key?: string|null, reasoning: ReasoningType|null, safety_identifier?: string|null, service_tier?: string|null, store?: bool|null, temperature: float|null, text?: ResponseFormatType|null, tool_choice: ResponseToolChoiceTypes, tools: ResponseToolObjectTypes, top_logprobs?: int|null, top_p: float|null, truncation: 'auto'|'disabled'|null, usage: UsageType|null, user: string|null, verbosity: string|null, metadata: array<string, string>|null}
+ * @phpstan-type CreateResponseType array{id: string, background?: bool|null, object: 'response', created_at: int, status: 'completed'|'failed'|'in_progress'|'incomplete', error: ErrorType|null, incomplete_details: IncompleteDetailsType|null, instructions: InstructionsType, max_output_tokens: int|null, max_tool_calls?: int|null, model: string, output: ResponseOutputObjectTypes, output_text: string|null, parallel_tool_calls: bool, previous_response_id: string|null, prompt: ReferencePromptObjectType|null, prompt_cache_key?: string|null, reasoning: ReasoningType|null, safety_identifier?: string|null, service_tier?: string|null, store?: bool|null, temperature: float|null, text?: ResponseFormatType|null, tool_choice: ResponseToolChoiceTypes, tools: ResponseToolObjectTypes, top_logprobs?: int|null, top_p: float|null, truncation: 'auto'|'disabled'|null, usage: UsageType|null, user: string|null, verbosity: string|null, metadata: array<string, string>|null}
  *
  * @implements ResponseContract<CreateResponseType>
  */

--- a/src/Responses/Responses/CreateResponse.php
+++ b/src/Responses/Responses/CreateResponse.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace OpenAI\Responses\Responses;
 
+use OpenAI\Actions\Responses\OutputObjects;
+use OpenAI\Actions\Responses\OutputText;
+use OpenAI\Actions\Responses\ToolChoiceObjects;
+use OpenAI\Actions\Responses\ToolObjects;
 use OpenAI\Contracts\ResponseContract;
 use OpenAI\Contracts\ResponseHasMetaInformationContract;
 use OpenAI\Responses\Concerns\ArrayAccessible;
@@ -18,7 +22,6 @@ use OpenAI\Responses\Responses\Output\OutputMcpApprovalRequest;
 use OpenAI\Responses\Responses\Output\OutputMcpCall;
 use OpenAI\Responses\Responses\Output\OutputMcpListTools;
 use OpenAI\Responses\Responses\Output\OutputMessage;
-use OpenAI\Responses\Responses\Output\OutputMessageContentOutputText;
 use OpenAI\Responses\Responses\Output\OutputReasoning;
 use OpenAI\Responses\Responses\Output\OutputWebSearchToolCall;
 use OpenAI\Responses\Responses\Tool\CodeInterpreterTool;
@@ -128,54 +131,9 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
      */
     public static function from(array $attributes, MetaInformation $meta): self
     {
-        $output = array_map(
-            fn (array $output): OutputMessage|OutputComputerToolCall|OutputFileSearchToolCall|OutputWebSearchToolCall|OutputFunctionToolCall|OutputReasoning|OutputMcpListTools|OutputMcpApprovalRequest|OutputMcpCall|OutputImageGenerationToolCall|OutputCodeInterpreterToolCall => match ($output['type']) {
-                'message' => OutputMessage::from($output),
-                'file_search_call' => OutputFileSearchToolCall::from($output),
-                'function_call' => OutputFunctionToolCall::from($output),
-                'web_search_call' => OutputWebSearchToolCall::from($output),
-                'computer_call' => OutputComputerToolCall::from($output),
-                'reasoning' => OutputReasoning::from($output),
-                'mcp_list_tools' => OutputMcpListTools::from($output),
-                'mcp_approval_request' => OutputMcpApprovalRequest::from($output),
-                'mcp_call' => OutputMcpCall::from($output),
-                'image_generation_call' => OutputImageGenerationToolCall::from($output),
-                'code_interpreter_call' => OutputCodeInterpreterToolCall::from($output),
-            },
-            $attributes['output'],
-        );
-
-        $toolChoice = is_array($attributes['tool_choice'])
-            ? match ($attributes['tool_choice']['type']) {
-                'file_search', 'web_search', 'web_search_preview', 'computer_use_preview' => HostedToolChoice::from($attributes['tool_choice']),
-                'function' => FunctionToolChoice::from($attributes['tool_choice']),
-            }
-        : $attributes['tool_choice'];
-
-        $tools = array_map(
-            fn (array $tool): ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool|RemoteMcpTool|CodeInterpreterTool => match ($tool['type']) {
-                'file_search' => FileSearchTool::from($tool),
-                'web_search', 'web_search_preview', 'web_search_preview_2025_03_11' => WebSearchTool::from($tool),
-                'function' => FunctionTool::from($tool),
-                'computer_use_preview' => ComputerUseTool::from($tool),
-                'image_generation' => ImageGenerationTool::from($tool),
-                'mcp' => RemoteMcpTool::from($tool),
-                'code_interpreter' => CodeInterpreterTool::from($tool),
-            },
-            $attributes['tools'],
-        );
-
-        // Remake the sdk only property output_text.
-        $texts = [];
-        foreach ($output as $item) {
-            if ($item instanceof OutputMessage) {
-                foreach ($item->content as $content) {
-                    if ($content instanceof OutputMessageContentOutputText) {
-                        $texts[] = $content->text;
-                    }
-                }
-            }
-        }
+        $output = OutputObjects::parse($attributes['output']);
+        $toolChoice = ToolChoiceObjects::parse($attributes['tool_choice']);
+        $tools = ToolObjects::parse($attributes['tools']);
 
         return new self(
             id: $attributes['id'],
@@ -194,7 +152,7 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
             maxOutputTokens: $attributes['max_output_tokens'],
             model: $attributes['model'],
             output: $output,
-            outputText: empty($texts) ? null : implode(' ', $texts),
+            outputText: OutputText::parse($output),
             parallelToolCalls: $attributes['parallel_tool_calls'],
             previousResponseId: $attributes['previous_response_id'],
             prompt: isset($attributes['prompt'])

--- a/src/Responses/Responses/CreateResponse.php
+++ b/src/Responses/Responses/CreateResponse.php
@@ -58,16 +58,14 @@ use OpenAI\Testing\Responses\Concerns\Fakeable;
  * @phpstan-import-type ErrorType from GenericResponseError
  * @phpstan-import-type IncompleteDetailsType from CreateResponseIncompleteDetails
  * @phpstan-import-type UsageType from CreateResponseUsage
- * @phpstan-import-type FunctionToolChoiceType from FunctionToolChoice
- * @phpstan-import-type HostedToolChoiceType from HostedToolChoice
  * @phpstan-import-type ReasoningType from CreateResponseReasoning
  * @phpstan-import-type ReferencePromptObjectType from ReferencePromptObject
+ * @phpstan-import-type ResponseToolChoiceTypes from ToolChoiceObjects
  *
  * @phpstan-type InstructionsType array<int, mixed>|string|null
- * @phpstan-type ToolChoiceType 'none'|'auto'|'required'|FunctionToolChoiceType|HostedToolChoiceType
  * @phpstan-type ToolsType array<int, ComputerUseToolType|FileSearchToolType|FunctionToolType|WebSearchToolType|ImageGenerationToolType|RemoteMcpToolType|CodeInterpreterToolType>
  * @phpstan-type OutputType array<int, OutputComputerToolCallType|OutputFileSearchToolCallType|OutputFunctionToolCallType|OutputMessageType|OutputReasoningType|OutputWebSearchToolCallType|OutputMcpListToolsType|OutputMcpApprovalRequestType|OutputMcpCallType|OutputImageGenerationToolCallType|OutputCodeInterpreterToolCallType>
- * @phpstan-type CreateResponseType array{id: string, background?: bool|null, object: 'response', created_at: int, status: 'completed'|'failed'|'in_progress'|'incomplete', error: ErrorType|null, incomplete_details: IncompleteDetailsType|null, instructions: InstructionsType, max_output_tokens: int|null, max_tool_calls?: int|null, model: string, output: OutputType, output_text: string|null, parallel_tool_calls: bool, previous_response_id: string|null, prompt: ReferencePromptObjectType|null, prompt_cache_key?: string|null, reasoning: ReasoningType|null, safety_identifier?: string|null, service_tier?: string|null, store?: bool|null, temperature: float|null, text?: ResponseFormatType|null, tool_choice: ToolChoiceType, tools: ToolsType, top_logprobs?: int|null, top_p: float|null, truncation: 'auto'|'disabled'|null, usage: UsageType|null, user: string|null, verbosity: string|null, metadata: array<string, string>|null}
+ * @phpstan-type CreateResponseType array{id: string, background?: bool|null, object: 'response', created_at: int, status: 'completed'|'failed'|'in_progress'|'incomplete', error: ErrorType|null, incomplete_details: IncompleteDetailsType|null, instructions: InstructionsType, max_output_tokens: int|null, max_tool_calls?: int|null, model: string, output: OutputType, output_text: string|null, parallel_tool_calls: bool, previous_response_id: string|null, prompt: ReferencePromptObjectType|null, prompt_cache_key?: string|null, reasoning: ReasoningType|null, safety_identifier?: string|null, service_tier?: string|null, store?: bool|null, temperature: float|null, text?: ResponseFormatType|null, tool_choice: ResponseToolChoiceTypes, tools: ToolsType, top_logprobs?: int|null, top_p: float|null, truncation: 'auto'|'disabled'|null, usage: UsageType|null, user: string|null, verbosity: string|null, metadata: array<string, string>|null}
  *
  * @implements ResponseContract<CreateResponseType>
  */

--- a/src/Responses/Responses/CreateResponse.php
+++ b/src/Responses/Responses/CreateResponse.php
@@ -48,24 +48,17 @@ use OpenAI\Testing\Responses\Concerns\Fakeable;
  * @phpstan-import-type OutputMcpCallType from OutputMcpCall
  * @phpstan-import-type OutputImageGenerationToolCallType from OutputImageGenerationToolCall
  * @phpstan-import-type OutputCodeInterpreterToolCallType from OutputCodeInterpreterToolCall
- * @phpstan-import-type ComputerUseToolType from ComputerUseTool
- * @phpstan-import-type FileSearchToolType from FileSearchTool
- * @phpstan-import-type ImageGenerationToolType from ImageGenerationTool
- * @phpstan-import-type RemoteMcpToolType from RemoteMcpTool
- * @phpstan-import-type FunctionToolType from FunctionTool
- * @phpstan-import-type WebSearchToolType from WebSearchTool
- * @phpstan-import-type CodeInterpreterToolType from CodeInterpreterTool
  * @phpstan-import-type ErrorType from GenericResponseError
  * @phpstan-import-type IncompleteDetailsType from CreateResponseIncompleteDetails
  * @phpstan-import-type UsageType from CreateResponseUsage
  * @phpstan-import-type ReasoningType from CreateResponseReasoning
  * @phpstan-import-type ReferencePromptObjectType from ReferencePromptObject
  * @phpstan-import-type ResponseToolChoiceTypes from ToolChoiceObjects
+ * @phpstan-import-type ResponseToolObjectTypes from ToolObjects
  *
  * @phpstan-type InstructionsType array<int, mixed>|string|null
- * @phpstan-type ToolsType array<int, ComputerUseToolType|FileSearchToolType|FunctionToolType|WebSearchToolType|ImageGenerationToolType|RemoteMcpToolType|CodeInterpreterToolType>
  * @phpstan-type OutputType array<int, OutputComputerToolCallType|OutputFileSearchToolCallType|OutputFunctionToolCallType|OutputMessageType|OutputReasoningType|OutputWebSearchToolCallType|OutputMcpListToolsType|OutputMcpApprovalRequestType|OutputMcpCallType|OutputImageGenerationToolCallType|OutputCodeInterpreterToolCallType>
- * @phpstan-type CreateResponseType array{id: string, background?: bool|null, object: 'response', created_at: int, status: 'completed'|'failed'|'in_progress'|'incomplete', error: ErrorType|null, incomplete_details: IncompleteDetailsType|null, instructions: InstructionsType, max_output_tokens: int|null, max_tool_calls?: int|null, model: string, output: OutputType, output_text: string|null, parallel_tool_calls: bool, previous_response_id: string|null, prompt: ReferencePromptObjectType|null, prompt_cache_key?: string|null, reasoning: ReasoningType|null, safety_identifier?: string|null, service_tier?: string|null, store?: bool|null, temperature: float|null, text?: ResponseFormatType|null, tool_choice: ResponseToolChoiceTypes, tools: ToolsType, top_logprobs?: int|null, top_p: float|null, truncation: 'auto'|'disabled'|null, usage: UsageType|null, user: string|null, verbosity: string|null, metadata: array<string, string>|null}
+ * @phpstan-type CreateResponseType array{id: string, background?: bool|null, object: 'response', created_at: int, status: 'completed'|'failed'|'in_progress'|'incomplete', error: ErrorType|null, incomplete_details: IncompleteDetailsType|null, instructions: InstructionsType, max_output_tokens: int|null, max_tool_calls?: int|null, model: string, output: OutputType, output_text: string|null, parallel_tool_calls: bool, previous_response_id: string|null, prompt: ReferencePromptObjectType|null, prompt_cache_key?: string|null, reasoning: ReasoningType|null, safety_identifier?: string|null, service_tier?: string|null, store?: bool|null, temperature: float|null, text?: ResponseFormatType|null, tool_choice: ResponseToolChoiceTypes, tools: ResponseToolObjectTypes, top_logprobs?: int|null, top_p: float|null, truncation: 'auto'|'disabled'|null, usage: UsageType|null, user: string|null, verbosity: string|null, metadata: array<string, string>|null}
  *
  * @implements ResponseContract<CreateResponseType>
  */

--- a/src/Responses/Responses/ListInputItems.php
+++ b/src/Responses/Responses/ListInputItems.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenAI\Responses\Responses;
 
+use OpenAI\Actions\Responses\ItemObjects;
 use OpenAI\Contracts\ResponseContract;
 use OpenAI\Contracts\ResponseHasMetaInformationContract;
 use OpenAI\Responses\Concerns\ArrayAccessible;
@@ -26,22 +27,10 @@ use OpenAI\Responses\Responses\Output\OutputWebSearchToolCall;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
- * @phpstan-import-type InputMessageType from InputMessage
- * @phpstan-import-type OutputMessageType from OutputMessage
- * @phpstan-import-type OutputFileSearchToolCallType from OutputFileSearchToolCall
- * @phpstan-import-type OutputComputerToolCallType from OutputComputerToolCall
- * @phpstan-import-type ComputerToolCallOutputType from ComputerToolCallOutput
- * @phpstan-import-type OutputWebSearchToolCallType from OutputWebSearchToolCall
- * @phpstan-import-type OutputFunctionToolCallType from OutputFunctionToolCall
- * @phpstan-import-type FunctionToolCallOutputType from FunctionToolCallOutput
- * @phpstan-import-type OutputReasoningType from OutputReasoning
- * @phpstan-import-type OutputMcpListToolsType from OutputMcpListTools
- * @phpstan-import-type OutputMcpApprovalRequestType from OutputMcpApprovalRequest
- * @phpstan-import-type OutputMcpCallType from OutputMcpCall
- * @phpstan-import-type OutputImageGenerationToolCallType from OutputImageGenerationToolCall
- * @phpstan-import-type OutputCodeInterpreterToolCallType from OutputCodeInterpreterToolCall
+ * @phpstan-import-type ResponseItemObjectTypes from ItemObjects
+ * @phpstan-import-type ResponseItemObjectReturnType from ItemObjects
  *
- * @phpstan-type ListInputItemsType array{data: array<int, InputMessageType|OutputMessageType|OutputFileSearchToolCallType|OutputComputerToolCallType|ComputerToolCallOutputType|OutputWebSearchToolCallType|OutputFunctionToolCallType|FunctionToolCallOutputType|OutputReasoningType|OutputMcpListToolsType|OutputMcpApprovalRequestType|OutputMcpCallType|OutputImageGenerationToolCallType|OutputCodeInterpreterToolCallType>, first_id: string, has_more: bool, last_id: string, object: 'list'}
+ * @phpstan-type ListInputItemsType array{data: ResponseItemObjectTypes, first_id: string, has_more: bool, last_id: string, object: 'list'}
  *
  * @implements ResponseContract<ListInputItemsType>
  */
@@ -54,7 +43,7 @@ final class ListInputItems implements ResponseContract, ResponseHasMetaInformati
     use HasMetaInformation;
 
     /**
-     * @param  array<int, InputMessage|OutputMessage|OutputFileSearchToolCall|OutputComputerToolCall|ComputerToolCallOutput|OutputWebSearchToolCall|OutputFunctionToolCall|FunctionToolCallOutput|OutputReasoning|OutputMcpListTools|OutputMcpApprovalRequest|OutputMcpCall|OutputImageGenerationToolCall|OutputCodeInterpreterToolCall>  $data
+     * @param  ResponseItemObjectReturnType  $data
      * @param  'list'  $object
      */
     private function __construct(
@@ -71,24 +60,7 @@ final class ListInputItems implements ResponseContract, ResponseHasMetaInformati
      */
     public static function from(array $attributes, MetaInformation $meta): self
     {
-        $data = array_map(
-            fn (array $item): InputMessage|OutputMessage|OutputFileSearchToolCall|OutputComputerToolCall|ComputerToolCallOutput|OutputWebSearchToolCall|OutputFunctionToolCall|FunctionToolCallOutput|OutputReasoning|OutputMcpListTools|OutputMcpApprovalRequest|OutputMcpCall|OutputImageGenerationToolCall|OutputCodeInterpreterToolCall => match ($item['type']) {
-                'message' => $item['role'] === 'assistant' ? OutputMessage::from($item) : InputMessage::from($item),
-                'file_search_call' => OutputFileSearchToolCall::from($item),
-                'function_call' => OutputFunctionToolCall::from($item),
-                'function_call_output' => FunctionToolCallOutput::from($item),
-                'web_search_call' => OutputWebSearchToolCall::from($item),
-                'computer_call' => OutputComputerToolCall::from($item),
-                'computer_call_output' => ComputerToolCallOutput::from($item),
-                'reasoning' => OutputReasoning::from($item),
-                'mcp_list_tools' => OutputMcpListTools::from($item),
-                'mcp_approval_request' => OutputMcpApprovalRequest::from($item),
-                'mcp_call' => OutputMcpCall::from($item),
-                'image_generation_call' => OutputImageGenerationToolCall::from($item),
-                'code_interpreter_call' => OutputCodeInterpreterToolCall::from($item),
-            },
-            $attributes['data'],
-        );
+        $data = ItemObjects::parse($attributes['data']);
 
         return new self(
             object: $attributes['object'],

--- a/src/Responses/Responses/ListInputItems.php
+++ b/src/Responses/Responses/ListInputItems.php
@@ -43,7 +43,7 @@ final class ListInputItems implements ResponseContract, ResponseHasMetaInformati
     use HasMetaInformation;
 
     /**
-     * @param  ResponseItemObjectReturnType  $data
+     * @param  array<int, InputMessage|OutputMessage|OutputFileSearchToolCall|OutputComputerToolCall|ComputerToolCallOutput|OutputWebSearchToolCall|OutputFunctionToolCall|FunctionToolCallOutput|OutputReasoning|OutputMcpListTools|OutputMcpApprovalRequest|OutputMcpCall|OutputImageGenerationToolCall|OutputCodeInterpreterToolCall>  $data
      * @param  'list'  $object
      */
     private function __construct(

--- a/src/Responses/Responses/ListInputItems.php
+++ b/src/Responses/Responses/ListInputItems.php
@@ -28,7 +28,6 @@ use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
  * @phpstan-import-type ResponseItemObjectTypes from ItemObjects
- * @phpstan-import-type ResponseItemObjectReturnType from ItemObjects
  *
  * @phpstan-type ListInputItemsType array{data: ResponseItemObjectTypes, first_id: string, has_more: bool, last_id: string, object: 'list'}
  *

--- a/src/Responses/Responses/RetrieveResponse.php
+++ b/src/Responses/Responses/RetrieveResponse.php
@@ -59,16 +59,14 @@ use OpenAI\Testing\Responses\Concerns\Fakeable;
  * @phpstan-import-type ErrorType from GenericResponseError
  * @phpstan-import-type IncompleteDetailsType from CreateResponseIncompleteDetails
  * @phpstan-import-type UsageType from CreateResponseUsage
- * @phpstan-import-type FunctionToolChoiceType from FunctionToolChoice
- * @phpstan-import-type HostedToolChoiceType from HostedToolChoice
  * @phpstan-import-type ReasoningType from CreateResponseReasoning
  * @phpstan-import-type ReferencePromptObjectType from ReferencePromptObject
+ * @phpstan-import-type ResponseToolChoiceTypes from ToolChoiceObjects
  *
  * @phpstan-type InstructionsType array<int, mixed>|string|null
- * @phpstan-type ToolChoiceType 'none'|'auto'|'required'|FunctionToolChoiceType|HostedToolChoiceType
  * @phpstan-type ToolsType array<int, ComputerUseToolType|FileSearchToolType|FunctionToolType|WebSearchToolType|ImageGenerationToolType|RemoteMcpToolType|CodeInterpreterToolType>
  * @phpstan-type OutputType array<int, OutputComputerToolCallType|OutputFileSearchToolCallType|OutputFunctionToolCallType|OutputMessageType|OutputReasoningType|OutputWebSearchToolCallType|OutputMcpListToolsType|OutputMcpApprovalRequestType|OutputMcpCallType|OutputImageGenerationToolCallType|OutputCodeInterpreterToolCallType>
- * @phpstan-type RetrieveResponseType array{id: string, background?: bool|null, object: 'response', created_at: int, status: 'completed'|'failed'|'in_progress'|'incomplete', error: ErrorType|null, incomplete_details: IncompleteDetailsType|null, instructions: InstructionsType, max_output_tokens: int|null, max_tool_calls?: int|null, model: string, output: OutputType, output_text: string|null, parallel_tool_calls: bool, previous_response_id: string|null, prompt: ReferencePromptObjectType|null, prompt_cache_key?: string|null, reasoning: ReasoningType|null, safety_identifier?: string|null, service_tier?: string|null, store: bool, temperature: float|null, text: ResponseFormatType, tool_choice: ToolChoiceType, tools: ToolsType, top_logprobs?: int|null, top_p: float|null, truncation: 'auto'|'disabled'|null, usage: UsageType|null, user: string|null, verbosity: string|null, metadata: array<string, string>|null}
+ * @phpstan-type RetrieveResponseType array{id: string, background?: bool|null, object: 'response', created_at: int, status: 'completed'|'failed'|'in_progress'|'incomplete', error: ErrorType|null, incomplete_details: IncompleteDetailsType|null, instructions: InstructionsType, max_output_tokens: int|null, max_tool_calls?: int|null, model: string, output: OutputType, output_text: string|null, parallel_tool_calls: bool, previous_response_id: string|null, prompt: ReferencePromptObjectType|null, prompt_cache_key?: string|null, reasoning: ReasoningType|null, safety_identifier?: string|null, service_tier?: string|null, store: bool, temperature: float|null, text: ResponseFormatType, tool_choice: ResponseToolChoiceTypes, tools: ToolsType, top_logprobs?: int|null, top_p: float|null, truncation: 'auto'|'disabled'|null, usage: UsageType|null, user: string|null, verbosity: string|null, metadata: array<string, string>|null}
  *
  * @implements ResponseContract<RetrieveResponseType>
  */

--- a/src/Responses/Responses/RetrieveResponse.php
+++ b/src/Responses/Responses/RetrieveResponse.php
@@ -37,29 +37,17 @@ use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
  * @phpstan-import-type ResponseFormatType from CreateResponseFormat
- * @phpstan-import-type OutputComputerToolCallType from OutputComputerToolCall
- * @phpstan-import-type OutputFileSearchToolCallType from OutputFileSearchToolCall
- * @phpstan-import-type OutputFunctionToolCallType from OutputFunctionToolCall
- * @phpstan-import-type OutputMessageType from OutputMessage
- * @phpstan-import-type OutputReasoningType from OutputReasoning
- * @phpstan-import-type OutputWebSearchToolCallType from OutputWebSearchToolCall
- * @phpstan-import-type OutputImageGenerationToolCallType from OutputImageGenerationToolCall
- * @phpstan-import-type OutputMcpListToolsType from OutputMcpListTools
- * @phpstan-import-type OutputMcpApprovalRequestType from OutputMcpApprovalRequest
- * @phpstan-import-type OutputMcpCallType from OutputMcpCall
- * @phpstan-import-type OutputImageGenerationToolCallType from OutputImageGenerationToolCall
- * @phpstan-import-type OutputCodeInterpreterToolCallType from OutputCodeInterpreterToolCall
  * @phpstan-import-type ErrorType from GenericResponseError
  * @phpstan-import-type IncompleteDetailsType from CreateResponseIncompleteDetails
  * @phpstan-import-type UsageType from CreateResponseUsage
  * @phpstan-import-type ReasoningType from CreateResponseReasoning
  * @phpstan-import-type ReferencePromptObjectType from ReferencePromptObject
+ * @phpstan-import-type ResponseOutputObjectTypes from OutputObjects
  * @phpstan-import-type ResponseToolChoiceTypes from ToolChoiceObjects
  * @phpstan-import-type ResponseToolObjectTypes from ToolObjects
  *
  * @phpstan-type InstructionsType array<int, mixed>|string|null
- * @phpstan-type OutputType array<int, OutputComputerToolCallType|OutputFileSearchToolCallType|OutputFunctionToolCallType|OutputMessageType|OutputReasoningType|OutputWebSearchToolCallType|OutputMcpListToolsType|OutputMcpApprovalRequestType|OutputMcpCallType|OutputImageGenerationToolCallType|OutputCodeInterpreterToolCallType>
- * @phpstan-type RetrieveResponseType array{id: string, background?: bool|null, object: 'response', created_at: int, status: 'completed'|'failed'|'in_progress'|'incomplete', error: ErrorType|null, incomplete_details: IncompleteDetailsType|null, instructions: InstructionsType, max_output_tokens: int|null, max_tool_calls?: int|null, model: string, output: OutputType, output_text: string|null, parallel_tool_calls: bool, previous_response_id: string|null, prompt: ReferencePromptObjectType|null, prompt_cache_key?: string|null, reasoning: ReasoningType|null, safety_identifier?: string|null, service_tier?: string|null, store: bool, temperature: float|null, text: ResponseFormatType, tool_choice: ResponseToolChoiceTypes, tools: ResponseToolObjectTypes, top_logprobs?: int|null, top_p: float|null, truncation: 'auto'|'disabled'|null, usage: UsageType|null, user: string|null, verbosity: string|null, metadata: array<string, string>|null}
+ * @phpstan-type RetrieveResponseType array{id: string, background?: bool|null, object: 'response', created_at: int, status: 'completed'|'failed'|'in_progress'|'incomplete', error: ErrorType|null, incomplete_details: IncompleteDetailsType|null, instructions: InstructionsType, max_output_tokens: int|null, max_tool_calls?: int|null, model: string, output: ResponseOutputObjectTypes, output_text: string|null, parallel_tool_calls: bool, previous_response_id: string|null, prompt: ReferencePromptObjectType|null, prompt_cache_key?: string|null, reasoning: ReasoningType|null, safety_identifier?: string|null, service_tier?: string|null, store: bool, temperature: float|null, text: ResponseFormatType, tool_choice: ResponseToolChoiceTypes, tools: ResponseToolObjectTypes, top_logprobs?: int|null, top_p: float|null, truncation: 'auto'|'disabled'|null, usage: UsageType|null, user: string|null, verbosity: string|null, metadata: array<string, string>|null}
  *
  * @implements ResponseContract<RetrieveResponseType>
  */

--- a/src/Responses/Responses/RetrieveResponse.php
+++ b/src/Responses/Responses/RetrieveResponse.php
@@ -49,24 +49,17 @@ use OpenAI\Testing\Responses\Concerns\Fakeable;
  * @phpstan-import-type OutputMcpCallType from OutputMcpCall
  * @phpstan-import-type OutputImageGenerationToolCallType from OutputImageGenerationToolCall
  * @phpstan-import-type OutputCodeInterpreterToolCallType from OutputCodeInterpreterToolCall
- * @phpstan-import-type ComputerUseToolType from ComputerUseTool
- * @phpstan-import-type FileSearchToolType from FileSearchTool
- * @phpstan-import-type ImageGenerationToolType from ImageGenerationTool
- * @phpstan-import-type RemoteMcpToolType from RemoteMcpTool
- * @phpstan-import-type FunctionToolType from FunctionTool
- * @phpstan-import-type WebSearchToolType from WebSearchTool
- * @phpstan-import-type CodeInterpreterToolType from CodeInterpreterTool
  * @phpstan-import-type ErrorType from GenericResponseError
  * @phpstan-import-type IncompleteDetailsType from CreateResponseIncompleteDetails
  * @phpstan-import-type UsageType from CreateResponseUsage
  * @phpstan-import-type ReasoningType from CreateResponseReasoning
  * @phpstan-import-type ReferencePromptObjectType from ReferencePromptObject
  * @phpstan-import-type ResponseToolChoiceTypes from ToolChoiceObjects
+ * @phpstan-import-type ResponseToolObjectTypes from ToolObjects
  *
  * @phpstan-type InstructionsType array<int, mixed>|string|null
- * @phpstan-type ToolsType array<int, ComputerUseToolType|FileSearchToolType|FunctionToolType|WebSearchToolType|ImageGenerationToolType|RemoteMcpToolType|CodeInterpreterToolType>
  * @phpstan-type OutputType array<int, OutputComputerToolCallType|OutputFileSearchToolCallType|OutputFunctionToolCallType|OutputMessageType|OutputReasoningType|OutputWebSearchToolCallType|OutputMcpListToolsType|OutputMcpApprovalRequestType|OutputMcpCallType|OutputImageGenerationToolCallType|OutputCodeInterpreterToolCallType>
- * @phpstan-type RetrieveResponseType array{id: string, background?: bool|null, object: 'response', created_at: int, status: 'completed'|'failed'|'in_progress'|'incomplete', error: ErrorType|null, incomplete_details: IncompleteDetailsType|null, instructions: InstructionsType, max_output_tokens: int|null, max_tool_calls?: int|null, model: string, output: OutputType, output_text: string|null, parallel_tool_calls: bool, previous_response_id: string|null, prompt: ReferencePromptObjectType|null, prompt_cache_key?: string|null, reasoning: ReasoningType|null, safety_identifier?: string|null, service_tier?: string|null, store: bool, temperature: float|null, text: ResponseFormatType, tool_choice: ResponseToolChoiceTypes, tools: ToolsType, top_logprobs?: int|null, top_p: float|null, truncation: 'auto'|'disabled'|null, usage: UsageType|null, user: string|null, verbosity: string|null, metadata: array<string, string>|null}
+ * @phpstan-type RetrieveResponseType array{id: string, background?: bool|null, object: 'response', created_at: int, status: 'completed'|'failed'|'in_progress'|'incomplete', error: ErrorType|null, incomplete_details: IncompleteDetailsType|null, instructions: InstructionsType, max_output_tokens: int|null, max_tool_calls?: int|null, model: string, output: OutputType, output_text: string|null, parallel_tool_calls: bool, previous_response_id: string|null, prompt: ReferencePromptObjectType|null, prompt_cache_key?: string|null, reasoning: ReasoningType|null, safety_identifier?: string|null, service_tier?: string|null, store: bool, temperature: float|null, text: ResponseFormatType, tool_choice: ResponseToolChoiceTypes, tools: ResponseToolObjectTypes, top_logprobs?: int|null, top_p: float|null, truncation: 'auto'|'disabled'|null, usage: UsageType|null, user: string|null, verbosity: string|null, metadata: array<string, string>|null}
  *
  * @implements ResponseContract<RetrieveResponseType>
  */

--- a/tests/Arch.php
+++ b/tests/Arch.php
@@ -31,6 +31,7 @@ test('resources')->expect('OpenAI\Resources')->toOnlyUse([
 
 test('responses')->expect('OpenAI\Responses')->toOnlyUse([
     'Http\Discovery\Psr17Factory',
+    'OpenAI\Actions',
     'OpenAI\Enums',
     'OpenAI\Exceptions\ErrorException',
     'OpenAI\Exceptions\UnknownEventException',


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

During development of #658 I learned the Conversation API has both items (ListInputItems) and output (Response output) that the Response API offers - they are an exact duplication. This is an insane level of duplication of code with the strict typing in place. Earlier iterations of this library had simple endpoints (completion, chat, etc) - as AI has evolved so has the endpoints which means we need to get creative.

The Response API is massive and we are missing a chunk of typed support, this means following the pattern of other endpoints we have a typed response for the Create endpoint, the Retrieve endpoint, the List endpoint, etc. For the most part these endpoints duplicate logic for parsing nested structures like items, data, tools, tool choices, etc.

<img width="1317" height="711" alt="Screenshot From 2025-09-01 19-07-40" src="https://github.com/user-attachments/assets/8e10d686-ab74-47d8-ba37-d722ecd09e1d" />
(duplicated between create, retrieve and list)

---

This massive amount of duplication has led to bugs (#667) where a new typed thing may be added but not added to all endpoints which is a poor developer experience. You add support for a type and it should naturally work in create, retrieve, etc.

I've introduced `Actions/Responses` (sub-folder after Responses) to house a few parsers:

 * ItemObjects - The input/output messages that you get when you list a conversation/response. The individual chunks of both input & output.
 * OutputObjects - The output messages you get from a Response/Conversation.
 * OutputText - The SDK specific string that parses all text messages from any Output that contains a content message.
 * ToolChoiceObjects - The tool choice preference between auto, hosted, etc.
 * ToolObjects - The wide variety of growing tools output (file, web, function, computer, image, mcp, code, container, etc)
 
 For Response/Conversation classes this means the parsing of complex objects becomes as easy as this.
 
 ```php
        $output = OutputObjects::parse($attributes['output']);
        $toolChoice = ToolChoiceObjects::parse($attributes['tool_choice']);
        $tools = ToolObjects::parse($attributes['tools']);
```

So code that needs these objects can unify their parsing into one central area. This is a big because updating types and concrete implementations across 6 files is terrible and it shows with how often PRs fail CI.

So now when I return to #658 I can leverage those helpers without adding an insane amount of duplication.

I want the complex types to be managed in these Actions and classes that leverage those Actions (Create, Retrieve and List) can import the types from the Actions. That means they are managed in 1 place!