### PR TITLE
fix: default tool call type to function for Mistral compatibility

### DIFF
--- a/src/Responses/Chat/CreateResponseToolCall.php
+++ b/src/Responses/Chat/CreateResponseToolCall.php
@@ -13,13 +13,13 @@ final class CreateResponseToolCall
     ) {}
 
     /**
-     * @param  array{id: string, type: string, function: array{name: string, arguments: string}}  $attributes
+     * @param  array{id: string, type?: string, function: array{name: string, arguments: string}}  $attributes
      */
     public static function from(array $attributes): self
     {
         return new self(
             $attributes['id'],
-            $attributes['type'],
+            $attributes['type'] ?? 'function',
             CreateResponseToolCallFunction::from($attributes['function']),
         );
     }


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

The Mistral API currently omits the `type` attribute in its tool call responses, which causes an `Undefined array key "type"` exception. This commit defaults the missing `type` to `'function'` (the standard supported type per OpenAI documentation) to prevent runtime errors and ensure broader compatibility with OpenAI-compatible APIs.

### Related:

Fixes #397
