### PR TITLE
fix: PHP 8.4 compatibility - TypeError when API returns null for results array

### DIFF
--- a/src/Responses/Moderations/CreateResponse.php
+++ b/src/Responses/Moderations/CreateResponse.php
@@ -28,8 +28,8 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
      * @param  array<int, CreateResponseResult>  $results
      */
     private function __construct(
-        public readonly string $id,
-        public readonly string $model,
+        public readonly ?string $id,
+        public readonly ?string $model,
         public readonly array $results,
         private readonly MetaInformation $meta,
     ) {}
@@ -46,8 +46,8 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
         ), $attributes['results'] ?? []);
 
         return new self(
-            $attributes['id'],
-            $attributes['model'],
+            $attributes['id'] ?? null,
+            $attributes['model'] ?? null,
             $results,
             $meta,
         );


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the OpenAI PHP team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

<!-- describe what your PR is solving -->

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
