### PR TITLE
Fix #692 [Bug]: Passing invalid parameters to gemini throws Undefined…

### DIFF
--- a/src/Transporters/HttpTransporter.php
+++ b/src/Transporters/HttpTransporter.php
@@ -172,12 +172,15 @@ final class HttpTransporter implements TransporterContract
         }
 
         try {
-            /** @var (array{error?: string|array{message: string|array<int, string>, type: string, code: string}})|(array{0?: array{error?: string|array{message: string|array<int, string>, code: string}}}) $data */
+            /** @var (array{error?: string|array{message: string|array<int, string>, type: string, code: string}})|(array{0?: array{error?: string|array{message: string|array<int, string>, code: string, status: string, type?: string}}}) $data */
             $data = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
 
             if (isset($data['error'])) {
                 throw new ErrorException($data['error'], $response);
             } elseif (isset($data[0]['error'])) {
+                if (! isset($data[0]['error']['type']) && isset($data[0]['error']['status'])) {
+                    $data[0]['error']['type'] = $data[0]['error']['status'];
+                }
                 throw new ErrorException($data[0]['error'], $response);
             }
         } catch (JsonException $jsonException) {


### PR DESCRIPTION
… array key "choices" /www/htdocs/vendor/openai-php/client/src/Responses/Chat/CreateResponse.php 54

Change-Id: Ibbf64cc554ef68844fd8338583f3fc8ec5fde413

### What:

- [ ] Bug Fix

### Description:

### Related:

Fix issue #692
