### PR TITLE
Fix error parsing for text/plain OpenAI responses

### DIFF
--- a/src/Transporters/HttpTransporter.php
+++ b/src/Transporters/HttpTransporter.php
@@ -163,7 +163,13 @@ final class HttpTransporter implements TransporterContract
             return;
         }
 
-        if (! str_contains($response->getHeaderLine('Content-Type'), ContentType::JSON->value)) {
+        $contentType = $response->getHeaderLine('Content-Type');
+
+        // Allow JSON or plain text containing JSON (OpenAI often sends text/plain for errors)
+        if (
+            ! str_contains($contentType, ContentType::JSON->value) &&
+            ! str_contains($contentType, ContentType::TEXT_PLAIN->value)
+        ) {
             return;
         }
 


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

OpenAI sometimes returns error payloads with Content-Type: text/plain.
The current ErrorResponseHandler ignores these responses, preventing
exceptions from being parsed correctly.

This patch updates the Content-Type check to allow both JSON and text/plain
content types, enabling consistent error handling.

The fix is backward compatible and does not change behavior for valid JSON
responses.

For example, calling `embeddings()->create()` with an invalid request results in the following runtime error instead of a clean `ErrorException`:

```php
$client = OpenAI::client($yourApiKey);

$response = $client->embeddings()->create([
    'model' => 'text-embedding-3-small',
    'input' => 'The food was delicious and the waiter...',
]);
```
Produces:
```php
PHP Warning:  Undefined array key "data" in vendor/openai-php/client/src/Responses/Embeddings/CreateResponse.php on line 47
PHP Fatal error:  Uncaught TypeError: array_map(): Argument #2 ($array) must be of type array, null given
    in vendor/openai-php/client/src/Responses/Embeddings/CreateResponse.php:45
```

### Related:

N/A
