### PR TITLE
feat: Support string|array output in FunctionToolCallOutput

### DIFF
--- a/src/Responses/Responses/Input/FunctionToolCallOutput.php
+++ b/src/Responses/Responses/Input/FunctionToolCallOutput.php
@@ -9,7 +9,7 @@ use OpenAI\Responses\Concerns\ArrayAccessible;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
- * @phpstan-type FunctionToolCallOutputType array{call_id: string, id: string, output: string, type: 'function_call_output', status: 'in_progress'|'completed'|'incompleted'}
+ * @phpstan-type FunctionToolCallOutputType array{call_id: string, id: string, output: string|array, type: 'function_call_output', status: 'in_progress'|'completed'|'incompleted'}
  *
  * @implements ResponseContract<FunctionToolCallOutputType>
  */
@@ -25,11 +25,12 @@ final class FunctionToolCallOutput implements ResponseContract
     /**
      * @param  'function_call_output'  $type
      * @param  'in_progress'|'completed'|'incompleted'  $status
+     * @param  string|array  $output  Output can be a string (for text/JSON) or array (for structured content like files/images)
      */
     private function __construct(
         public readonly string $callId,
         public readonly string $id,
-        public readonly string $output,
+        public readonly string|array $output,
         public readonly string $type,
         public readonly string $status,
     ) {}


### PR DESCRIPTION
  - Update FunctionToolCallOutput to accept string|array for output parameter
  - This enables returning structured file/image references from function calls
  - Aligns with OpenAI's recent API update for file outputs in tool results
  - No breaking changes: existing string outputs continue to work

<!--
- Fill in the form below correctly. This will help the OpenAI PHP team to understand the PR and also work on it.
-->

### What:

- [x] New Feature

### Description:

[twitter](https://x.com/OpenAIDevs/status/1971618905941856495)
Openai released support for image and file inputs inside tool call results.
This PR aligns with that
 