### PR TITLE
fix: guard missing vector store response description for Azure OpenAI compatibility

### DIFF
--- a/src/Responses/VectorStores/VectorStoreResponse.php
+++ b/src/Responses/VectorStores/VectorStoreResponse.php
@@ -55,7 +55,7 @@ final class VectorStoreResponse implements ResponseContract, ResponseHasMetaInfo
             $attributes['object'],
             $attributes['created_at'],
             $attributes['name'],
-            $attributes['description'],
+            $attributes['description'] ?? null,
             $attributes['usage_bytes'],
             VectorStoreResponseFileCounts::from($attributes['file_counts']),
             $attributes['status'],


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

This package targets the OpenAI API, but the same SDK also works against **Azure OpenAI**, which exposes an OpenAI-compatible surface. For teams on Azure (often for compliance, data-residency, or enterprise-procurement reasons) it's nice to be able to stay on the same client as everyone else.

`v0.19.1` added a new `description` field to `VectorStoreResponse` and reads it unconditionally in `VectorStoreResponse::from()`. Azure OpenAI's vector-store endpoint does not (yet) return that field, so calls against Azure now fail with:

> Undefined array key "description"

This guards the read with `?? null`, matching the pattern already used for other optional fields across the codebase (e.g. `CreateResponse`, `CreateStreamedResponse`, `CreateResponseMessage`). The constructor parameter is already `?string`, so behavior against OpenAI is unchanged, but Azure users no longer have to pin to `<0.19.1` while waiting for parity on Microsoft's side.

A small, defensive change that costs nothing for OpenAI users and unblocks the Azure ones.