### PR TITLE
Ratelimit event

### DIFF
--- a/src/Responses/Responses/CreateStreamedResponse.php
+++ b/src/Responses/Responses/CreateStreamedResponse.php
@@ -26,6 +26,7 @@ use OpenAI\Responses\Responses\Streaming\OutputItem;
 use OpenAI\Responses\Responses\Streaming\OutputTextAnnotationAdded;
 use OpenAI\Responses\Responses\Streaming\OutputTextDelta;
 use OpenAI\Responses\Responses\Streaming\OutputTextDone;
+use OpenAI\Responses\Responses\Streaming\RateLimits;
 use OpenAI\Responses\Responses\Streaming\ReasoningSummaryPart;
 use OpenAI\Responses\Responses\Streaming\ReasoningSummaryTextDelta;
 use OpenAI\Responses\Responses\Streaming\ReasoningSummaryTextDone;
@@ -53,7 +54,7 @@ final class CreateStreamedResponse implements ResponseContract
 
     private function __construct(
         public readonly string $event,
-        public readonly Response|OutputItem|ContentPart|OutputTextDelta|OutputTextAnnotationAdded|OutputTextDone|RefusalDelta|RefusalDone|FunctionCallArgumentsDelta|FunctionCallArgumentsDone|FileSearchCall|WebSearchCall|CodeInterpreterCall|CodeInterpreterCodeDelta|CodeInterpreterCodeDone|ReasoningSummaryPart|ReasoningSummaryTextDelta|ReasoningSummaryTextDone|ReasoningTextDelta|ReasoningTextDone|McpListTools|McpListToolsInProgress|McpCall|McpCallArgumentsDelta|McpCallArgumentsDone|ImageGenerationPart|ImageGenerationPartialImage|Error $response,
+        public readonly Response|OutputItem|ContentPart|OutputTextDelta|OutputTextAnnotationAdded|OutputTextDone|RefusalDelta|RefusalDone|FunctionCallArgumentsDelta|FunctionCallArgumentsDone|FileSearchCall|WebSearchCall|CodeInterpreterCall|CodeInterpreterCodeDelta|CodeInterpreterCodeDone|ReasoningSummaryPart|ReasoningSummaryTextDelta|ReasoningSummaryTextDone|ReasoningTextDelta|ReasoningTextDone|McpListTools|McpListToolsInProgress|McpCall|McpCallArgumentsDelta|McpCallArgumentsDone|ImageGenerationPart|ImageGenerationPartialImage|RateLimits|Error $response,
     ) {}
 
     /**
@@ -115,6 +116,7 @@ final class CreateStreamedResponse implements ResponseContract
             'response.image_generation_call.generating',
             'response.image_generation_call.in_progress' => ImageGenerationPart::from($attributes, $meta), // @phpstan-ignore-line
             'response.image_generation_call.partial_image' => ImageGenerationPartialImage::from($attributes, $meta), // @phpstan-ignore-line
+            'response.rate_limits.updated' => RateLimits::from($attributes, $meta), // @phpstan-ignore-line
             'error' => Error::from($attributes, $meta), // @phpstan-ignore-line
             default => throw new UnknownEventException('Unknown Responses streaming event: '.$event),
         };

--- a/src/Responses/Responses/Streaming/RateLimits.php
+++ b/src/Responses/Responses/Streaming/RateLimits.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Responses\Responses\Streaming;
+
+use OpenAI\Contracts\ResponseContract;
+use OpenAI\Contracts\ResponseHasMetaInformationContract;
+use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Responses\Concerns\HasMetaInformation;
+use OpenAI\Responses\Meta\MetaInformation;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * @phpstan-type RateLimitsType array{type: string}
+ *
+ * @implements ResponseContract<RateLimitsType>
+ */
+final class RateLimits implements ResponseContract, ResponseHasMetaInformationContract
+{
+    /**
+     * @use ArrayAccessible<RateLimitsType>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+    use HasMetaInformation;
+
+    private function __construct(
+        private readonly MetaInformation $meta,
+    ) {}
+
+    /**
+     * @param  RateLimitsType  $attributes
+     */
+    public static function from(array $attributes, MetaInformation $meta): self
+    {
+        return new self(
+            meta: $meta,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'type' => 'response.rate_limits.updated',
+        ];
+    }
+}

--- a/tests/Fixtures/Responses.php
+++ b/tests/Fixtures/Responses.php
@@ -944,3 +944,8 @@ function responseReasoningTextDoneEvent()
 {
     return fopen(__DIR__.'/Streams/ResponseReasoningTextDone.txt', 'r');
 }
+
+function responseRateLimitsUpdatedEvent()
+{
+    return fopen(__DIR__.'/Streams/ResponseRateLimitsUpdated.txt', 'r');
+}

--- a/tests/Fixtures/Streams/ResponseRateLimitsUpdated.txt
+++ b/tests/Fixtures/Streams/ResponseRateLimitsUpdated.txt
@@ -1,0 +1,1 @@
+data: {"type":"response.rate_limits.updated"}

--- a/tests/Responses/Responses/CreateStreamedResponse.php
+++ b/tests/Responses/Responses/CreateStreamedResponse.php
@@ -2,6 +2,7 @@
 
 use OpenAI\Responses\Responses\CreateResponse;
 use OpenAI\Responses\Responses\CreateStreamedResponse;
+use OpenAI\Responses\Responses\Streaming\RateLimits;
 use OpenAI\Responses\Responses\Streaming\ReasoningTextDelta;
 use OpenAI\Responses\Responses\Streaming\ReasoningTextDone;
 use OpenAI\Responses\Responses\Streaming\Response;
@@ -54,4 +55,16 @@ test('reasoning text done event', function () {
         ->response->outputIndex->toBe(0)
         ->response->contentIndex->toBe(0)
         ->response->sequenceNumber->toBe(10);
+});
+
+test('rate limits updated event', function () {
+    $response = CreateStreamedResponse::fake(responseRateLimitsUpdatedEvent());
+
+    expect($response->getIterator()->current())
+        ->toBeInstanceOf(CreateStreamedResponse::class)
+        ->event->toBe('response.rate_limits.updated')
+        ->response->toBeInstanceOf(RateLimits::class)
+        ->response->toArray()->toBe([
+            'type' => 'response.rate_limits.updated',
+        ]);
 });


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Adds support for `responses.rate_limits.updated`

### Related:

fixes: #760 
