### PR TITLE
fix missing sequence numbers

### DIFF
--- a/src/Responses/Responses/Streaming/ContentPart.php
+++ b/src/Responses/Responses/Streaming/ContentPart.php
@@ -17,7 +17,7 @@ use OpenAI\Testing\Responses\Concerns\Fakeable;
  * @phpstan-import-type OutputTextType from OutputMessageContentOutputText
  * @phpstan-import-type ContentRefusalType from OutputMessageContentRefusal
  *
- * @phpstan-type ContentPartType array{type: string, content_index: int, item_id: string, output_index: int, part: OutputTextType|ContentRefusalType}
+ * @phpstan-type ContentPartType array{type: string, content_index: int, item_id: string, output_index: int, sequence_number: int, part: OutputTextType|ContentRefusalType}
  *
  * @implements ResponseContract<ContentPartType>
  */
@@ -36,6 +36,7 @@ final class ContentPart implements ResponseContract, ResponseHasMetaInformationC
         public readonly int $contentIndex,
         public readonly string $itemId,
         public readonly int $outputIndex,
+        public readonly int $sequenceNumber,
         public readonly OutputMessageContentOutputText|OutputMessageContentRefusal $part,
         private readonly MetaInformation $meta,
     ) {}
@@ -55,6 +56,7 @@ final class ContentPart implements ResponseContract, ResponseHasMetaInformationC
             contentIndex: $attributes['content_index'],
             itemId: $attributes['item_id'],
             outputIndex: $attributes['output_index'],
+            sequenceNumber: $attributes['sequence_number'],
             part: $part,
             meta: $meta,
         );
@@ -70,6 +72,7 @@ final class ContentPart implements ResponseContract, ResponseHasMetaInformationC
             'content_index' => $this->contentIndex,
             'item_id' => $this->itemId,
             'output_index' => $this->outputIndex,
+            'sequence_number' => $this->sequenceNumber,
             'part' => $this->part->toArray(),
         ];
     }

--- a/src/Responses/Responses/Streaming/OutputItem.php
+++ b/src/Responses/Responses/Streaming/OutputItem.php
@@ -35,7 +35,7 @@ use OpenAI\Testing\Responses\Concerns\Fakeable;
  * @phpstan-import-type OutputMcpCallType from OutputMcpCall
  * @phpstan-import-type OutputCodeInterpreterToolCallType from OutputCodeInterpreterToolCall
  *
- * @phpstan-type OutputItemType array{type: string, output_index: int, item: OutputCodeInterpreterToolCallType|OutputComputerToolCallType|OutputFileSearchToolCallType|OutputFunctionToolCallType|OutputMessageType|OutputReasoningType|OutputWebSearchToolCallType|OutputMcpListToolsType|OutputMcpApprovalRequestType|OutputMcpCallType|OutputImageGenerationToolCallType}
+ * @phpstan-type OutputItemType array{type: string, output_index: int, sequence_number: int, item: OutputCodeInterpreterToolCallType|OutputComputerToolCallType|OutputFileSearchToolCallType|OutputFunctionToolCallType|OutputMessageType|OutputReasoningType|OutputWebSearchToolCallType|OutputMcpListToolsType|OutputMcpApprovalRequestType|OutputMcpCallType|OutputImageGenerationToolCallType}
  *
  * @implements ResponseContract<OutputItemType>
  */
@@ -52,6 +52,7 @@ final class OutputItem implements ResponseContract, ResponseHasMetaInformationCo
     private function __construct(
         public readonly string $type,
         public readonly int $outputIndex,
+        public readonly int $sequenceNumber,
         public readonly OutputMessage|OutputCodeInterpreterToolCall|OutputFileSearchToolCall|OutputFunctionToolCall|OutputWebSearchToolCall|OutputComputerToolCall|OutputReasoning|OutputMcpListTools|OutputMcpApprovalRequest|OutputMcpCall|OutputImageGenerationToolCall $item,
         private readonly MetaInformation $meta,
     ) {}
@@ -78,6 +79,7 @@ final class OutputItem implements ResponseContract, ResponseHasMetaInformationCo
         return new self(
             type: $attributes['type'],
             outputIndex: $attributes['output_index'],
+            sequenceNumber: $attributes['sequence_number'],
             item: $item,
             meta: $meta,
         );
@@ -91,6 +93,7 @@ final class OutputItem implements ResponseContract, ResponseHasMetaInformationCo
         return [
             'type' => $this->type,
             'output_index' => $this->outputIndex,
+            'sequence_number' => $this->sequenceNumber,
             'item' => $this->item->toArray(),
         ];
     }

--- a/src/Responses/Responses/Streaming/OutputTextDone.php
+++ b/src/Responses/Responses/Streaming/OutputTextDone.php
@@ -12,7 +12,7 @@ use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
- * @phpstan-type OutputTextDoneType array{type: string, content_index: int, item_id: string, output_index: int, text: string}
+ * @phpstan-type OutputTextDoneType array{type: string, content_index: int, item_id: string, output_index: int, sequence_number: int, text: string}
  *
  * @implements ResponseContract<OutputTextDoneType>
  */
@@ -31,6 +31,7 @@ final class OutputTextDone implements ResponseContract, ResponseHasMetaInformati
         public readonly int $contentIndex,
         public readonly string $itemId,
         public readonly int $outputIndex,
+        public readonly int $sequenceNumber,
         public readonly string $text,
         private readonly MetaInformation $meta,
     ) {}
@@ -45,6 +46,7 @@ final class OutputTextDone implements ResponseContract, ResponseHasMetaInformati
             contentIndex: $attributes['content_index'],
             itemId: $attributes['item_id'],
             outputIndex: $attributes['output_index'],
+            sequenceNumber: $attributes['sequence_number'],
             text: $attributes['text'],
             meta: $meta,
         );
@@ -60,6 +62,7 @@ final class OutputTextDone implements ResponseContract, ResponseHasMetaInformati
             'content_index' => $this->contentIndex,
             'item_id' => $this->itemId,
             'output_index' => $this->outputIndex,
+            'sequence_number' => $this->sequenceNumber,
             'text' => $this->text,
         ];
     }


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the OpenAI PHP team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

Adds missing `sequence_number` to `OutputItem`, `ContentPart` and `OutputTextDone`. According to [OpenAI streaming events](https://developers.openai.com/api/reference/resources/responses/streaming-events), they should all have the `sequence_number` attribute when streaming a response through the Responses API.

[response.output_item.added](https://developers.openai.com/api/reference/resources/responses/streaming-events#response.output_item.added)  
[response.output_item.done](https://developers.openai.com/api/reference/resources/responses/streaming-events#response.output_item.done)  
[response.content_part.added](https://developers.openai.com/api/reference/resources/responses/streaming-events#response.content_part.added)  
[response.content_part.done](https://developers.openai.com/api/reference/resources/responses/streaming-events#response.content_part.done)  
[response.output_text.done](https://developers.openai.com/api/reference/resources/responses/streaming-events#response.output_text.done)  

