### PR TITLE
fix: Allow bytes to be nullable on ContainerFileResponse

### DIFF
--- a/src/Responses/Containers/Files/ContainerFileResponse.php
+++ b/src/Responses/Containers/Files/ContainerFileResponse.php
@@ -12,7 +12,7 @@ use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
- * @phpstan-type ContainerFileType array{id: string, object: 'container.file', created_at: int, bytes: int, container_id: string, path: string, source: 'user'|'assistant'}
+ * @phpstan-type ContainerFileType array{id: string, object: 'container.file', created_at: int, bytes: int|null, container_id: string, path: string, source: 'user'|'assistant'}
  *
  * @implements ResponseContract<ContainerFileType>
  */
@@ -34,7 +34,7 @@ final class ContainerFileResponse implements ResponseContract, ResponseHasMetaIn
         public readonly string $id,
         public readonly string $object,
         public readonly int $createdAt,
-        public readonly int $bytes,
+        public readonly ?int $bytes,
         public readonly string $containerId,
         public readonly string $path,
         public readonly string $source,

--- a/tests/Fixtures/ContainerFile.php
+++ b/tests/Fixtures/ContainerFile.php
@@ -19,6 +19,22 @@ function containerFileResource(): array
 /**
  * @return array<string, mixed>
  */
+function containerFileResourceAssistant(): array
+{
+    return [
+        'id' => 'cfile_68efad3233308191ae2aea6fdc172940',
+        'object' => 'container.file',
+        'created_at' => 1760537906,
+        'bytes' => null,
+        'container_id' => 'cntr_68efad24888881938f8d8a661b5036450ac07bb92e293373',
+        'path' => '/mnt/data/dummy_risk_priority_bar_chart.png',
+        'source' => 'assistant',
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
 function containerFileListResource(): array
 {
     return [

--- a/tests/Responses/Containers/Files/ContainerFileResponse.php
+++ b/tests/Responses/Containers/Files/ContainerFileResponse.php
@@ -15,6 +15,19 @@ test('from', function () {
         ->source->toBe('user');
 });
 
+test('from response with null bytes', function () {
+    $result = ContainerFileResponse::from(containerFileResourceAssistant(), meta());
+
+    expect($result)
+        ->id->toBe('cfile_68efad3233308191ae2aea6fdc172940')
+        ->object->toBe('container.file')
+        ->createdAt->toBe(1760537906)
+        ->bytes->toBeNull()
+        ->containerId->toBe('cntr_68efad24888881938f8d8a661b5036450ac07bb92e293373')
+        ->path->toBe('/mnt/data/dummy_risk_priority_bar_chart.png')
+        ->source->toBe('assistant');
+});
+
 test('as array accessible', function () {
     $result = ContainerFileResponse::from(containerFileResource(), meta());
 


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the OpenAI PHP team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

This PR fixes an issue where OpenAI sometimes responds with the bytes being `null` instead of a integer in the response when retrieving a container file. I've simply allowed the bytes property to be nullable and added an additional test.

Example request & response showcasing null response

```bash
curl https://api.openai.com/v1/containers/cntr_68efad24888881938f8d8a661b5036450ac07bb92e293373/files/cfile_68efad3233308191ae2aea6fdc172940 \
  -H "Authorization: Bearer $OPENAI_API_KEY"

{
  "id": "cfile_68efad3233308191ae2aea6fdc172940",
  "object": "container.file",
  "created_at": 1760537906,
  "bytes": null,
  "container_id": "cntr_68efad24888881938f8d8a661b5036450ac07bb92e293373",
  "path": "/mnt/data/dummy_risk_priority_bar_chart.png",
  "source": "assistant"
}%   
```