### PR TITLE
Add support for reasoning text streaming events

### DIFF
--- a/src/Responses/Responses/CreateStreamedResponse.php
+++ b/src/Responses/Responses/CreateStreamedResponse.php
@@ -29,6 +29,8 @@ use OpenAI\Responses\Responses\Streaming\OutputTextDone;
 use OpenAI\Responses\Responses\Streaming\ReasoningSummaryPart;
 use OpenAI\Responses\Responses\Streaming\ReasoningSummaryTextDelta;
 use OpenAI\Responses\Responses\Streaming\ReasoningSummaryTextDone;
+use OpenAI\Responses\Responses\Streaming\ReasoningTextDelta;
+use OpenAI\Responses\Responses\Streaming\ReasoningTextDone;
 use OpenAI\Responses\Responses\Streaming\RefusalDelta;
 use OpenAI\Responses\Responses\Streaming\RefusalDone;
 use OpenAI\Responses\Responses\Streaming\WebSearchCall;
@@ -50,7 +52,7 @@ final class CreateStreamedResponse implements ResponseContract
 
     private function __construct(
         public readonly string $event,
-        public readonly CreateResponse|OutputItem|ContentPart|OutputTextDelta|OutputTextAnnotationAdded|OutputTextDone|RefusalDelta|RefusalDone|FunctionCallArgumentsDelta|FunctionCallArgumentsDone|FileSearchCall|WebSearchCall|CodeInterpreterCall|CodeInterpreterCodeDelta|CodeInterpreterCodeDone|ReasoningSummaryPart|ReasoningSummaryTextDelta|ReasoningSummaryTextDone|McpListTools|McpListToolsInProgress|McpCall|McpCallArgumentsDelta|McpCallArgumentsDone|ImageGenerationPart|ImageGenerationPartialImage|Error $response,
+        public readonly CreateResponse|OutputItem|ContentPart|OutputTextDelta|OutputTextAnnotationAdded|OutputTextDone|RefusalDelta|RefusalDone|FunctionCallArgumentsDelta|FunctionCallArgumentsDone|FileSearchCall|WebSearchCall|CodeInterpreterCall|CodeInterpreterCodeDelta|CodeInterpreterCodeDone|ReasoningSummaryPart|ReasoningSummaryTextDelta|ReasoningSummaryTextDone|ReasoningTextDelta|ReasoningTextDone|McpListTools|McpListToolsInProgress|McpCall|McpCallArgumentsDelta|McpCallArgumentsDone|ImageGenerationPart|ImageGenerationPartialImage|Error $response,
     ) {}
 
     /**
@@ -95,6 +97,8 @@ final class CreateStreamedResponse implements ResponseContract
             'response.reasoning_summary_part.done' => ReasoningSummaryPart::from($attributes, $meta), // @phpstan-ignore-line
             'response.reasoning_summary_text.delta' => ReasoningSummaryTextDelta::from($attributes, $meta), // @phpstan-ignore-line
             'response.reasoning_summary_text.done' => ReasoningSummaryTextDone::from($attributes, $meta), // @phpstan-ignore-line
+            'response.reasoning_text.delta' => ReasoningTextDelta::from($attributes, $meta), // @phpstan-ignore-line
+            'response.reasoning_text.done' => ReasoningTextDone::from($attributes, $meta), // @phpstan-ignore-line
             'response.mcp_list_tools.in_progress' => McpListToolsInProgress::from($attributes, $meta), // @phpstan-ignore-line
             'response.mcp_list_tools.failed',
             'response.mcp_list_tools.completed' => McpListTools::from($attributes, $meta), // @phpstan-ignore-line

--- a/src/Responses/Responses/Streaming/ReasoningTextDelta.php
+++ b/src/Responses/Responses/Streaming/ReasoningTextDelta.php
@@ -12,7 +12,7 @@ use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
- * @phpstan-type ReasoningTextDeltaType array{content_index: int, delta: string, item_id: string, output_index: int, sequence_number: int, type: string}
+ * @phpstan-type ReasoningTextDeltaType array{content_index: int, delta: string, item_id: string, output_index: int, sequence_number: int}
  *
  * @implements ResponseContract<ReasoningTextDeltaType>
  */
@@ -32,7 +32,6 @@ final class ReasoningTextDelta implements ResponseContract, ResponseHasMetaInfor
         public readonly string $itemId,
         public readonly int $outputIndex,
         public readonly int $sequenceNumber,
-        public readonly string $type,
         private readonly MetaInformation $meta,
     ) {}
 
@@ -47,7 +46,6 @@ final class ReasoningTextDelta implements ResponseContract, ResponseHasMetaInfor
             itemId: $attributes['item_id'],
             outputIndex: $attributes['output_index'],
             sequenceNumber: $attributes['sequence_number'],
-            type: $attributes['type'],
             meta: $meta,
         );
     }
@@ -63,7 +61,6 @@ final class ReasoningTextDelta implements ResponseContract, ResponseHasMetaInfor
             'item_id' => $this->itemId,
             'output_index' => $this->outputIndex,
             'sequence_number' => $this->sequenceNumber,
-            'type' => $this->type,
         ];
     }
 }

--- a/src/Responses/Responses/Streaming/ReasoningTextDelta.php
+++ b/src/Responses/Responses/Streaming/ReasoningTextDelta.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Responses\Responses\Streaming;
+
+use OpenAI\Contracts\ResponseContract;
+use OpenAI\Contracts\ResponseHasMetaInformationContract;
+use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Responses\Concerns\HasMetaInformation;
+use OpenAI\Responses\Meta\MetaInformation;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * @phpstan-type ReasoningTextDeltaType array{content_index: int, delta: string, item_id: string, output_index: int, sequence_number: int, type: string}
+ *
+ * @implements ResponseContract<ReasoningTextDeltaType>
+ */
+final class ReasoningTextDelta implements ResponseContract, ResponseHasMetaInformationContract
+{
+    /**
+     * @use ArrayAccessible<ReasoningTextDeltaType>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+    use HasMetaInformation;
+
+    private function __construct(
+        public readonly int $contentIndex,
+        public readonly string $delta,
+        public readonly string $itemId,
+        public readonly int $outputIndex,
+        public readonly int $sequenceNumber,
+        public readonly string $type,
+        private readonly MetaInformation $meta,
+    ) {}
+
+    /**
+     * @param  ReasoningTextDeltaType  $attributes
+     */
+    public static function from(array $attributes, MetaInformation $meta): self
+    {
+        return new self(
+            contentIndex: $attributes['content_index'],
+            delta: $attributes['delta'],
+            itemId: $attributes['item_id'],
+            outputIndex: $attributes['output_index'],
+            sequenceNumber: $attributes['sequence_number'],
+            type: $attributes['type'],
+            meta: $meta,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'content_index' => $this->contentIndex,
+            'delta' => $this->delta,
+            'item_id' => $this->itemId,
+            'output_index' => $this->outputIndex,
+            'sequence_number' => $this->sequenceNumber,
+            'type' => $this->type,
+        ];
+    }
+}

--- a/src/Responses/Responses/Streaming/ReasoningTextDone.php
+++ b/src/Responses/Responses/Streaming/ReasoningTextDone.php
@@ -12,7 +12,7 @@ use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
- * @phpstan-type ReasoningTextDoneType array{content_index: int, item_id: string, output_index: int, sequence_number: int, text: string, type: string}
+ * @phpstan-type ReasoningTextDoneType array{content_index: int, item_id: string, output_index: int, sequence_number: int, text: string}
  *
  * @implements ResponseContract<ReasoningTextDoneType>
  */
@@ -32,7 +32,6 @@ final class ReasoningTextDone implements ResponseContract, ResponseHasMetaInform
         public readonly int $outputIndex,
         public readonly int $sequenceNumber,
         public readonly string $text,
-        public readonly string $type,
         private readonly MetaInformation $meta,
     ) {}
 
@@ -47,7 +46,6 @@ final class ReasoningTextDone implements ResponseContract, ResponseHasMetaInform
             outputIndex: $attributes['output_index'],
             sequenceNumber: $attributes['sequence_number'],
             text: $attributes['text'],
-            type: $attributes['type'],
             meta: $meta,
         );
     }
@@ -63,7 +61,6 @@ final class ReasoningTextDone implements ResponseContract, ResponseHasMetaInform
             'output_index' => $this->outputIndex,
             'sequence_number' => $this->sequenceNumber,
             'text' => $this->text,
-            'type' => $this->type,
         ];
     }
 }

--- a/src/Responses/Responses/Streaming/ReasoningTextDone.php
+++ b/src/Responses/Responses/Streaming/ReasoningTextDone.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Responses\Responses\Streaming;
+
+use OpenAI\Contracts\ResponseContract;
+use OpenAI\Contracts\ResponseHasMetaInformationContract;
+use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Responses\Concerns\HasMetaInformation;
+use OpenAI\Responses\Meta\MetaInformation;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * @phpstan-type ReasoningTextDoneType array{content_index: int, item_id: string, output_index: int, sequence_number: int, text: string, type: string}
+ *
+ * @implements ResponseContract<ReasoningTextDoneType>
+ */
+final class ReasoningTextDone implements ResponseContract, ResponseHasMetaInformationContract
+{
+    /**
+     * @use ArrayAccessible<ReasoningTextDoneType>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+    use HasMetaInformation;
+
+    private function __construct(
+        public readonly int $contentIndex,
+        public readonly string $itemId,
+        public readonly int $outputIndex,
+        public readonly int $sequenceNumber,
+        public readonly string $text,
+        public readonly string $type,
+        private readonly MetaInformation $meta,
+    ) {}
+
+    /**
+     * @param  ReasoningTextDoneType  $attributes
+     */
+    public static function from(array $attributes, MetaInformation $meta): self
+    {
+        return new self(
+            contentIndex: $attributes['content_index'],
+            itemId: $attributes['item_id'],
+            outputIndex: $attributes['output_index'],
+            sequenceNumber: $attributes['sequence_number'],
+            text: $attributes['text'],
+            type: $attributes['type'],
+            meta: $meta,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'content_index' => $this->contentIndex,
+            'item_id' => $this->itemId,
+            'output_index' => $this->outputIndex,
+            'sequence_number' => $this->sequenceNumber,
+            'text' => $this->text,
+            'type' => $this->type,
+        ];
+    }
+}

--- a/tests/Fixtures/Responses.php
+++ b/tests/Fixtures/Responses.php
@@ -760,3 +760,13 @@ function responseCompletionSteamCreatedEvent()
 {
     return fopen(__DIR__.'/Streams/ResponseCreatedResponse.txt', 'r');
 }
+
+function responseReasoningTextDeltaEvent()
+{
+    return fopen(__DIR__.'/Streams/ResponseReasoningTextDelta.txt', 'r');
+}
+
+function responseReasoningTextDoneEvent()
+{
+    return fopen(__DIR__.'/Streams/ResponseReasoningTextDone.txt', 'r');
+}

--- a/tests/Fixtures/Streams/ResponseReasoningTextDelta.txt
+++ b/tests/Fixtures/Streams/ResponseReasoningTextDelta.txt
@@ -1,0 +1,1 @@
+data: {"type":"response.reasoning_text.delta","content_index":0,"delta":"Let me analyze","item_id":"item_123","output_index":0,"sequence_number":5}

--- a/tests/Fixtures/Streams/ResponseReasoningTextDone.txt
+++ b/tests/Fixtures/Streams/ResponseReasoningTextDone.txt
@@ -1,0 +1,1 @@
+data: {"type":"response.reasoning_text.done","content_index":0,"item_id":"item_123","output_index":0,"sequence_number":10,"text":"Let me analyze this problem step by step to provide the best solution."}

--- a/tests/Responses/Responses/CreateStreamedResponse.php
+++ b/tests/Responses/Responses/CreateStreamedResponse.php
@@ -2,6 +2,8 @@
 
 use OpenAI\Responses\Responses\CreateResponse;
 use OpenAI\Responses\Responses\CreateStreamedResponse;
+use OpenAI\Responses\Responses\Streaming\ReasoningTextDelta;
+use OpenAI\Responses\Responses\Streaming\ReasoningTextDone;
 
 test('fake', function () {
     $response = CreateStreamedResponse::fake();
@@ -19,4 +21,34 @@ test('from', function () {
         ->event->toBe('response.created')
         ->response->toBeInstanceOf(CreateResponse::class)
         ->response->id->toBe('resp_67ccf18ef5fc8190b16dbee19bc54e5f087bb177ab789d5c');
+});
+
+test('reasoning text delta event', function () {
+    $response = CreateStreamedResponse::fake(responseReasoningTextDeltaEvent());
+
+    expect($response->getIterator()->current())
+        ->toBeInstanceOf(CreateStreamedResponse::class)
+        ->event->toBe('response.reasoning_text.delta')
+        ->response->toBeInstanceOf(ReasoningTextDelta::class)
+        ->response->delta->toBe('Let me analyze')
+        ->response->itemId->toBe('item_123')
+        ->response->outputIndex->toBe(0)
+        ->response->contentIndex->toBe(0)
+        ->response->sequenceNumber->toBe(5)
+        ->response->type->toBe('response.reasoning_text.delta');
+});
+
+test('reasoning text done event', function () {
+    $response = CreateStreamedResponse::fake(responseReasoningTextDoneEvent());
+
+    expect($response->getIterator()->current())
+        ->toBeInstanceOf(CreateStreamedResponse::class)
+        ->event->toBe('response.reasoning_text.done')
+        ->response->toBeInstanceOf(ReasoningTextDone::class)
+        ->response->text->toBe('Let me analyze this problem step by step to provide the best solution.')
+        ->response->itemId->toBe('item_123')
+        ->response->outputIndex->toBe(0)
+        ->response->contentIndex->toBe(0)
+        ->response->sequenceNumber->toBe(10)
+        ->response->type->toBe('response.reasoning_text.done');
 });

--- a/tests/Responses/Responses/CreateStreamedResponse.php
+++ b/tests/Responses/Responses/CreateStreamedResponse.php
@@ -34,8 +34,7 @@ test('reasoning text delta event', function () {
         ->response->itemId->toBe('item_123')
         ->response->outputIndex->toBe(0)
         ->response->contentIndex->toBe(0)
-        ->response->sequenceNumber->toBe(5)
-        ->response->type->toBe('response.reasoning_text.delta');
+        ->response->sequenceNumber->toBe(5);
 });
 
 test('reasoning text done event', function () {
@@ -49,6 +48,5 @@ test('reasoning text done event', function () {
         ->response->itemId->toBe('item_123')
         ->response->outputIndex->toBe(0)
         ->response->contentIndex->toBe(0)
-        ->response->sequenceNumber->toBe(10)
-        ->response->type->toBe('response.reasoning_text.done');
+        ->response->sequenceNumber->toBe(10);
 });


### PR DESCRIPTION
  ### What:

  - [ ] Bug Fix
  - [x] New Feature

  ### Description:

  Adds support for the new reasoning text streaming events introduced in OpenAI's Response API when using models with reasoning capabilities (like gpt-oss):

  - `response.reasoning_text.delta` - Emitted when a delta is added to reasoning text content
  - `response.reasoning_text.done` - Emitted when reasoning text is completed

  These events are documented in the [OpenAI API Reference](https://platform.openai.com/docs/api-reference/responses_streaming/response/reasoning_text) and are used when models perform step-by-step reasoning before
  generating their response.

  **Changes made:**
  - Created `ReasoningTextDelta` class to handle reasoning text delta events
  - Created `ReasoningTextDone` class to handle completed reasoning text events
  - Updated `CreateStreamedResponse` to recognize and properly parse these new event types
  - Added test coverage with fixtures and test cases for both event types

  ### Related:

  N/A - Feature addition based on OpenAI API updates
