### PR TITLE
Fix undefined array key errors for xAI Responses API

### DIFF
--- a/src/Responses/Responses/CreateResponse.php
+++ b/src/Responses/Responses/CreateResponse.php
@@ -129,12 +129,14 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
             incompleteDetails: isset($attributes['incomplete_details'])
                 ? CreateResponseIncompleteDetails::from($attributes['incomplete_details'])
                 : null,
-            instructions: $attributes['instructions'],
+            instructions: $attributes['instructions'] ?? null,
             maxToolCalls: $attributes['max_tool_calls'] ?? null,
             maxOutputTokens: $attributes['max_output_tokens'],
             model: $attributes['model'],
             output: $output,
-            outputText: OutputText::parse($output),
+            outputText: isset($output)
+                ? OutputText::parse($output)
+                : null,
             parallelToolCalls: $attributes['parallel_tool_calls'],
             previousResponseId: $attributes['previous_response_id'],
             prompt: isset($attributes['prompt'])
@@ -155,7 +157,7 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
             tools: $tools,
             topLogProbs: $attributes['top_logprobs'] ?? null,
             topP: $attributes['top_p'],
-            truncation: $attributes['truncation'],
+            truncation: $attributes['truncation'] ?? null,
             usage: isset($attributes['usage'])
                 ? CreateResponseUsage::from($attributes['usage'])
                 : null,

--- a/src/Responses/Responses/CreateResponse.php
+++ b/src/Responses/Responses/CreateResponse.php
@@ -134,9 +134,7 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
             maxOutputTokens: $attributes['max_output_tokens'],
             model: $attributes['model'],
             output: $output,
-            outputText: isset($output)
-                ? OutputText::parse($output)
-                : null,
+            outputText: OutputText::parse($output),
             parallelToolCalls: $attributes['parallel_tool_calls'],
             previousResponseId: $attributes['previous_response_id'],
             prompt: isset($attributes['prompt'])


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

xAI Responses API does not return certain attributes. The `Responses/Responses/CreateResponse` class already allows these fields to be null.

- Added null fallbacks to `instructions, and `truncation` attributes to avoid errors when handling xAI Responses API response _(e.g. grok-4)_

See [xAI Docs](https://docs.x.ai/docs/api-reference#create-new-response)
