### PR TITLE
fix(Doubao): increase nullability on image usage types

### DIFF
--- a/src/Responses/Images/CreateResponse.php
+++ b/src/Responses/Images/CreateResponse.php
@@ -12,12 +12,12 @@ use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
- * @implements ResponseContract<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}>
+ * @implements ResponseContract<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>, usage?: array{total_tokens: int, input_tokens: int|null, output_tokens: int|null, input_tokens_details: array{text_tokens: int, image_tokens: int}|null}}>
  */
 final class CreateResponse implements ResponseContract, ResponseHasMetaInformationContract
 {
     /**
-     * @use ArrayAccessible<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}>
+     * @use ArrayAccessible<array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>, usage?: array{total_tokens: int, input_tokens: int|null, output_tokens: int|null, input_tokens_details: array{text_tokens: int, image_tokens: int}|null}}>
      */
     use ArrayAccessible;
 
@@ -37,7 +37,7 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}  $attributes
+     * @param  array{created: int, data: array<int, array{url?: string, b64_json?: string, revised_prompt?: string}>, usage?: array{total_tokens: int, input_tokens?: int, output_tokens?: int, input_tokens_details?: array{text_tokens: int, image_tokens: int}}}  $attributes
      */
     public static function from(array $attributes, MetaInformation $meta): self
     {

--- a/src/Responses/Images/EditResponse.php
+++ b/src/Responses/Images/EditResponse.php
@@ -12,12 +12,12 @@ use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
- * @implements ResponseContract<array{created: int, data: array<int, array{url?: string, b64_json?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}>
+ * @implements ResponseContract<array{created: int, data: array<int, array{url?: string, b64_json?: string}>, usage?: array{total_tokens: int, input_tokens: int|null, output_tokens: int|null, input_tokens_details: array{text_tokens: int, image_tokens: int}|null}}>
  */
 final class EditResponse implements ResponseContract, ResponseHasMetaInformationContract
 {
     /**
-     * @use ArrayAccessible<array{created: int, data: array<int, array{url?: string, b64_json?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}>
+     * @use ArrayAccessible<array{created: int, data: array<int, array{url?: string, b64_json?: string}>, usage?: array{total_tokens: int, input_tokens: int|null, output_tokens: int|null, input_tokens_details: array{text_tokens: int, image_tokens: int}|null}}>
      */
     use ArrayAccessible;
 
@@ -37,7 +37,7 @@ final class EditResponse implements ResponseContract, ResponseHasMetaInformation
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{created: int, data: array<int, array{url?: string, b64_json?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}  $attributes
+     * @param  array{created: int, data: array<int, array{url?: string, b64_json?: string}>, usage?: array{total_tokens: int, input_tokens?: int, output_tokens?: int, input_tokens_details?: array{text_tokens: int, image_tokens: int}}}  $attributes
      */
     public static function from(array $attributes, MetaInformation $meta): self
     {

--- a/src/Responses/Images/ImageResponseUsage.php
+++ b/src/Responses/Images/ImageResponseUsage.php
@@ -8,26 +8,28 @@ final class ImageResponseUsage
 {
     private function __construct(
         public readonly int $totalTokens,
-        public readonly int $inputTokens,
-        public readonly int $outputTokens,
-        public readonly ImageResponseUsageInputTokensDetails $inputTokensDetails,
+        public readonly ?int $inputTokens,
+        public readonly ?int $outputTokens,
+        public readonly ?ImageResponseUsageInputTokensDetails $inputTokensDetails,
     ) {}
 
     /**
-     * @param  array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}  $attributes
+     * @param  array{total_tokens: int, input_tokens?: int, output_tokens?: int, input_tokens_details?: array{text_tokens: int, image_tokens: int}}  $attributes
      */
     public static function from(array $attributes): self
     {
         return new self(
-            $attributes['total_tokens'],
-            $attributes['input_tokens'],
-            $attributes['output_tokens'],
-            ImageResponseUsageInputTokensDetails::from($attributes['input_tokens_details']),
+            totalTokens: $attributes['total_tokens'],
+            inputTokens: $attributes['input_tokens'] ?? null,
+            outputTokens: $attributes['output_tokens'] ?? null,
+            inputTokensDetails: isset($attributes['input_tokens_details'])
+                ? ImageResponseUsageInputTokensDetails::from($attributes['input_tokens_details'])
+                : null,
         );
     }
 
     /**
-     * @return array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}
+     * @return array{total_tokens: int, input_tokens: int|null, output_tokens: int|null, input_tokens_details: array{text_tokens: int, image_tokens: int}|null}
      */
     public function toArray(): array
     {
@@ -35,7 +37,7 @@ final class ImageResponseUsage
             'total_tokens' => $this->totalTokens,
             'input_tokens' => $this->inputTokens,
             'output_tokens' => $this->outputTokens,
-            'input_tokens_details' => $this->inputTokensDetails->toArray(),
+            'input_tokens_details' => $this->inputTokensDetails?->toArray(),
         ];
     }
 }

--- a/src/Responses/Images/VariationResponse.php
+++ b/src/Responses/Images/VariationResponse.php
@@ -12,12 +12,12 @@ use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
- * @implements ResponseContract<array{created: int, data: array<int, array{url?: string, b64_json?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}>
+ * @implements ResponseContract<array{created: int, data: array<int, array{url?: string, b64_json?: string}>, usage?: array{total_tokens: int, input_tokens: int|null, output_tokens: int|null, input_tokens_details: array{text_tokens: int, image_tokens: int}|null}}>
  */
 final class VariationResponse implements ResponseContract, ResponseHasMetaInformationContract
 {
     /**
-     * @use ArrayAccessible<array{created: int, data: array<int, array{url?: string, b64_json?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}>
+     * @use ArrayAccessible<array{created: int, data: array<int, array{url?: string, b64_json?: string}>, usage?: array{total_tokens: int, input_tokens: int|null, output_tokens: int|null, input_tokens_details: array{text_tokens: int, image_tokens: int}|null}}>
      */
     use ArrayAccessible;
 
@@ -37,7 +37,7 @@ final class VariationResponse implements ResponseContract, ResponseHasMetaInform
     /**
      * Acts as static factory, and returns a new Response instance.
      *
-     * @param  array{created: int, data: array<int, array{url?: string, b64_json?: string}>, usage?: array{total_tokens: int, input_tokens: int, output_tokens: int, input_tokens_details: array{text_tokens: int, image_tokens: int}}}  $attributes
+     * @param  array{created: int, data: array<int, array{url?: string, b64_json?: string}>, usage?: array{total_tokens: int, input_tokens?: int, output_tokens?: int, input_tokens_details?: array{text_tokens: int, image_tokens: int}}}  $attributes
      */
     public static function from(array $attributes, MetaInformation $meta): self
     {

--- a/tests/Fixtures/Image.php
+++ b/tests/Fixtures/Image.php
@@ -73,6 +73,28 @@ function imageCreateWithUsage(): array
 /**
  * @return array<string, mixed>
  */
+function imageCreateWithDoubaoUsage(): array
+{
+    return [
+        'model' => 'doubao-seedream-4.0',
+        'created' => 1664136088,
+        'data' => [
+            [
+                'url' => 'https://openai.com/image.png',
+                'size' => '3104x1312',
+            ],
+        ],
+        'usage' => [
+            'generated_tokens' => 1,
+            'total_tokens' => 100,
+            'output_tokens' => 50,
+        ],
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
 function imageEditWithUrl(): array
 {
     return [
@@ -127,6 +149,25 @@ function imageEditWithUsage(): array
 /**
  * @return array<string, mixed>
  */
+function imageEditWithDoubaoUsage(): array
+{
+    return [
+        'created' => 1664136088,
+        'data' => [
+            [
+                'url' => 'https://openai.com/image.png',
+            ],
+        ],
+        'usage' => [
+            'total_tokens' => 100,
+            'output_tokens' => 50,
+        ],
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
 function imageVariationWithUrl(): array
 {
     return [
@@ -174,6 +215,25 @@ function imageVariationWithUsage(): array
                 'text_tokens' => 10,
                 'image_tokens' => 40,
             ],
+        ],
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function imageVariationWithDoubaoUsage(): array
+{
+    return [
+        'created' => 1664136088,
+        'data' => [
+            [
+                'url' => 'https://openai.com/image.png',
+            ],
+        ],
+        'usage' => [
+            'total_tokens' => 100,
+            'output_tokens' => 50,
         ],
     ];
 }

--- a/tests/Responses/Images/CreateResponse.php
+++ b/tests/Responses/Images/CreateResponse.php
@@ -76,6 +76,22 @@ test('from with usage', function () {
         ->usage->inputTokensDetails->imageTokens->toBe(40);
 });
 
+test('from with doubao subset usage', function () {
+    $response = CreateResponse::from(imageCreateWithDoubaoUsage(), meta());
+
+    expect($response)
+        ->toBeInstanceOf(CreateResponse::class)
+        ->created->toBe(1664136088)
+        ->data->toBeArray()->toHaveCount(1)
+        ->data->each->toBeInstanceOf(CreateResponseData::class)
+        ->meta()->toBeInstanceOf(MetaInformation::class)
+        ->usage->toBeInstanceOf(ImageResponseUsage::class)
+        ->usage->totalTokens->toBe(100)
+        ->usage->inputTokens->toBeNull()
+        ->usage->outputTokens->toBe(50)
+        ->usage->inputTokensDetails->toBeNull();
+});
+
 test('to array with usage', function () {
     $response = CreateResponse::from(imageCreateWithUsage(), meta());
 

--- a/tests/Responses/Images/EditResponse.php
+++ b/tests/Responses/Images/EditResponse.php
@@ -76,6 +76,21 @@ test('from with usage', function () {
         ->usage->inputTokensDetails->imageTokens->toBe(40);
 });
 
+test('from with doubao usage', function () {
+    $response = EditResponse::from(imageEditWithDoubaoUsage(), meta());
+
+    expect($response)
+        ->toBeInstanceOf(EditResponse::class)
+        ->created->toBe(1664136088)
+        ->data->toBeArray()->toHaveCount(1)
+        ->data->each->toBeInstanceOf(EditResponseData::class)
+        ->meta()->toBeInstanceOf(MetaInformation::class)
+        ->usage->toBeInstanceOf(ImageResponseUsage::class)
+        ->usage->totalTokens->toBe(100)
+        ->usage->outputTokens->toBe(50)
+        ->usage->inputTokensDetails->toBeNull();
+});
+
 test('to array with usage', function () {
     $response = EditResponse::from(imageEditWithUsage(), meta());
 

--- a/tests/Responses/Images/VariationResponse.php
+++ b/tests/Responses/Images/VariationResponse.php
@@ -76,6 +76,21 @@ test('from with usage', function () {
         ->usage->inputTokensDetails->imageTokens->toBe(40);
 });
 
+test('from with doubao usage', function () {
+    $response = VariationResponse::from(imageVariationWithDoubaoUsage(), meta());
+
+    expect($response)
+        ->toBeInstanceOf(VariationResponse::class)
+        ->created->toBe(1664136088)
+        ->data->toBeArray()->toHaveCount(1)
+        ->data->each->toBeInstanceOf(VariationResponseData::class)
+        ->meta()->toBeInstanceOf(MetaInformation::class)
+        ->usage->toBeInstanceOf(ImageResponseUsage::class)
+        ->usage->totalTokens->toBe(100)
+        ->usage->outputTokens->toBe(50)
+        ->usage->inputTokensDetails->toBeNull();
+});
+
 test('to array with usage', function () {
     $response = VariationResponse::from(imageVariationWithUsage(), meta());
 


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

An OpenAI complaint service has a near compatible implementation but is missing some usage fields. Since this doesn't change anything nullable on the property, just usage - I feel its fine to increase nullability at benefit of supporting another provider.

### Related:

fixes: #683 
