### PR TITLE
Add 'response.queued' event to CreateStreamedResponse

### DIFF
--- a/src/Responses/Responses/CreateStreamedResponse.php
+++ b/src/Responses/Responses/CreateStreamedResponse.php
@@ -67,6 +67,7 @@ final class CreateStreamedResponse implements ResponseContract
 
         $response = match ($event) {
             'response.created',
+            'response.queued',
             'response.in_progress',
             'response.completed',
             'response.failed',


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [x] New Feature

### Description:

Fixes `OpenAI\Exceptions\UnknownEventException: Unknown Responses streaming event: response.queued`, which is probably a newly added event

https://platform.openai.com/docs/api-reference/responses-streaming/response/queued
