### PR TITLE
fix VectorStoreResponseFileCounts attribute order

### DIFF
--- a/src/Responses/VectorStores/VectorStoreResponseFileCounts.php
+++ b/src/Responses/VectorStores/VectorStoreResponseFileCounts.php
@@ -38,8 +38,8 @@ final class VectorStoreResponseFileCounts implements ResponseContract
         return new self(
             $attributes['in_progress'],
             $attributes['completed'],
-            $attributes['cancelled'],
             $attributes['failed'],
+            $attributes['cancelled'],
             $attributes['total'],
         );
     }


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the OpenAI PHP team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

`failed` and `cancelled` counts were swapped in the response.
