### PR TITLE
feat: add support for Gemini extra_content in tool calls

### DIFF
--- a/src/Responses/Chat/CreateResponseToolCall.php
+++ b/src/Responses/Chat/CreateResponseToolCall.php
@@ -10,10 +10,11 @@ final class CreateResponseToolCall
         public readonly string $id,
         public readonly string $type,
         public readonly CreateResponseToolCallFunction $function,
+        public readonly ?CreateResponseToolCallExtraContent $extra_content,
     ) {}
 
     /**
-     * @param  array{id: string, type?: string, function: array{name: string, arguments: string}}  $attributes
+     * @param  array{id: string, type?: string, function: array{name: string, arguments: string}, extra_content?: array{google?: array{thought_signature: string}}}  $attributes
      */
     public static function from(array $attributes): self
     {
@@ -21,18 +22,22 @@ final class CreateResponseToolCall
             $attributes['id'],
             $attributes['type'] ?? 'function',
             CreateResponseToolCallFunction::from($attributes['function']),
+            isset($attributes['extra_content']) ? CreateResponseToolCallExtraContent::from($attributes['extra_content']) : null,
         );
     }
 
     /**
-     * @return array{id: string, type: string, function: array{name: string, arguments: string}}
+     * @return array{id: string, type: string, function: array{name: string, arguments: string}, extra_content?: array{google?: array{thought_signature: string}|null}}
      */
     public function toArray(): array
     {
-        return [
+        $extraContentArray = $this->extra_content?->toArray();
+
+        return array_filter([
             'id' => $this->id,
             'type' => $this->type,
             'function' => $this->function->toArray(),
-        ];
+            'extra_content' => empty($extraContentArray) ? null : $extraContentArray,
+        ], fn ($value) => $value !== null);
     }
 }

--- a/src/Responses/Chat/CreateResponseToolCallExtraContent.php
+++ b/src/Responses/Chat/CreateResponseToolCallExtraContent.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Responses\Chat;
+
+final class CreateResponseToolCallExtraContent
+{
+    private function __construct(
+        public readonly ?CreateResponseToolCallExtraContentGoogle $google,
+    ) {}
+
+    /**
+     * @param  array{google?: array{thought_signature: string}}  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            isset($attributes['google']) ? CreateResponseToolCallExtraContentGoogle::from($attributes['google']) : null
+        );
+    }
+
+    /**
+     * @return array{google?: array{thought_signature: string}|null}
+     */
+    public function toArray(): array
+    {
+        return array_filter([
+            'google' => $this->google?->toArray(),
+        ], fn ($value) => $value !== null);
+    }
+}

--- a/src/Responses/Chat/CreateResponseToolCallExtraContentGoogle.php
+++ b/src/Responses/Chat/CreateResponseToolCallExtraContentGoogle.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Responses\Chat;
+
+final class CreateResponseToolCallExtraContentGoogle
+{
+    private function __construct(
+        public readonly string $thought_signature,
+    ) {}
+
+    /**
+     * @param  array{thought_signature?: string}  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            $attributes['thought_signature'] ?? '',
+        );
+    }
+
+    /**
+     * @return array{thought_signature: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'thought_signature' => $this->thought_signature,
+        ];
+    }
+}


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

This PR adds support for the `extra_content` payload returned by Gemini API tool calls, which includes provider-specific data like `thought_signature`.

**Changes Introduced:**

* **Added new DTOs:** Created `CreateResponseToolCallExtraContent` and `CreateResponseToolCallExtraContentGoogle` to capture the Gemini payloads.
* **Updated existing DTO:** Added `?CreateResponseToolCallExtraContent $extra_content` to `CreateResponseToolCall`.
* **Cross-Provider Compatibility:** Modified `toArray()` methods across these DTOs to strip the `extra_content` and `google` keys when they are `null` or empty.

**Why filter `null` values?**

APIs with strict schema validation (like Mistral) throw "Extra inputs are not permitted" errors if they receive `"extra_content": null` in the message history. Conditionally stripping these keys ensures developers can seamlessly reuse these response objects across different API providers without writing custom payload-stripping logic.
