### PR TITLE
Include response body in RateLimitException message

### DIFF
--- a/src/Exceptions/RateLimitException.php
+++ b/src/Exceptions/RateLimitException.php
@@ -11,6 +11,6 @@ final class RateLimitException extends Exception
 {
     public function __construct(public ResponseInterface $response)
     {
-        parent::__construct('Request rate limit has been exceeded: ' . $response->getBody());
+        parent::__construct('Request rate limit has been exceeded: '.$response->getBody());
     }
 }


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the OpenAI PHP team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Before (no clue about why RateLimitException is thrown)

```
RateLimitException   
  Request rate limit has been exceeded.
```

After (with details)

```
RateLimitException   
  Request rate limit has been exceeded: {
  "error": {
    "message": "You exceeded your current quota, please check your plan and billing details. For more information on this error, read the docs: https://platform.openai.com/docs/guides/error-codes/api-errors.",
    "type": "insufficient_quota",
    "param": null,
    "code": "insufficient_quota"
  }
}
```