### PR TITLE
fix(OpenAI): add support for missing `url` on web search output

### DIFF
--- a/src/Responses/Responses/Output/WebSearch/OutputWebSearchActionSources.php
+++ b/src/Responses/Responses/Output/WebSearch/OutputWebSearchActionSources.php
@@ -9,7 +9,7 @@ use OpenAI\Responses\Concerns\ArrayAccessible;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
- * @phpstan-type WebSearchActionSourcesType array{type: 'url', url: string}
+ * @phpstan-type WebSearchActionSourcesType array{type: 'url', url: string|null}
  *
  * @implements ResponseContract<WebSearchActionSourcesType>
  */
@@ -27,7 +27,7 @@ final class OutputWebSearchActionSources implements ResponseContract
      */
     private function __construct(
         public readonly string $type,
-        public readonly string $url
+        public readonly ?string $url
     ) {}
 
     /**
@@ -37,7 +37,7 @@ final class OutputWebSearchActionSources implements ResponseContract
     {
         return new self(
             type: $attributes['type'],
-            url: $attributes['url'],
+            url: $attributes['url'] ?? null,
         );
     }
 

--- a/tests/Responses/Responses/Output/OutputWebSearchToolCall.php
+++ b/tests/Responses/Responses/Output/OutputWebSearchToolCall.php
@@ -100,3 +100,20 @@ test('from with action but without query & sources', function () {
         ->not->toHaveKey('query')
         ->not->toHaveKey('sources');
 });
+
+test('from with source without url', function () {
+    $payload = outputWebSearchToolCall();
+    $payload['action']['sources'] = [
+        ['type' => 'url'],
+    ];
+
+    $response = OutputWebSearchToolCall::from($payload);
+
+    expect($response)
+        ->toBeInstanceOf(OutputWebSearchToolCall::class)
+        ->action->sources->toHaveCount(1);
+
+    expect($response->action->sources[0])
+        ->type->toBe('url')
+        ->url->toBeNull();
+});


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Fixes Web Search Output when no `url` is returned in payload.

### Related:

fixes: #729 
