### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/src/OpenAI.php
+++ b/src/OpenAI.php
@@ -20,6 +20,34 @@ final class OpenAI
     }
 
     /**
+     * Creates a new Astraflow Client (global endpoint) with the given API key.
+     *
+     * Astraflow by UCloud — OpenAI-compatible platform supporting 200+ models (global endpoint).
+     * Sign up at https://astraflow.ucloud-global.com
+     */
+    public static function astraflow(string $apiKey): Client
+    {
+        return self::factory()
+            ->withApiKey($apiKey)
+            ->withBaseUri('api-us-ca.umodelverse.ai/v1')
+            ->make();
+    }
+
+    /**
+     * Creates a new Astraflow Client (China endpoint) with the given API key.
+     *
+     * Astraflow by UCloud — OpenAI-compatible platform supporting 200+ models (China endpoint).
+     * Sign up at https://astraflow.ucloud.cn
+     */
+    public static function astraflowCn(string $apiKey): Client
+    {
+        return self::factory()
+            ->withApiKey($apiKey)
+            ->withBaseUri('api.modelverse.cn/v1')
+            ->make();
+    }
+
+    /**
      * Creates a new factory instance to configure a custom Open AI Client
      */
     public static function factory(): Factory


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Adds convenience static methods to the `OpenAI` class for [Astraflow](https://astraflow.ucloud-global.com) — an OpenAI-compatible AI model aggregation platform by UCloud (优刻得) that supports 200+ models.

Because Astraflow is fully OpenAI-compatible, the integration requires **zero new dependencies** and **zero new files** — it is just two thin factory methods that pre-set the correct `baseUri` while delegating everything else to the existing `Factory`.

**New API:**

```php
// Global endpoint (env: ASTRAFLOW_API_KEY)
$client = OpenAI::astraflow(getenv('ASTRAFLOW_API_KEY'));

// China endpoint (env: ASTRAFLOW_CN_API_KEY)
$client = OpenAI::astraflowCn(getenv('ASTRAFLOW_CN_API_KEY'));
```

Both methods return a fully-configured `OpenAI\Client` and support the same interface as `OpenAI::client()`. For advanced configuration (custom HTTP client, headers, stream handler, etc.) users can fall back to the existing `OpenAI::factory()` fluent API:

```php
$client = OpenAI::factory()
    ->withApiKey(getenv('ASTRAFLOW_API_KEY'))
    ->withBaseUri('api-us-ca.umodelverse.ai/v1')
    ->make();
```

**Endpoints:**

| Variant | Base URI | Sign-up |
|---------|----------|---------|
| Global  | `https://api-us-ca.umodelverse.ai/v1` | https://astraflow.ucloud-global.com |
| China   | `https://api.modelverse.cn/v1`        | https://astraflow.ucloud.cn         |

**Changes:**

- `src/OpenAI.php` — added `OpenAI::astraflow(string $apiKey): Client` and `OpenAI::astraflowCn(string $apiKey): Client` static methods (mirrors the existing `OpenAI::client()` pattern).