### PR TITLE
fix: Handle new OpenAI response keep_alive type

### DIFF
--- a/src/Responses/StreamResponse.php
+++ b/src/Responses/StreamResponse.php
@@ -60,7 +60,7 @@ final class StreamResponse implements ResponseHasMetaInformationContract, Respon
                 throw new ErrorException($response['error'], $this->response);
             }
 
-            $skippableTypes = ['ping', 'keepalive'];
+            $skippableTypes = ['ping', 'keepalive', 'response.keep_alive'];
             if (isset($response['type']) && in_array($response['type'], $skippableTypes, true)) {
                 continue;
             }


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

OpenAI/OpenRouter updated their API with a new keep-alive type that isn't handled before yielding the streamed response, causing an unhandled type exception in the Response class

### Related:
