### PR TITLE
add support for extra_content in chat response tool calls returned by Gemini models

### DIFF
--- a/src/Responses/Chat/CreateResponseToolCall.php
+++ b/src/Responses/Chat/CreateResponseToolCall.php
@@ -10,10 +10,11 @@ final class CreateResponseToolCall
         public readonly string $id,
         public readonly string $type,
         public readonly CreateResponseToolCallFunction $function,
+        public readonly array $extraContent
     ) {}
 
     /**
-     * @param  array{id: string, type: string, function: array{name: string, arguments: string}}  $attributes
+     * @param  array{id: string, type: string, function: array{name: string, arguments: string}, extra_content: array|null}  $attributes
      */
     public static function from(array $attributes): self
     {
@@ -21,11 +22,12 @@ final class CreateResponseToolCall
             $attributes['id'],
             $attributes['type'],
             CreateResponseToolCallFunction::from($attributes['function']),
+            $attributes['extra_content'] ?? []
         );
     }
 
     /**
-     * @return array{id: string, type: string, function: array{name: string, arguments: string}}
+     * @return array{id: string, type: string, function: array{name: string, arguments: string}, extra_content: array}
      */
     public function toArray(): array
     {
@@ -33,6 +35,7 @@ final class CreateResponseToolCall
             'id' => $this->id,
             'type' => $this->type,
             'function' => $this->function->toArray(),
+            'extra_content' => $this->extraContent,
         ];
     }
 }

--- a/src/Transporters/HttpTransporter.php
+++ b/src/Transporters/HttpTransporter.php
@@ -175,8 +175,8 @@ final class HttpTransporter implements TransporterContract
             /** @var array{error?: string|array{message: string|array<int, string>, type: string, code: string}} $data */
             $data = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
 
-            if (isset($data['error'])) {
-                throw new ErrorException($data['error'], $response);
+            if (isset($data['error']) || isset($data[0]['error'])) {
+                throw new ErrorException($data['error'] ?? $data[0]['error'], $response);
             }
         } catch (JsonException $jsonException) {
             throw new UnserializableResponse($jsonException, $response);


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [X] New Feature

### Description:

This PR introduces support for the ⁠extra_content field, which is returned by certain Gemini models (specifically those utilizing the reasoning signature) during tool calls.
When interacting with these models, the API provides ⁠extra_content alongside tool calls. To maintain the integrity of the conversation and satisfy the model's reasoning signature requirements, this content must be preserved and passed back to the API when submitting tool outputs.
Changes:
	• Updated the response handling to parse and expose ⁠extra_content from tool call responses. 	
         • Updated the payload builder to include ⁠extra_content when submitting tool outputs back to the model.
