### PR TITLE
fix(OpenAI): don't bail out early on text/plain - only if JSON parsing errors occurred.

### DIFF
--- a/tests/Transporters/HttpTransporter.php
+++ b/tests/Transporters/HttpTransporter.php
@@ -115,7 +115,7 @@ test('request object server user errors', function (string $requestMethod) {
 test('request object mismatched project error', function (string $requestMethod) {
     $payload = Payload::list('models');
 
-    $response = new Response(401, ['Content-Type' => 'application/json; charset=utf-8'], json_encode([
+    $response = new Response(401, ['Content-Type' => 'text/plain; charset=utf-8'], json_encode([
         'error' => [
             'message' => 'OpenAI-Project header should match project for API key',
             'type' => 'invalid_request_error',


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

We have a problem that we get JSON back with `Content-Type: text/plain` which destroys our SDK. This is because for some multi-modal endpoints like transcription - we get back non-JSON intentionally. So we rely on Content-Type to skip JSON decoding and move along.

So errors or logic that is valid JSON with a wrong Content-Type cause bad things. I'd argue this is a bug with upstream providers, but we need to make a change.

Now during JSON parsing if we have an Exception (i.e not json) - we first check the Content-Type. If its not JSON - we bail out with no exception.

### Related:

fixes: #735
closes: #723