### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ If you or your business relies on this package, it's important to support the de
 - [Testing](#testing)
 - [Webhooks][#webhooks]
 - [Services](#services)
+  - [Astraflow](#astraflow)
   - [Azure](#azure)
 
 ## Get Started
@@ -3135,6 +3136,57 @@ try {
 ```
 
 ## Services
+
+### Astraflow
+
+[Astraflow](https://astraflow.ucloud.cn/) (by UCloud / 优刻得) is an OpenAI-compatible AI model aggregation platform that supports **200+ models** through two regional endpoints. Sign up for an API key at **https://astraflow.ucloud.cn/**.
+
+| Endpoint | Base URI | Environment variable |
+|----------|----------|---------------------|
+| Global   | `https://api-us-ca.umodelverse.ai/v1` | `ASTRAFLOW_API_KEY` |
+| China    | `https://api.modelverse.cn/v1`        | `ASTRAFLOW_CN_API_KEY` |
+
+#### Global endpoint
+
+```php
+$client = Astraflow::client(getenv('ASTRAFLOW_API_KEY'));
+
+$response = $client->chat()->create([
+    'model' => 'deepseek-r1', // any of 200+ supported models
+    'messages' => [
+        ['role' => 'user', 'content' => 'Hello!'],
+    ],
+]);
+
+echo $response->choices[0]->message->content;
+```
+
+#### China endpoint
+
+```php
+$client = Astraflow::clientCn(getenv('ASTRAFLOW_CN_API_KEY'));
+
+$response = $client->chat()->create([
+    'model' => 'deepseek-r1',
+    'messages' => [
+        ['role' => 'user', 'content' => '你好！'],
+    ],
+]);
+
+echo $response->choices[0]->message->content;
+```
+
+#### Full factory customisation
+
+```php
+$client = Astraflow::factory()
+    ->withApiKey(getenv('ASTRAFLOW_API_KEY'))
+    ->withBaseUri(Astraflow::BASE_URI)           // or Astraflow::BASE_URI_CN
+    ->withHttpClient(new \GuzzleHttp\Client([]))
+    ->withHttpHeader('X-Custom-Header', 'value')
+    ->withQueryParam('my-param', 'bar')
+    ->make();
+```
 
 ### Azure
 

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
             "OpenAI\\": "src/"
         },
         "files": [
-            "src/OpenAI.php"
+            "src/OpenAI.php",
+            "src/Astraflow.php"
         ]
     },
     "autoload-dev": {

--- a/src/Astraflow.php
+++ b/src/Astraflow.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use OpenAI\Client;
+use OpenAI\Factory;
+
+/**
+ * Astraflow (by UCloud / 优刻得) is an OpenAI-compatible AI model aggregation
+ * platform that provides access to 200+ models through two regional endpoints.
+ *
+ * Global endpoint : https://api-us-ca.umodelverse.ai/v1  (env: ASTRAFLOW_API_KEY)
+ * China  endpoint : https://api.modelverse.cn/v1         (env: ASTRAFLOW_CN_API_KEY)
+ *
+ * Sign up at https://astraflow.ucloud.cn/
+ */
+final class Astraflow
+{
+    /**
+     * Global endpoint base URI.
+     */
+    public const BASE_URI = 'https://api-us-ca.umodelverse.ai/v1';
+
+    /**
+     * China endpoint base URI.
+     */
+    public const BASE_URI_CN = 'https://api.modelverse.cn/v1';
+
+    /**
+     * Creates a new Astraflow client pointed at the **global** endpoint.
+     *
+     * Set the ASTRAFLOW_API_KEY environment variable to your API key, then:
+     *
+     *   $client = Astraflow::client(getenv('ASTRAFLOW_API_KEY'));
+     */
+    public static function client(string $apiKey): Client
+    {
+        return self::factory()
+            ->withApiKey($apiKey)
+            ->withBaseUri(self::BASE_URI)
+            ->make();
+    }
+
+    /**
+     * Creates a new Astraflow client pointed at the **China** endpoint.
+     *
+     * Set the ASTRAFLOW_CN_API_KEY environment variable to your API key, then:
+     *
+     *   $client = Astraflow::clientCn(getenv('ASTRAFLOW_CN_API_KEY'));
+     */
+    public static function clientCn(string $apiKey): Client
+    {
+        return self::factory()
+            ->withApiKey($apiKey)
+            ->withBaseUri(self::BASE_URI_CN)
+            ->make();
+    }
+
+    /**
+     * Creates a new factory instance so you can fully customise the Astraflow client.
+     *
+     *   $client = Astraflow::factory()
+     *       ->withApiKey(getenv('ASTRAFLOW_API_KEY'))
+     *       ->withBaseUri(Astraflow::BASE_URI)
+     *       ->withHttpHeader('X-Custom-Header', 'value')
+     *       ->make();
+     */
+    public static function factory(): Factory
+    {
+        return new Factory;
+    }
+}

--- a/tests/Astraflow.php
+++ b/tests/Astraflow.php
@@ -1,0 +1,97 @@
+<?php
+
+use GuzzleHttp\Client as GuzzleClient;
+use OpenAI\Client;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+// ---------------------------------------------------------------------------
+// Global endpoint
+// ---------------------------------------------------------------------------
+
+it('may create a global-endpoint client', function () {
+    $client = Astraflow::client('astraflow-test-key');
+
+    expect($client)->toBeInstanceOf(Client::class);
+});
+
+// ---------------------------------------------------------------------------
+// China endpoint
+// ---------------------------------------------------------------------------
+
+it('may create a china-endpoint client', function () {
+    $client = Astraflow::clientCn('astraflow-cn-test-key');
+
+    expect($client)->toBeInstanceOf(Client::class);
+});
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+it('may create a client via factory', function () {
+    $client = Astraflow::factory()
+        ->withApiKey('astraflow-test-key')
+        ->make();
+
+    expect($client)->toBeInstanceOf(Client::class);
+});
+
+it('may create a global-endpoint client via factory', function () {
+    $client = Astraflow::factory()
+        ->withApiKey('astraflow-test-key')
+        ->withBaseUri(Astraflow::BASE_URI)
+        ->make();
+
+    expect($client)->toBeInstanceOf(Client::class);
+});
+
+it('may create a china-endpoint client via factory', function () {
+    $client = Astraflow::factory()
+        ->withApiKey('astraflow-cn-test-key')
+        ->withBaseUri(Astraflow::BASE_URI_CN)
+        ->make();
+
+    expect($client)->toBeInstanceOf(Client::class);
+});
+
+it('sets a custom http client via factory', function () {
+    $client = Astraflow::factory()
+        ->withApiKey('astraflow-test-key')
+        ->withBaseUri(Astraflow::BASE_URI)
+        ->withHttpClient(new GuzzleClient)
+        ->make();
+
+    expect($client)->toBeInstanceOf(Client::class);
+});
+
+it('sets a custom http header via factory', function () {
+    $client = Astraflow::factory()
+        ->withApiKey('astraflow-test-key')
+        ->withBaseUri(Astraflow::BASE_URI)
+        ->withHttpHeader('X-My-Header', 'foo')
+        ->make();
+
+    expect($client)->toBeInstanceOf(Client::class);
+});
+
+it('sets a custom query parameter via factory', function () {
+    $client = Astraflow::factory()
+        ->withApiKey('astraflow-test-key')
+        ->withBaseUri(Astraflow::BASE_URI)
+        ->withQueryParam('my-param', 'bar')
+        ->make();
+
+    expect($client)->toBeInstanceOf(Client::class);
+});
+
+it('sets a custom stream handler via factory', function () {
+    $client = Astraflow::factory()
+        ->withApiKey('astraflow-test-key')
+        ->withBaseUri(Astraflow::BASE_URI)
+        ->withHttpClient($httpClient = new GuzzleClient)
+        ->withStreamHandler(fn (RequestInterface $request): ResponseInterface => $httpClient->send($request, ['stream' => true]))
+        ->make();
+
+    expect($client)->toBeInstanceOf(Client::class);
+});


### PR DESCRIPTION
## Add Astraflow provider support

[Astraflow](https://astraflow.ucloud.cn/) (by UCloud / 优刻得) is an OpenAI-compatible AI model aggregation platform that supports 200+ models via two regional endpoints:

| Region | Base URI | Env var |
|--------|----------|---------|
| Global | `https://api-us-ca.umodelverse.ai/v1` | `ASTRAFLOW_API_KEY` |
| China  | `https://api.modelverse.cn/v1`        | `ASTRAFLOW_CN_API_KEY` |

### Changes

| File | What changed |
|------|-------------|
| `src/Astraflow.php` | New global-namespace facade — mirrors `src/OpenAI.php`; exposes `client()` (global endpoint), `clientCn()` (China endpoint), and `factory()` |
| `composer.json` | Registers `src/Astraflow.php` under `autoload.files` so the class is available without an explicit `use` |
| `tests/Astraflow.php` | Unit tests that mirror `tests/OpenAI.php`, covering both endpoints and the full factory API |
| `README.md` | Documents the new **Astraflow** service under the *Services* section (Table of Contents + prose) |

### Usage

```php
// Global endpoint
$client = Astraflow::client(getenv('ASTRAFLOW_API_KEY'));

// China endpoint
$client = Astraflow::clientCn(getenv('ASTRAFLOW_CN_API_KEY'));

// Fine-grained factory — pick any endpoint / HTTP client / headers
$client = Astraflow::factory()
    ->withApiKey(getenv('ASTRAFLOW_API_KEY'))
    ->withBaseUri(Astraflow::BASE_URI)   // or Astraflow::BASE_URI_CN
    ->make();
```

Sign up for an API key at **https://astraflow.ucloud.cn/**.