### PR TITLE
add support for extra_content in chat response tool calls returned by Gemini models

### DIFF
--- a/src/Responses/Chat/CreateResponseToolCall.php
+++ b/src/Responses/Chat/CreateResponseToolCall.php
@@ -10,10 +10,11 @@ final class CreateResponseToolCall
         public readonly string $id,
         public readonly string $type,
         public readonly CreateResponseToolCallFunction $function,
+        public readonly array $extraContent,
     ) {}
 
     /**
-     * @param  array{id: string, type?: string, function: array{name: string, arguments: string}}  $attributes
+     * @param  array{id: string, type?: string, function: array{name: string, arguments: string}, extra_content: array{name: string, arguments: string}|null}  $attributes
      */
     public static function from(array $attributes): self
     {
@@ -21,11 +22,12 @@ final class CreateResponseToolCall
             $attributes['id'],
             $attributes['type'] ?? 'function',
             CreateResponseToolCallFunction::from($attributes['function']),
+            $attributes['extra_content'] ?? [],
         );
     }
 
     /**
-     * @return array{id: string, type: string, function: array{name: string, arguments: string}}
+     * @return array{id: string, type: string, function: array{name: string, arguments: string}, extra_content: array{name: string, arguments: string}|null}
      */
     public function toArray(): array
     {
@@ -33,6 +35,7 @@ final class CreateResponseToolCall
             'id' => $this->id,
             'type' => $this->type,
             'function' => $this->function->toArray(),
+            'extra_content' => $this->extraContent,
         ];
     }
 }

--- a/src/Responses/Chat/CreateResponseToolCall.php
+++ b/src/Responses/Chat/CreateResponseToolCall.php
@@ -7,9 +7,6 @@ namespace OpenAI\Responses\Chat;
 final class CreateResponseToolCall
 {
     /**
-     * @param string $id
-     * @param string $type
-     * @param CreateResponseToolCallFunction $function
      * @param array<string, array<string,string>>|null $extraContent
      */
     private function __construct(

--- a/src/Responses/Chat/CreateResponseToolCall.php
+++ b/src/Responses/Chat/CreateResponseToolCall.php
@@ -7,7 +7,7 @@ namespace OpenAI\Responses\Chat;
 final class CreateResponseToolCall
 {
     /**
-     * @param array<string, array<string,string>>|null $extraContent
+     * @param  array<string, array<string,string>>|null  $extraContent
      */
     private function __construct(
         public readonly string $id,

--- a/src/Responses/Chat/CreateResponseToolCall.php
+++ b/src/Responses/Chat/CreateResponseToolCall.php
@@ -6,15 +6,21 @@ namespace OpenAI\Responses\Chat;
 
 final class CreateResponseToolCall
 {
+    /**
+     * @param string $id
+     * @param string $type
+     * @param CreateResponseToolCallFunction $function
+     * @param array<string, array<string,string>>|null $extraContent
+     */
     private function __construct(
         public readonly string $id,
         public readonly string $type,
         public readonly CreateResponseToolCallFunction $function,
-        public readonly ?array $extraContent,
+        public readonly ?array $extraContent = null,
     ) {}
 
     /**
-     * @param  array{id: string, type?: string, function: array{name: string, arguments: string}, extra_content: array<string, array<string,string>>|null}  $attributes
+     * @param  array{id: string, type?: string, function: array{name: string, arguments: string}, extra_content?: array<string, array<string,string>>|null}  $attributes
      */
     public static function from(array $attributes): self
     {

--- a/src/Responses/Chat/CreateResponseToolCall.php
+++ b/src/Responses/Chat/CreateResponseToolCall.php
@@ -14,7 +14,7 @@ final class CreateResponseToolCall
     ) {}
 
     /**
-     * @param  array{id: string, type?: string, function: array{name: string, arguments: string}, extra_content: array{name: string, arguments: string}|null}  $attributes
+     * @param  array{id: string, type?: string, function: array{name: string, arguments: string}, extra_content: array<string, array<string,string>>|null}  $attributes
      */
     public static function from(array $attributes): self
     {
@@ -27,7 +27,7 @@ final class CreateResponseToolCall
     }
 
     /**
-     * @return array{id: string, type: string, function: array{name: string, arguments: string}, extra_content: array{name: string, arguments: string}|null}
+     * @return array{id: string, type: string, function: array{name: string, arguments: string}, extra_content: array<string, array<string,string>>|null}
      */
     public function toArray(): array
     {

--- a/src/Responses/Chat/CreateResponseToolCall.php
+++ b/src/Responses/Chat/CreateResponseToolCall.php
@@ -10,7 +10,7 @@ final class CreateResponseToolCall
         public readonly string $id,
         public readonly string $type,
         public readonly CreateResponseToolCallFunction $function,
-        public readonly array $extraContent,
+        public readonly ?array $extraContent,
     ) {}
 
     /**
@@ -22,20 +22,20 @@ final class CreateResponseToolCall
             $attributes['id'],
             $attributes['type'] ?? 'function',
             CreateResponseToolCallFunction::from($attributes['function']),
-            $attributes['extra_content'] ?? [],
+            $attributes['extra_content'] ?? null,
         );
     }
 
     /**
-     * @return array{id: string, type: string, function: array{name: string, arguments: string}, extra_content: array<string, array<string,string>>|null}
+     * @return array{id: string, type: string, function: array{name: string, arguments: string}, extra_content?: array<string, array<string,string>>}
      */
     public function toArray(): array
     {
-        return [
+        return array_filter([
             'id' => $this->id,
             'type' => $this->type,
             'function' => $this->function->toArray(),
             'extra_content' => $this->extraContent,
-        ];
+        ], fn (mixed $value): bool => ! is_null($value));
     }
 }

--- a/src/Responses/Chat/CreateStreamedResponseToolCall.php
+++ b/src/Responses/Chat/CreateStreamedResponseToolCall.php
@@ -6,6 +6,13 @@ namespace OpenAI\Responses\Chat;
 
 final class CreateStreamedResponseToolCall
 {
+    /**
+     * @param int|null $index
+     * @param string|null $id
+     * @param string|null $type
+     * @param CreateStreamedResponseToolCallFunction $function
+     * @param array<string, array<string,string>>|null $extraContent
+     */
     private function __construct(
         public readonly ?int $index,
         public readonly ?string $id,

--- a/src/Responses/Chat/CreateStreamedResponseToolCall.php
+++ b/src/Responses/Chat/CreateStreamedResponseToolCall.php
@@ -18,7 +18,7 @@ final class CreateStreamedResponseToolCall
     ) {}
 
     /**
-     * @param  array{index?: int, id?: string, type?: string, function: array{name?: string, arguments: string}, extra_content: array<string, array<string,string>>|null}  $attributes
+     * @param  array{index?: int, id?: string, type?: string, function: array{name?: string, arguments: string}, extra_content?: array<string, array<string,string>>|null}  $attributes
      */
     public static function from(array $attributes): self
     {

--- a/src/Responses/Chat/CreateStreamedResponseToolCall.php
+++ b/src/Responses/Chat/CreateStreamedResponseToolCall.php
@@ -7,7 +7,7 @@ namespace OpenAI\Responses\Chat;
 final class CreateStreamedResponseToolCall
 {
     /**
-     * @param array<string, array<string,string>>|null $extraContent
+     * @param  array<string, array<string,string>>|null  $extraContent
      */
     private function __construct(
         public readonly ?int $index,

--- a/src/Responses/Chat/CreateStreamedResponseToolCall.php
+++ b/src/Responses/Chat/CreateStreamedResponseToolCall.php
@@ -15,7 +15,7 @@ final class CreateStreamedResponseToolCall
     ) {}
 
     /**
-     * @param  array{index?: int, id?: string, type?: string, function: array{name?: string, arguments: string}, extra_content: array{name: string, arguments: string}|null}  $attributes
+     * @param  array{index?: int, id?: string, type?: string, function: array{name?: string, arguments: string}, extra_content: array<string, array<string,string>>|null}  $attributes
      */
     public static function from(array $attributes): self
     {
@@ -29,7 +29,7 @@ final class CreateStreamedResponseToolCall
     }
 
     /**
-     * @return array{index?: int, id?: string, type?: string, function?: array{name?: string, arguments: string}, extra_content: array{name: string, arguments: string}|null}
+     * @return array{index?: int, id?: string, type?: string, function?: array{name?: string, arguments: string}, extra_content: array<string, array<string,string>>|null}
      */
     public function toArray(): array
     {

--- a/src/Responses/Chat/CreateStreamedResponseToolCall.php
+++ b/src/Responses/Chat/CreateStreamedResponseToolCall.php
@@ -7,10 +7,6 @@ namespace OpenAI\Responses\Chat;
 final class CreateStreamedResponseToolCall
 {
     /**
-     * @param int|null $index
-     * @param string|null $id
-     * @param string|null $type
-     * @param CreateStreamedResponseToolCallFunction $function
      * @param array<string, array<string,string>>|null $extraContent
      */
     private function __construct(

--- a/src/Responses/Chat/CreateStreamedResponseToolCall.php
+++ b/src/Responses/Chat/CreateStreamedResponseToolCall.php
@@ -29,7 +29,7 @@ final class CreateStreamedResponseToolCall
     }
 
     /**
-     * @return array{index?: int, id?: string, type?: string, function?: array{name?: string, arguments: string}, extra_content: array<string, array<string,string>>|null}
+     * @return array{index?: int, id?: string, type?: string, function?: array{name?: string, arguments: string}, extra_content?: array<string, array<string,string>>}
      */
     public function toArray(): array
     {

--- a/src/Responses/Chat/CreateStreamedResponseToolCall.php
+++ b/src/Responses/Chat/CreateStreamedResponseToolCall.php
@@ -11,10 +11,11 @@ final class CreateStreamedResponseToolCall
         public readonly ?string $id,
         public readonly ?string $type,
         public readonly CreateStreamedResponseToolCallFunction $function,
+        public readonly ?array $extraContent,
     ) {}
 
     /**
-     * @param  array{index?: int, id?: string, type?: string, function: array{name?: string, arguments: string}}  $attributes
+     * @param  array{index?: int, id?: string, type?: string, function: array{name?: string, arguments: string}, extra_content: array{name: string, arguments: string}|null}  $attributes
      */
     public static function from(array $attributes): self
     {
@@ -23,11 +24,12 @@ final class CreateStreamedResponseToolCall
             $attributes['id'] ?? null,
             $attributes['type'] ?? null,
             CreateStreamedResponseToolCallFunction::from($attributes['function']),
+            $attributes['extra_content'] ?? null,
         );
     }
 
     /**
-     * @return array{index?: int, id?: string, type?: string, function?: array{name?: string, arguments: string}}
+     * @return array{index?: int, id?: string, type?: string, function?: array{name?: string, arguments: string}, extra_content: array{name: string, arguments: string}|null}
      */
     public function toArray(): array
     {
@@ -36,6 +38,7 @@ final class CreateStreamedResponseToolCall
             'id' => $this->id,
             'type' => $this->type,
             'function' => $this->function->toArray(),
+            'extra_content' => $this->extraContent,
         ], fn (mixed $value): bool => ! is_null($value));
     }
 }

--- a/tests/Fixtures/Chat.php
+++ b/tests/Fixtures/Chat.php
@@ -495,6 +495,50 @@ function chatCompletionWithToolCalls(): array
 /**
  * @return array<string, mixed>
  */
+function chatCompletionWithToolCallsAndExtraContent(): array
+{
+    return [
+        'id' => 'chatcmpl-123',
+        'object' => 'chat.completion',
+        'created' => 1699333252,
+        'model' => 'gpt-3.5-turbo-0613',
+        'choices' => [
+            [
+                'index' => 0,
+                'message' => [
+                    'role' => 'assistant',
+                    'content' => null,
+                    'tool_calls' => [
+                        [
+                            'id' => 'call_trlgKnhMpYSC7CFXKw3CceUZ',
+                            'type' => 'function',
+                            'function' => [
+                                'name' => 'get_current_weather',
+                                'arguments' => "{\n  \"location\": \"Boston, MA\"\n}",
+                            ],
+                            'extra_content' => [
+                                'google' => [
+                                    'thought_signature' => 'trlgKnhMpYSC7CFXKw3CceUZ'
+                                ]
+                            ],
+                        ],
+                    ],
+                ],
+                'logprobs' => null,
+                'finish_reason' => 'tool_calls',
+            ],
+        ],
+        'usage' => [
+            'prompt_tokens' => 71,
+            'completion_tokens' => 17,
+            'total_tokens' => 88,
+        ],
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
 function chatCompletionMessageWithFunctionAndNoContent(): array
 {
     return [

--- a/tests/Fixtures/Chat.php
+++ b/tests/Fixtures/Chat.php
@@ -519,7 +519,7 @@ function chatCompletionWithToolCallsAndExtraContent(): array
                             'extra_content' => [
                                 'google' => [
                                     'thought_signature' => 'trlgKnhMpYSC7CFXKw3CceUZ',
-                                ]
+                                ],
                             ],
                         ],
                     ],

--- a/tests/Fixtures/Chat.php
+++ b/tests/Fixtures/Chat.php
@@ -518,7 +518,7 @@ function chatCompletionWithToolCallsAndExtraContent(): array
                             ],
                             'extra_content' => [
                                 'google' => [
-                                    'thought_signature' => 'trlgKnhMpYSC7CFXKw3CceUZ'
+                                    'thought_signature' => 'trlgKnhMpYSC7CFXKw3CceUZ',
                                 ]
                             ],
                         ],

--- a/tests/Responses/Chat/CreateResponseMessage.php
+++ b/tests/Responses/Chat/CreateResponseMessage.php
@@ -33,7 +33,26 @@ test('from tool calls response', function () {
         ->content->toBeNull()
         ->toolCalls->toBeArray()
         ->toolCalls->toHaveCount(1)
-        ->toolCalls->each->toBeInstanceOf(CreateResponseToolCall::class);
+        ->toolCalls->each->toBeInstanceOf(CreateResponseToolCall::class)
+        ->and($result->toolCalls[0])
+        ->extraContent->toBeNull();
+});
+
+test('from tool calls response with extra content', function () {
+    $result = CreateResponseMessage::from(chatCompletionWithToolCallsAndExtraContent()['choices'][0]['message']);
+
+    expect($result)
+        ->role->toBe('assistant')
+        ->content->toBeNull()
+        ->toolCalls->toBeArray()
+        ->toolCalls->toHaveCount(1)
+        ->toolCalls->each->toBeInstanceOf(CreateResponseToolCall::class)
+        ->and($result->toolCalls[0])
+        ->extraContent->toBeArray()
+        ->extraContent->toHaveCount(1)
+        ->extraContent->toHaveKey('google')
+        ->extraContent->google->toHaveKey('thought_signature')
+        ->extraContent->google->thought_signature->toBe('trlgKnhMpYSC7CFXKw3CceUZ');
 });
 
 test('from annotations response', function () {
@@ -92,6 +111,13 @@ test('to array from tool calls response', function () {
 
     expect($result->toArray())
         ->toBe(chatCompletionWithToolCalls()['choices'][0]['message']);
+});
+
+test('to array from tool calls response with extra content', function () {
+    $result = CreateResponseMessage::from(chatCompletionWithToolCallsAndExtraContent()['choices'][0]['message']);
+
+    expect($result->toArray())
+        ->toBe(chatCompletionWithToolCallsAndExtraContent()['choices'][0]['message']);
 });
 
 test('to array from annotations response', function () {


### PR DESCRIPTION
### What:

- [X] Bug Fix
- [ ] New Feature

### Description:

This is a newer fix, based on #718 in order to fix the Gemini reponse. Gemini sends 'extra_content' when using tools in order to transfer the `thought_signature`. This is how it looks in the raw response:

```json
{
  "choices": [
    {
      "finish_reason": "tool_calls",
      "index": 0,
      "message": {
        "role": "assistant",
        "tool_calls": [
          {
            "extra_content": {
              "google": {
                "thought_signature": "<token>"
              }
            },
            "function": {
              "arguments": "{}",
              "name": "function-name"
            },
            "id": "<id>",
            "type": "function"
          },
          // ...
        ]
      }
    }
  ],
  // ...
```

### Related:

See other PR #718 - this one should take care of failed checks

closes: #718 
