### PR TITLE
Feature: add support for reasoning content in streamed completions API

### DIFF
--- a/src/Responses/Chat/CreateStreamedResponseDelta.php
+++ b/src/Responses/Chat/CreateStreamedResponseDelta.php
@@ -12,6 +12,7 @@ final class CreateStreamedResponseDelta
     private function __construct(
         public readonly ?string $role,
         public readonly ?string $content,
+        public readonly ?string $reasoningContent,  
         public readonly array $toolCalls,
         public readonly ?CreateStreamedResponseFunctionCall $functionCall,
     ) {}
@@ -28,6 +29,7 @@ final class CreateStreamedResponseDelta
         return new self(
             $attributes['role'] ?? null,
             $attributes['content'] ?? null,
+            $attributes['reasoning_content'] ?? null,
             $toolCalls,
             isset($attributes['function_call']) ? CreateStreamedResponseFunctionCall::from($attributes['function_call']) : null,
         );

--- a/tests/Responses/Chat/CreateStreamedResponseDelta.php
+++ b/tests/Responses/Chat/CreateStreamedResponseDelta.php
@@ -18,6 +18,20 @@ test('from content chunk', function () {
     expect($result)
         ->role->toBeNull()
         ->content->toBe('Hello')
+        ->reasoningContent->toBeNull()
+        ->functionCall->toBeNull();
+});
+
+test('from reasoning content chunk', function () {
+    $delta = [
+        'reasoning_content' => 'Let me think about this...',
+    ];
+    $result = CreateStreamedResponseDelta::from($delta);
+
+    expect($result)
+        ->role->toBeNull()
+        ->content->toBeNull()
+        ->reasoningContent->toBe('Let me think about this...')
         ->functionCall->toBeNull();
 });
 


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:
Add support for the reasoning_content field in chat completions API responses for streamed responses. This field is added at the same level as content in both streaming and non-streaming requests. The field is marked as optional to handle cases where it's not present in the API response.


### Related:
Same as but for streaming https://github.com/openai-php/client/pull/737