### PR TITLE
chore(OpenAI): deprecate Assistants API officially

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you or your business relies on this package, it's important to support the de
   - [Models Resource](#models-resource)
   - [Responses Resource](#responses-resource)
   - [Containers Resource](#containers-resource)
-  - [Containers Files Resource](#container-files-resource)
+  - [Containers Files Resource](#containers-files-resource)
   - [Chat Resource](#chat-resource)
   - [Audio Resource](#audio-resource)
   - [Embeddings Resource](#embeddings-resource)
@@ -1723,7 +1723,7 @@ foreach($stream as $response){
 ### `Assistants` Resource (deprecated)
 
 > [!WARNING]
-> OpenAI has deprecated the Assistants API and will stop working by first half of 2026. https://platform.openai.com/docs/guides/responses-vs-chat-completions#assistants
+> OpenAI has deprecated the Assistants API and will stop working by August 26, 2026. https://platform.openai.com/docs/guides/migrate-to-responses#assistants-api
 
 <details>
 <summary>Assistants API Information</summary>
@@ -1857,7 +1857,7 @@ $response->toArray(); // ['object' => 'list', ...]]
 ### `Threads` Resource (deprecated)
 
 > [!WARNING]
-> OpenAI has deprecated the Assistants API and will stop working by first half of 2026. https://platform.openai.com/docs/guides/responses-vs-chat-completions#assistants
+> OpenAI has deprecated the Assistants API and will stop working by August 26, 2026. https://platform.openai.com/docs/guides/migrate-to-responses#assistants-api
 
 <details>
 <summary>Threads API Information</summary>
@@ -1984,7 +1984,7 @@ $response->toArray(); // ['id' => 'thread_tKFLqzRN9n7MnyKKvc1Q7868', ...]
 ### `Thread Messages` Resource (deprecated)
 
 > [!WARNING]
-> OpenAI has deprecated the Assistants API and will stop working by first half of 2026. https://platform.openai.com/docs/guides/responses-vs-chat-completions#assistants
+> OpenAI has deprecated the Assistants API and will stop working by August 26, 2026. https://platform.openai.com/docs/guides/migrate-to-responses#assistants-api
 
 <details>
 <summary>Thread Messages API Information</summary>
@@ -2128,7 +2128,7 @@ $response->toArray(); // ['object' => 'list', ...]]
 ### `Thread Runs` Resource (deprecated)
 
 > [!WARNING]
-> OpenAI has deprecated the Assistants API and will stop working by first half of 2026. https://platform.openai.com/docs/guides/responses-vs-chat-completions#assistants
+> OpenAI has deprecated the Assistants API and will stop working by August 26, 2026. https://platform.openai.com/docs/guides/migrate-to-responses#assistants-api
 
 <details>
 <summary>Thread Runs API Information</summary>
@@ -2451,7 +2451,7 @@ $response->toArray(); // ['object' => 'list', ...]]
 ### `Thread Run Steps` Resource (deprecated)
 
 > [!WARNING]
-> OpenAI has deprecated the Assistants API and will stop working by first half of 2026. https://platform.openai.com/docs/guides/responses-vs-chat-completions#assistants
+> OpenAI has deprecated the Assistants API and will stop working by August 26, 2026. https://platform.openai.com/docs/guides/migrate-to-responses#assistants-api
 
 <details>
 <summary>Thread Run Steps API Information</summary>

--- a/src/Contracts/ClientContract.php
+++ b/src/Contracts/ClientContract.php
@@ -122,6 +122,8 @@ interface ClientContract
      * Build assistants that can call models and use tools to perform tasks.
      *
      * @see https://platform.openai.com/docs/api-reference/assistants
+     * @deprecated OpenAI has deprecated this endpoint and will stop working by August 26, 2026.
+     * https://platform.openai.com/docs/guides/migrate-to-responses#assistants-api
      */
     public function assistants(): AssistantsContract;
 
@@ -129,6 +131,8 @@ interface ClientContract
      * Create threads that assistants can interact with.
      *
      * @see https://platform.openai.com/docs/api-reference/threads
+     * @deprecated OpenAI has deprecated this endpoint and will stop working by August 26, 2026.
+     * https://platform.openai.com/docs/guides/migrate-to-responses#assistants-api
      */
     public function threads(): ThreadsContract;
 


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

> We now have Assistant-like and Thread-like objects in the Responses API. Learn more in the [migration guide](https://platform.openai.com/docs/guides/assistants/migration). As of August 26th, 2025, we're deprecating the Assistants API, with a sunset date of August 26, 2026.

With OpenAI deprecating Assistants API - its time for us to do so as well.

### Related:

fixes: #672 
