### PR TITLE
feat(OpenAI): Add 'tool_search' functionality.

### DIFF
--- a/src/Actions/Responses/CustomToolInputObjects.php
+++ b/src/Actions/Responses/CustomToolInputObjects.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Actions\Responses;
+
+use OpenAI\Responses\Responses\Tool\CustomToolInputs\GrammarInput;
+use OpenAI\Responses\Responses\Tool\CustomToolInputs\TextInput;
+
+/**
+ * @phpstan-import-type TextInputType from TextInput
+ * @phpstan-import-type GrammarInputType from GrammarInput
+ *
+ * @phpstan-type CustomToolInputTypes TextInputType|GrammarInputType
+ * @phpstan-type CustomToolInputReturnType TextInput|GrammarInput
+ */
+final class CustomToolInputObjects
+{
+    /**
+     * @param  CustomToolInputTypes  $attributes
+     */
+    public static function parse(array $attributes): TextInput|GrammarInput
+    {
+        return match ($attributes['type']) {
+            'text' => TextInput::from($attributes),
+            'grammar' => GrammarInput::from($attributes),
+        };
+    }
+}

--- a/src/Actions/Responses/NamespaceToolObjects.php
+++ b/src/Actions/Responses/NamespaceToolObjects.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Actions\Responses;
+
+use OpenAI\Responses\Responses\Tool\NamespaceTools\CustomTool;
+use OpenAI\Responses\Responses\Tool\NamespaceTools\FunctionTool;
+
+/**
+ * @phpstan-import-type FunctionToolType from FunctionTool
+ * @phpstan-import-type CustomToolType from CustomTool
+ *
+ * @phpstan-type ResponseNamespaceToolObjectTypes array<int, FunctionToolType|CustomToolType>
+ * @phpstan-type ResponseNamespaceToolObjectReturnType array<int, FunctionTool|CustomTool>
+ */
+final class NamespaceToolObjects
+{
+    /**
+     * @param  ResponseNamespaceToolObjectTypes  $toolItems
+     * @return ResponseNamespaceToolObjectReturnType
+     */
+    public static function parse(array $toolItems): array
+    {
+        return array_map(
+            fn (array $tool): FunctionTool|CustomTool => match ($tool['type']) {
+                'function' => FunctionTool::from($tool),
+                'custom' => CustomTool::from($tool),
+                /** @phpstan-ignore-next-line */
+                default => throw new \InvalidArgumentException("Unknown tool type: {$tool['type']}"),
+            },
+            $toolItems,
+        );
+    }
+}

--- a/src/Actions/Responses/NamespaceToolObjects.php
+++ b/src/Actions/Responses/NamespaceToolObjects.php
@@ -26,8 +26,6 @@ final class NamespaceToolObjects
             fn (array $tool): FunctionTool|CustomTool => match ($tool['type']) {
                 'function' => FunctionTool::from($tool),
                 'custom' => CustomTool::from($tool),
-                /** @phpstan-ignore-next-line */
-                default => throw new \InvalidArgumentException("Unknown tool type: {$tool['type']}"),
             },
             $toolItems,
         );

--- a/src/Actions/Responses/OutputObjects.php
+++ b/src/Actions/Responses/OutputObjects.php
@@ -65,7 +65,7 @@ final class OutputObjects
                 'custom_tool_call' => OutputCustomToolCall::from($item),
                 'tool_search_call' => OutputToolSearchCall::from($item),
                 'tool_search_output' => OutputToolSearchOutput::from($item),
-                default => throw new \UnexpectedValueException('Unknown output item type.'),
+                default => throw new \UnexpectedValueException('Uh oh! We do not recognize this type. Please submit a bug to openai-php/client on GitHub!'),
             },
             $outputItems,
         );

--- a/src/Actions/Responses/OutputObjects.php
+++ b/src/Actions/Responses/OutputObjects.php
@@ -16,6 +16,8 @@ use OpenAI\Responses\Responses\Output\OutputMcpCall;
 use OpenAI\Responses\Responses\Output\OutputMcpListTools;
 use OpenAI\Responses\Responses\Output\OutputMessage;
 use OpenAI\Responses\Responses\Output\OutputReasoning;
+use OpenAI\Responses\Responses\Output\OutputToolSearchCall;
+use OpenAI\Responses\Responses\Output\OutputToolSearchOutput;
 use OpenAI\Responses\Responses\Output\OutputWebSearchToolCall;
 
 /**
@@ -32,9 +34,11 @@ use OpenAI\Responses\Responses\Output\OutputWebSearchToolCall;
  * @phpstan-import-type OutputCodeInterpreterToolCallType from OutputCodeInterpreterToolCall
  * @phpstan-import-type OutputLocalShellCallType from OutputLocalShellCall
  * @phpstan-import-type OutputCustomToolCallType from OutputCustomToolCall
+ * @phpstan-import-type OutputToolSearchCallType from OutputToolSearchCall
+ * @phpstan-import-type OutputToolSearchOutputType from OutputToolSearchOutput
  *
- * @phpstan-type ResponseOutputObjectTypes array<int, OutputComputerToolCallType|OutputFileSearchToolCallType|OutputFunctionToolCallType|OutputMessageType|OutputReasoningType|OutputWebSearchToolCallType|OutputMcpListToolsType|OutputMcpApprovalRequestType|OutputMcpCallType|OutputImageGenerationToolCallType|OutputCodeInterpreterToolCallType|OutputLocalShellCallType|OutputCustomToolCallType>
- * @phpstan-type ResponseOutputObjectReturnType array<int, OutputMessage|OutputComputerToolCall|OutputFileSearchToolCall|OutputWebSearchToolCall|OutputFunctionToolCall|OutputReasoning|OutputMcpListTools|OutputMcpApprovalRequest|OutputMcpCall|OutputImageGenerationToolCall|OutputCodeInterpreterToolCall|OutputLocalShellCall|OutputCustomToolCall>
+ * @phpstan-type ResponseOutputObjectTypes array<int, OutputComputerToolCallType|OutputFileSearchToolCallType|OutputFunctionToolCallType|OutputMessageType|OutputReasoningType|OutputWebSearchToolCallType|OutputMcpListToolsType|OutputMcpApprovalRequestType|OutputMcpCallType|OutputImageGenerationToolCallType|OutputCodeInterpreterToolCallType|OutputLocalShellCallType|OutputCustomToolCallType|OutputToolSearchCallType|OutputToolSearchOutputType>
+ * @phpstan-type ResponseOutputObjectReturnType array<int, OutputMessage|OutputComputerToolCall|OutputFileSearchToolCall|OutputWebSearchToolCall|OutputFunctionToolCall|OutputReasoning|OutputMcpListTools|OutputMcpApprovalRequest|OutputMcpCall|OutputImageGenerationToolCall|OutputCodeInterpreterToolCall|OutputLocalShellCall|OutputCustomToolCall|OutputToolSearchCall|OutputToolSearchOutput>
  */
 final class OutputObjects
 {
@@ -45,7 +49,7 @@ final class OutputObjects
     public static function parse(array $outputItems): array
     {
         return array_map(
-            fn (array $item): OutputMessage|OutputComputerToolCall|OutputFileSearchToolCall|OutputWebSearchToolCall|OutputFunctionToolCall|OutputReasoning|OutputMcpListTools|OutputMcpApprovalRequest|OutputMcpCall|OutputImageGenerationToolCall|OutputCodeInterpreterToolCall|OutputLocalShellCall|OutputCustomToolCall => match ($item['type']) {
+            fn (array $item): OutputMessage|OutputComputerToolCall|OutputFileSearchToolCall|OutputWebSearchToolCall|OutputFunctionToolCall|OutputReasoning|OutputMcpListTools|OutputMcpApprovalRequest|OutputMcpCall|OutputImageGenerationToolCall|OutputCodeInterpreterToolCall|OutputLocalShellCall|OutputCustomToolCall|OutputToolSearchCall|OutputToolSearchOutput => match ($item['type']) {
                 'message' => OutputMessage::from($item),
                 'file_search_call' => OutputFileSearchToolCall::from($item),
                 'function_call' => OutputFunctionToolCall::from($item),
@@ -59,6 +63,8 @@ final class OutputObjects
                 'code_interpreter_call' => OutputCodeInterpreterToolCall::from($item),
                 'local_shell_call' => OutputLocalShellCall::from($item),
                 'custom_tool_call' => OutputCustomToolCall::from($item),
+                'tool_search_call' => OutputToolSearchCall::from($item),
+                'tool_search_output' => OutputToolSearchOutput::from($item),
             },
             $outputItems,
         );

--- a/src/Actions/Responses/OutputObjects.php
+++ b/src/Actions/Responses/OutputObjects.php
@@ -65,6 +65,7 @@ final class OutputObjects
                 'custom_tool_call' => OutputCustomToolCall::from($item),
                 'tool_search_call' => OutputToolSearchCall::from($item),
                 'tool_search_output' => OutputToolSearchOutput::from($item),
+                default => throw new \UnexpectedValueException('Unknown output item type.'),
             },
             $outputItems,
         );

--- a/src/Actions/Responses/ToolObjects.php
+++ b/src/Actions/Responses/ToolObjects.php
@@ -16,19 +16,8 @@ use OpenAI\Responses\Responses\Tool\ToolSearchTool;
 use OpenAI\Responses\Responses\Tool\WebSearchTool;
 
 /**
- * @phpstan-import-type ComputerUseToolType from ComputerUseTool
- * @phpstan-import-type FileSearchToolType from FileSearchTool
- * @phpstan-import-type ImageGenerationToolType from ImageGenerationTool
- * @phpstan-import-type RemoteMcpToolType from RemoteMcpTool
- * @phpstan-import-type FunctionToolType from FunctionTool
- * @phpstan-import-type WebSearchToolType from WebSearchTool
- * @phpstan-import-type CodeInterpreterToolType from CodeInterpreterTool
- * @phpstan-import-type ToolSearchToolType from ToolSearchTool
- * @phpstan-import-type NamespaceToolType from NamespaceTool
- * @phpstan-import-type CustomToolType from CustomTool
- *
- * @phpstan-type ResponseToolObjectTypes array<int, ComputerUseToolType|FileSearchToolType|FunctionToolType|WebSearchToolType|ImageGenerationToolType|RemoteMcpToolType|CodeInterpreterToolType|ToolSearchToolType|NamespaceToolType|CustomToolType>
- * @phpstan-type ResponseToolObjectReturnType array<int, ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool|RemoteMcpTool|CodeInterpreterTool|ToolSearchTool|NamespaceTool|CustomToolType>
+ * @phpstan-type ResponseToolObjectTypes array<int, array{type: string}>
+ * @phpstan-type ResponseToolObjectReturnType array<int, ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool|RemoteMcpTool|CodeInterpreterTool|ToolSearchTool|NamespaceTool|CustomTool>
  */
 final class ToolObjects
 {
@@ -40,16 +29,17 @@ final class ToolObjects
     {
         return array_map(
             fn (array $tool): ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool|RemoteMcpTool|CodeInterpreterTool|ToolSearchTool|NamespaceTool|CustomTool => match ($tool['type']) {
-                'file_search' => FileSearchTool::from($tool),
-                'web_search', 'web_search_preview', 'web_search_preview_2025_03_11' => WebSearchTool::from($tool),
-                'function' => FunctionTool::from($tool),
-                'computer_use_preview' => ComputerUseTool::from($tool),
-                'image_generation' => ImageGenerationTool::from($tool),
-                'mcp' => RemoteMcpTool::from($tool),
-                'code_interpreter' => CodeInterpreterTool::from($tool),
-                'tool_search' => ToolSearchTool::from($tool),
-                'namespace' => NamespaceTool::from($tool),
-                'custom' => CustomTool::from($tool),
+                'file_search' => FileSearchTool::from($tool), // @phpstan-ignore-line
+                'web_search', 'web_search_preview', 'web_search_preview_2025_03_11' => WebSearchTool::from($tool), // @phpstan-ignore-line
+                'function' => FunctionTool::from($tool), // @phpstan-ignore-line
+                'computer_use_preview' => ComputerUseTool::from($tool), // @phpstan-ignore-line
+                'image_generation' => ImageGenerationTool::from($tool), // @phpstan-ignore-line
+                'mcp' => RemoteMcpTool::from($tool), // @phpstan-ignore-line
+                'code_interpreter' => CodeInterpreterTool::from($tool), // @phpstan-ignore-line
+                'tool_search' => ToolSearchTool::from($tool), // @phpstan-ignore-line
+                'namespace' => NamespaceTool::from($tool), // @phpstan-ignore-line
+                'custom' => CustomTool::from($tool), // @phpstan-ignore-line
+                default => throw new \InvalidArgumentException("Unknown tool type: {$tool['type']}"),
             },
             $toolItems,
         );

--- a/src/Actions/Responses/ToolObjects.php
+++ b/src/Actions/Responses/ToolObjects.php
@@ -9,7 +9,9 @@ use OpenAI\Responses\Responses\Tool\ComputerUseTool;
 use OpenAI\Responses\Responses\Tool\FileSearchTool;
 use OpenAI\Responses\Responses\Tool\FunctionTool;
 use OpenAI\Responses\Responses\Tool\ImageGenerationTool;
+use OpenAI\Responses\Responses\Tool\NamespaceTool;
 use OpenAI\Responses\Responses\Tool\RemoteMcpTool;
+use OpenAI\Responses\Responses\Tool\ToolSearchTool;
 use OpenAI\Responses\Responses\Tool\WebSearchTool;
 
 /**
@@ -20,9 +22,11 @@ use OpenAI\Responses\Responses\Tool\WebSearchTool;
  * @phpstan-import-type FunctionToolType from FunctionTool
  * @phpstan-import-type WebSearchToolType from WebSearchTool
  * @phpstan-import-type CodeInterpreterToolType from CodeInterpreterTool
+ * @phpstan-import-type ToolSearchToolType from ToolSearchTool
+ * @phpstan-import-type NamespaceToolType from NamespaceTool
  *
- * @phpstan-type ResponseToolObjectTypes array<int, ComputerUseToolType|FileSearchToolType|FunctionToolType|WebSearchToolType|ImageGenerationToolType|RemoteMcpToolType|CodeInterpreterToolType>
- * @phpstan-type ResponseToolObjectReturnType array<int, ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool|RemoteMcpTool|CodeInterpreterTool>
+ * @phpstan-type ResponseToolObjectTypes array<int, ComputerUseToolType|FileSearchToolType|FunctionToolType|WebSearchToolType|ImageGenerationToolType|RemoteMcpToolType|CodeInterpreterToolType|ToolSearchToolType|NamespaceToolType>
+ * @phpstan-type ResponseToolObjectReturnType array<int, ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool|RemoteMcpTool|CodeInterpreterTool|ToolSearchTool|NamespaceTool>
  */
 final class ToolObjects
 {
@@ -33,7 +37,7 @@ final class ToolObjects
     public static function parse(array $toolItems): array
     {
         return array_map(
-            fn (array $tool): ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool|RemoteMcpTool|CodeInterpreterTool => match ($tool['type']) {
+            fn (array $tool): ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool|RemoteMcpTool|CodeInterpreterTool|ToolSearchTool|NamespaceTool => match ($tool['type']) {
                 'file_search' => FileSearchTool::from($tool),
                 'web_search', 'web_search_preview', 'web_search_preview_2025_03_11' => WebSearchTool::from($tool),
                 'function' => FunctionTool::from($tool),
@@ -41,6 +45,8 @@ final class ToolObjects
                 'image_generation' => ImageGenerationTool::from($tool),
                 'mcp' => RemoteMcpTool::from($tool),
                 'code_interpreter' => CodeInterpreterTool::from($tool),
+                'tool_search' => ToolSearchTool::from($tool),
+                'namespace' => NamespaceTool::from($tool),
             },
             $toolItems,
         );

--- a/src/Actions/Responses/ToolObjects.php
+++ b/src/Actions/Responses/ToolObjects.php
@@ -16,8 +16,19 @@ use OpenAI\Responses\Responses\Tool\ToolSearchTool;
 use OpenAI\Responses\Responses\Tool\WebSearchTool;
 
 /**
- * @phpstan-type ResponseToolObjectTypes array<int, array{type: string}>
- * @phpstan-type ResponseToolObjectReturnType array<int, ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool|RemoteMcpTool|CodeInterpreterTool|ToolSearchTool|NamespaceTool|CustomTool>
+ * @phpstan-import-type CodeInterpreterToolType from CodeInterpreterTool
+ * @phpstan-import-type ComputerUseToolType from ComputerUseTool
+ * @phpstan-import-type CustomToolType from CustomTool
+ * @phpstan-import-type FileSearchToolType from FileSearchTool
+ * @phpstan-import-type FunctionToolType from FunctionTool
+ * @phpstan-import-type ImageGenerationToolType from ImageGenerationTool
+ * @phpstan-import-type NamespaceToolType from NamespaceTool
+ * @phpstan-import-type RemoteMcpToolType from RemoteMcpTool
+ * @phpstan-import-type ToolSearchToolType from ToolSearchTool
+ * @phpstan-import-type WebSearchToolType from WebSearchTool
+ *
+ * @phpstan-type ResponseToolObjectTypes array<int, CodeInterpreterToolType|ComputerUseToolType|CustomToolType|FileSearchToolType|FunctionToolType|ImageGenerationToolType|NamespaceToolType|RemoteMcpToolType|ToolSearchToolType|WebSearchToolType>
+ * @phpstan-type ResponseToolObjectReturnType array<int, CodeInterpreterTool|ComputerUseTool|CustomTool|FileSearchTool|FunctionTool|ImageGenerationTool|NamespaceTool|RemoteMcpTool|ToolSearchTool|WebSearchTool>
  */
 final class ToolObjects
 {
@@ -28,18 +39,17 @@ final class ToolObjects
     public static function parse(array $toolItems): array
     {
         return array_map(
-            fn (array $tool): ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool|RemoteMcpTool|CodeInterpreterTool|ToolSearchTool|NamespaceTool|CustomTool => match ($tool['type']) {
-                'file_search' => FileSearchTool::from($tool), // @phpstan-ignore-line
-                'web_search', 'web_search_preview', 'web_search_preview_2025_03_11' => WebSearchTool::from($tool), // @phpstan-ignore-line
-                'function' => FunctionTool::from($tool), // @phpstan-ignore-line
-                'computer_use_preview' => ComputerUseTool::from($tool), // @phpstan-ignore-line
-                'image_generation' => ImageGenerationTool::from($tool), // @phpstan-ignore-line
-                'mcp' => RemoteMcpTool::from($tool), // @phpstan-ignore-line
-                'code_interpreter' => CodeInterpreterTool::from($tool), // @phpstan-ignore-line
-                'tool_search' => ToolSearchTool::from($tool), // @phpstan-ignore-line
-                'namespace' => NamespaceTool::from($tool), // @phpstan-ignore-line
-                'custom' => CustomTool::from($tool), // @phpstan-ignore-line
-                default => throw new \InvalidArgumentException("Unknown tool type: {$tool['type']}"),
+            fn (array $tool): CodeInterpreterTool|ComputerUseTool|CustomTool|FileSearchTool|FunctionTool|ImageGenerationTool|NamespaceTool|RemoteMcpTool|ToolSearchTool|WebSearchTool => match ($tool['type']) {
+                'file_search' => FileSearchTool::from($tool),
+                'web_search', 'web_search_preview', 'web_search_preview_2025_03_11' => WebSearchTool::from($tool),
+                'function' => FunctionTool::from($tool),
+                'computer_use_preview' => ComputerUseTool::from($tool),
+                'image_generation' => ImageGenerationTool::from($tool),
+                'mcp' => RemoteMcpTool::from($tool),
+                'code_interpreter' => CodeInterpreterTool::from($tool),
+                'tool_search' => ToolSearchTool::from($tool),
+                'namespace' => NamespaceTool::from($tool),
+                'custom' => CustomTool::from($tool),
             },
             $toolItems,
         );

--- a/src/Actions/Responses/ToolObjects.php
+++ b/src/Actions/Responses/ToolObjects.php
@@ -6,6 +6,7 @@ namespace OpenAI\Actions\Responses;
 
 use OpenAI\Responses\Responses\Tool\CodeInterpreterTool;
 use OpenAI\Responses\Responses\Tool\ComputerUseTool;
+use OpenAI\Responses\Responses\Tool\CustomTool;
 use OpenAI\Responses\Responses\Tool\FileSearchTool;
 use OpenAI\Responses\Responses\Tool\FunctionTool;
 use OpenAI\Responses\Responses\Tool\ImageGenerationTool;
@@ -24,9 +25,10 @@ use OpenAI\Responses\Responses\Tool\WebSearchTool;
  * @phpstan-import-type CodeInterpreterToolType from CodeInterpreterTool
  * @phpstan-import-type ToolSearchToolType from ToolSearchTool
  * @phpstan-import-type NamespaceToolType from NamespaceTool
+ * @phpstan-import-type CustomToolType from CustomTool
  *
- * @phpstan-type ResponseToolObjectTypes array<int, ComputerUseToolType|FileSearchToolType|FunctionToolType|WebSearchToolType|ImageGenerationToolType|RemoteMcpToolType|CodeInterpreterToolType|ToolSearchToolType|NamespaceToolType>
- * @phpstan-type ResponseToolObjectReturnType array<int, ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool|RemoteMcpTool|CodeInterpreterTool|ToolSearchTool|NamespaceTool>
+ * @phpstan-type ResponseToolObjectTypes array<int, ComputerUseToolType|FileSearchToolType|FunctionToolType|WebSearchToolType|ImageGenerationToolType|RemoteMcpToolType|CodeInterpreterToolType|ToolSearchToolType|NamespaceToolType|CustomToolType>
+ * @phpstan-type ResponseToolObjectReturnType array<int, ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool|RemoteMcpTool|CodeInterpreterTool|ToolSearchTool|NamespaceTool|CustomToolType>
  */
 final class ToolObjects
 {
@@ -37,7 +39,7 @@ final class ToolObjects
     public static function parse(array $toolItems): array
     {
         return array_map(
-            fn (array $tool): ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool|RemoteMcpTool|CodeInterpreterTool|ToolSearchTool|NamespaceTool => match ($tool['type']) {
+            fn (array $tool): ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool|RemoteMcpTool|CodeInterpreterTool|ToolSearchTool|NamespaceTool|CustomTool => match ($tool['type']) {
                 'file_search' => FileSearchTool::from($tool),
                 'web_search', 'web_search_preview', 'web_search_preview_2025_03_11' => WebSearchTool::from($tool),
                 'function' => FunctionTool::from($tool),
@@ -47,6 +49,7 @@ final class ToolObjects
                 'code_interpreter' => CodeInterpreterTool::from($tool),
                 'tool_search' => ToolSearchTool::from($tool),
                 'namespace' => NamespaceTool::from($tool),
+                'custom' => CustomTool::from($tool),
             },
             $toolItems,
         );

--- a/src/Responses/Responses/CreateResponse.php
+++ b/src/Responses/Responses/CreateResponse.php
@@ -25,13 +25,17 @@ use OpenAI\Responses\Responses\Output\OutputMcpCall;
 use OpenAI\Responses\Responses\Output\OutputMcpListTools;
 use OpenAI\Responses\Responses\Output\OutputMessage;
 use OpenAI\Responses\Responses\Output\OutputReasoning;
+use OpenAI\Responses\Responses\Output\OutputToolSearchCall;
+use OpenAI\Responses\Responses\Output\OutputToolSearchOutput;
 use OpenAI\Responses\Responses\Output\OutputWebSearchToolCall;
 use OpenAI\Responses\Responses\Tool\CodeInterpreterTool;
 use OpenAI\Responses\Responses\Tool\ComputerUseTool;
 use OpenAI\Responses\Responses\Tool\FileSearchTool;
 use OpenAI\Responses\Responses\Tool\FunctionTool;
 use OpenAI\Responses\Responses\Tool\ImageGenerationTool;
+use OpenAI\Responses\Responses\Tool\NamespaceTool;
 use OpenAI\Responses\Responses\Tool\RemoteMcpTool;
+use OpenAI\Responses\Responses\Tool\ToolSearchTool;
 use OpenAI\Responses\Responses\Tool\WebSearchTool;
 use OpenAI\Responses\Responses\ToolChoice\FunctionToolChoice;
 use OpenAI\Responses\Responses\ToolChoice\HostedToolChoice;
@@ -47,6 +51,9 @@ use OpenAI\Testing\Responses\Concerns\Fakeable;
  * @phpstan-import-type ResponseOutputObjectTypes from OutputObjects
  * @phpstan-import-type ResponseToolChoiceTypes from ToolChoiceObjects
  * @phpstan-import-type ResponseToolObjectTypes from ToolObjects
+ * @phpstan-import-type ResponseOutputObjectReturnType from OutputObjects
+ * @phpstan-import-type ResponseToolChoiceReturnType from ToolChoiceObjects
+ * @phpstan-import-type ResponseToolObjectReturnType from ToolObjects
  *
  * @phpstan-type InstructionsType array<int, mixed>|string|null
  * @phpstan-type CreateResponseType array{id: string, background?: bool|null, object: 'response', created_at: int, status: 'completed'|'failed'|'in_progress'|'incomplete', error: ErrorType|null, incomplete_details?: IncompleteDetailsType|null, instructions: InstructionsType, max_output_tokens?: int|null, max_tool_calls?: int|null, model: string, output: ResponseOutputObjectTypes, output_text: string|null, parallel_tool_calls: bool, previous_response_id?: string|null, prompt: ReferencePromptObjectType|null, prompt_cache_key?: string|null, reasoning?: ReasoningType|null, safety_identifier?: string|null, service_tier?: string|null, store?: bool|null, temperature?: float|null, text?: ResponseFormatType|null, tool_choice: ResponseToolChoiceTypes, tools: ResponseToolObjectTypes, top_logprobs?: int|null, top_p?: float|null, truncation?: 'auto'|'disabled'|null, usage?: UsageType|null, user?: string|null, verbosity?: string|null, metadata?: array<string, string>|null}
@@ -67,8 +74,8 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
      * @param  'response'  $object
      * @param  'completed'|'failed'|'in_progress'|'incomplete'  $status
      * @param  array<int, mixed>|string|null  $instructions
-     * @param  array<int, OutputMessage|OutputComputerToolCall|OutputFileSearchToolCall|OutputWebSearchToolCall|OutputFunctionToolCall|OutputReasoning|OutputMcpListTools|OutputMcpApprovalRequest|OutputMcpCall|OutputImageGenerationToolCall|OutputCodeInterpreterToolCall|OutputLocalShellCall|OutputCustomToolCall>  $output
-     * @param  array<int, ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool|RemoteMcpTool|ImageGenerationTool|CodeInterpreterTool>  $tools
+     * @param  ResponseOutputObjectReturnType  $output
+     * @param  ResponseToolObjectReturnType  $tools
      * @param  'auto'|'disabled'|null  $truncation
      * @param  array<string, string>  $metadata
      */
@@ -187,7 +194,7 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
             'metadata' => $this->metadata ?? [],
             'model' => $this->model,
             'output' => array_map(
-                fn (OutputMessage|OutputComputerToolCall|OutputFileSearchToolCall|OutputWebSearchToolCall|OutputFunctionToolCall|OutputReasoning|OutputMcpListTools|OutputMcpApprovalRequest|OutputMcpCall|OutputImageGenerationToolCall|OutputCodeInterpreterToolCall|OutputLocalShellCall|OutputCustomToolCall $output): array => $output->toArray(),
+                fn (OutputMessage|OutputComputerToolCall|OutputFileSearchToolCall|OutputWebSearchToolCall|OutputFunctionToolCall|OutputReasoning|OutputMcpListTools|OutputMcpApprovalRequest|OutputMcpCall|OutputImageGenerationToolCall|OutputCodeInterpreterToolCall|OutputLocalShellCall|OutputCustomToolCall|OutputToolSearchCall|OutputToolSearchOutput $output): array => $output->toArray(),
                 $this->output
             ),
             'parallel_tool_calls' => $this->parallelToolCalls,
@@ -204,7 +211,7 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
                 ? $this->toolChoice
                 : $this->toolChoice->toArray(),
             'tools' => array_map(
-                fn (ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool|RemoteMcpTool|CodeInterpreterTool $tool): array => $tool->toArray(),
+                fn (ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool|RemoteMcpTool|CodeInterpreterTool|ToolSearchTool|NamespaceTool $tool): array => $tool->toArray(),
                 $this->tools
             ),
             'top_logprobs' => $this->topLogProbs,

--- a/src/Responses/Responses/CreateResponse.php
+++ b/src/Responses/Responses/CreateResponse.php
@@ -30,6 +30,7 @@ use OpenAI\Responses\Responses\Output\OutputToolSearchOutput;
 use OpenAI\Responses\Responses\Output\OutputWebSearchToolCall;
 use OpenAI\Responses\Responses\Tool\CodeInterpreterTool;
 use OpenAI\Responses\Responses\Tool\ComputerUseTool;
+use OpenAI\Responses\Responses\Tool\CustomTool;
 use OpenAI\Responses\Responses\Tool\FileSearchTool;
 use OpenAI\Responses\Responses\Tool\FunctionTool;
 use OpenAI\Responses\Responses\Tool\ImageGenerationTool;
@@ -211,7 +212,7 @@ final class CreateResponse implements ResponseContract, ResponseHasMetaInformati
                 ? $this->toolChoice
                 : $this->toolChoice->toArray(),
             'tools' => array_map(
-                fn (ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool|RemoteMcpTool|CodeInterpreterTool|ToolSearchTool|NamespaceTool $tool): array => $tool->toArray(),
+                fn (ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool|RemoteMcpTool|CodeInterpreterTool|ToolSearchTool|NamespaceTool|CustomTool $tool): array => $tool->toArray(),
                 $this->tools
             ),
             'top_logprobs' => $this->topLogProbs,

--- a/src/Responses/Responses/Output/OutputToolSearchCall.php
+++ b/src/Responses/Responses/Output/OutputToolSearchCall.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Responses\Responses\Output;
+
+use OpenAI\Contracts\ResponseContract;
+use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * @phpstan-type OutputToolSearchCallType array{id: string, arguments: mixed, call_id: ?string, execution: 'server'|'client', status: 'in_progress'|'completed'|'incomplete', type: 'tool_search_call', created_by?: ?string}
+ *
+ * @implements ResponseContract<OutputToolSearchCallType>
+ */
+final class OutputToolSearchCall implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<OutputToolSearchCallType>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+
+    /**
+     * @param  'server'|'client'  $execution
+     * @param  'in_progress'|'completed'|'incomplete'  $status
+     * @param  'tool_search_call'  $type
+     */
+    private function __construct(
+        public readonly string $id,
+        public readonly mixed $arguments,
+        public readonly ?string $callId,
+        public readonly string $execution,
+        public readonly string $status,
+        public readonly string $type,
+        public readonly ?string $createdBy,
+    ) {}
+
+    /**
+     * @param  OutputToolSearchCallType  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            id: $attributes['id'],
+            arguments: $attributes['arguments'],
+            callId: $attributes['call_id'] ?? null,
+            execution: $attributes['execution'],
+            status: $attributes['status'],
+            type: $attributes['type'],
+            createdBy: $attributes['created_by'] ?? null,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'arguments' => $this->arguments,
+            'call_id' => $this->callId,
+            'execution' => $this->execution,
+            'status' => $this->status,
+            'type' => $this->type,
+            'createdBy' => $this->createdBy,
+        ];
+    }
+}

--- a/src/Responses/Responses/Output/OutputToolSearchCall.php
+++ b/src/Responses/Responses/Output/OutputToolSearchCall.php
@@ -65,7 +65,7 @@ final class OutputToolSearchCall implements ResponseContract
             'execution' => $this->execution,
             'status' => $this->status,
             'type' => $this->type,
-            'createdBy' => $this->createdBy,
+            'created_by' => $this->createdBy,
         ];
     }
 }

--- a/src/Responses/Responses/Output/OutputToolSearchOutput.php
+++ b/src/Responses/Responses/Output/OutputToolSearchOutput.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Responses\Responses\Output;
+
+use OpenAI\Contracts\ResponseContract;
+use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * @phpstan-type OutputToolSearchOutputType array{id: string, call_id: ?string, execution: 'server'|'client', status: 'in_progress'|'completed'|'incomplete', tools: mixed, type: 'tool_search_output', created_by?: ?string}
+ *
+ * @implements ResponseContract<OutputToolSearchOutputType>
+ */
+final class OutputToolSearchOutput implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<OutputToolSearchOutputType>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+
+    /**
+     * @param  'server'|'client'  $execution
+     * @param  'in_progress'|'completed'|'incomplete'  $status
+     * @param  'tool_search_output'  $type
+     */
+    private function __construct(
+        public readonly string $id,
+        public readonly ?string $callId,
+        public readonly string $execution,
+        public readonly string $status,
+        public readonly mixed $tools,
+        public readonly string $type,
+        public readonly ?string $createdBy,
+    ) {}
+
+    /**
+     * @param  OutputToolSearchOutputType  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            id: $attributes['id'],
+            callId: $attributes['call_id'] ?? null,
+            execution: $attributes['execution'],
+            status: $attributes['status'],
+            tools: $attributes['tools'],
+            type: $attributes['type'],
+            createdBy: $attributes['created_by'] ?? null,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'call_id' => $this->callId,
+            'execution' => $this->execution,
+            'status' => $this->status,
+            'tools' => $this->tools,
+            'type' => $this->type,
+            'created_by' => $this->createdBy,
+        ];
+    }
+}

--- a/src/Responses/Responses/Output/OutputToolSearchOutput.php
+++ b/src/Responses/Responses/Output/OutputToolSearchOutput.php
@@ -4,12 +4,26 @@ declare(strict_types=1);
 
 namespace OpenAI\Responses\Responses\Output;
 
+use OpenAI\Actions\Responses\ToolObjects;
 use OpenAI\Contracts\ResponseContract;
 use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Responses\Responses\Tool\CodeInterpreterTool;
+use OpenAI\Responses\Responses\Tool\ComputerUseTool;
+use OpenAI\Responses\Responses\Tool\CustomTool;
+use OpenAI\Responses\Responses\Tool\FileSearchTool;
+use OpenAI\Responses\Responses\Tool\FunctionTool;
+use OpenAI\Responses\Responses\Tool\ImageGenerationTool;
+use OpenAI\Responses\Responses\Tool\NamespaceTool;
+use OpenAI\Responses\Responses\Tool\RemoteMcpTool;
+use OpenAI\Responses\Responses\Tool\ToolSearchTool;
+use OpenAI\Responses\Responses\Tool\WebSearchTool;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
- * @phpstan-type OutputToolSearchOutputType array{id: string, call_id: ?string, execution: 'server'|'client', status: 'in_progress'|'completed'|'incomplete', tools: mixed, type: 'tool_search_output', created_by?: ?string}
+ * @phpstan-import-type ResponseToolObjectTypes from ToolObjects
+ * @phpstan-import-type ResponseToolObjectReturnType from ToolObjects
+ *
+ * @phpstan-type OutputToolSearchOutputType array{id: string, call_id: ?string, execution: 'server'|'client', status: 'in_progress'|'completed'|'incomplete', tools: ResponseToolObjectTypes, type: 'tool_search_output', created_by?: ?string}
  *
  * @implements ResponseContract<OutputToolSearchOutputType>
  */
@@ -25,6 +39,7 @@ final class OutputToolSearchOutput implements ResponseContract
     /**
      * @param  'server'|'client'  $execution
      * @param  'in_progress'|'completed'|'incomplete'  $status
+     * @param  ResponseToolObjectReturnType  $tools
      * @param  'tool_search_output'  $type
      */
     private function __construct(
@@ -32,7 +47,7 @@ final class OutputToolSearchOutput implements ResponseContract
         public readonly ?string $callId,
         public readonly string $execution,
         public readonly string $status,
-        public readonly mixed $tools,
+        public readonly array $tools,
         public readonly string $type,
         public readonly ?string $createdBy,
     ) {}
@@ -47,7 +62,7 @@ final class OutputToolSearchOutput implements ResponseContract
             callId: $attributes['call_id'] ?? null,
             execution: $attributes['execution'],
             status: $attributes['status'],
-            tools: $attributes['tools'],
+            tools: ToolObjects::parse($attributes['tools']),
             type: $attributes['type'],
             createdBy: $attributes['created_by'] ?? null,
         );
@@ -63,7 +78,10 @@ final class OutputToolSearchOutput implements ResponseContract
             'call_id' => $this->callId,
             'execution' => $this->execution,
             'status' => $this->status,
-            'tools' => $this->tools,
+            'tools' => array_map(
+                fn (CodeInterpreterTool|ComputerUseTool|CustomTool|FileSearchTool|FunctionTool|ImageGenerationTool|NamespaceTool|RemoteMcpTool|ToolSearchTool|WebSearchTool $tool): array => $tool->toArray(),
+                $this->tools,
+            ),
             'type' => $this->type,
             'created_by' => $this->createdBy,
         ];

--- a/src/Responses/Responses/RetrieveResponse.php
+++ b/src/Responses/Responses/RetrieveResponse.php
@@ -30,6 +30,7 @@ use OpenAI\Responses\Responses\Output\OutputToolSearchOutput;
 use OpenAI\Responses\Responses\Output\OutputWebSearchToolCall;
 use OpenAI\Responses\Responses\Tool\CodeInterpreterTool;
 use OpenAI\Responses\Responses\Tool\ComputerUseTool;
+use OpenAI\Responses\Responses\Tool\CustomTool;
 use OpenAI\Responses\Responses\Tool\FileSearchTool;
 use OpenAI\Responses\Responses\Tool\FunctionTool;
 use OpenAI\Responses\Responses\Tool\ImageGenerationTool;
@@ -212,7 +213,7 @@ final class RetrieveResponse implements ResponseContract, ResponseHasMetaInforma
                 ? $this->toolChoice
                 : $this->toolChoice->toArray(),
             'tools' => array_map(
-                fn (ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool|RemoteMcpTool|CodeInterpreterTool|ToolSearchTool|NamespaceTool $tool): array => $tool->toArray(),
+                fn (ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool|RemoteMcpTool|CodeInterpreterTool|ToolSearchTool|NamespaceTool|CustomTool $tool): array => $tool->toArray(),
                 $this->tools
             ),
             'top_logprobs' => $this->topLogProbs,

--- a/src/Responses/Responses/RetrieveResponse.php
+++ b/src/Responses/Responses/RetrieveResponse.php
@@ -25,13 +25,17 @@ use OpenAI\Responses\Responses\Output\OutputMcpCall;
 use OpenAI\Responses\Responses\Output\OutputMcpListTools;
 use OpenAI\Responses\Responses\Output\OutputMessage;
 use OpenAI\Responses\Responses\Output\OutputReasoning;
+use OpenAI\Responses\Responses\Output\OutputToolSearchCall;
+use OpenAI\Responses\Responses\Output\OutputToolSearchOutput;
 use OpenAI\Responses\Responses\Output\OutputWebSearchToolCall;
 use OpenAI\Responses\Responses\Tool\CodeInterpreterTool;
 use OpenAI\Responses\Responses\Tool\ComputerUseTool;
 use OpenAI\Responses\Responses\Tool\FileSearchTool;
 use OpenAI\Responses\Responses\Tool\FunctionTool;
 use OpenAI\Responses\Responses\Tool\ImageGenerationTool;
+use OpenAI\Responses\Responses\Tool\NamespaceTool;
 use OpenAI\Responses\Responses\Tool\RemoteMcpTool;
+use OpenAI\Responses\Responses\Tool\ToolSearchTool;
 use OpenAI\Responses\Responses\Tool\WebSearchTool;
 use OpenAI\Responses\Responses\ToolChoice\FunctionToolChoice;
 use OpenAI\Responses\Responses\ToolChoice\HostedToolChoice;
@@ -47,6 +51,9 @@ use OpenAI\Testing\Responses\Concerns\Fakeable;
  * @phpstan-import-type ResponseOutputObjectTypes from OutputObjects
  * @phpstan-import-type ResponseToolChoiceTypes from ToolChoiceObjects
  * @phpstan-import-type ResponseToolObjectTypes from ToolObjects
+ * @phpstan-import-type ResponseOutputObjectReturnType from OutputObjects
+ * @phpstan-import-type ResponseToolChoiceReturnType from ToolChoiceObjects
+ * @phpstan-import-type ResponseToolObjectReturnType from ToolObjects
  *
  * @phpstan-type InstructionsType array<int, mixed>|string|null
  * @phpstan-type RetrieveResponseType array{id: string, background?: bool|null, object: 'response', created_at: int, status: 'completed'|'failed'|'in_progress'|'incomplete', error: ErrorType|null, incomplete_details?: IncompleteDetailsType|null, instructions: InstructionsType, max_output_tokens?: int|null, max_tool_calls?: int|null, model: string, output: ResponseOutputObjectTypes, output_text: string|null, parallel_tool_calls: bool, previous_response_id?: string|null, prompt: ReferencePromptObjectType|null, prompt_cache_key?: string|null, reasoning?: ReasoningType|null, safety_identifier?: string|null, service_tier?: string|null, store?: bool|null, temperature?: float|null, text?: ResponseFormatType|null, tool_choice: ResponseToolChoiceTypes, tools: ResponseToolObjectTypes, top_logprobs?: int|null, top_p?: float|null, truncation?: 'auto'|'disabled'|null, usage?: UsageType|null, user?: string|null, verbosity?: string|null, metadata?: array<string, string>|null}
@@ -67,8 +74,8 @@ final class RetrieveResponse implements ResponseContract, ResponseHasMetaInforma
      * @param  'response'  $object
      * @param  'completed'|'failed'|'in_progress'|'incomplete'  $status
      * @param  array<int, mixed>|string|null  $instructions
-     * @param  array<int, OutputMessage|OutputComputerToolCall|OutputFileSearchToolCall|OutputWebSearchToolCall|OutputFunctionToolCall|OutputReasoning|OutputMcpListTools|OutputMcpApprovalRequest|OutputMcpCall|OutputImageGenerationToolCall|OutputCodeInterpreterToolCall|OutputLocalShellCall|OutputCustomToolCall>  $output
-     * @param  array<int, ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool|RemoteMcpTool|ImageGenerationTool|CodeInterpreterTool>  $tools
+     * @param  ResponseOutputObjectReturnType  $output
+     * @param  ResponseToolObjectReturnType  $tools
      * @param  'auto'|'disabled'|null  $truncation
      * @param  array<string, string>  $metadata
      */
@@ -187,7 +194,7 @@ final class RetrieveResponse implements ResponseContract, ResponseHasMetaInforma
             'metadata' => $this->metadata ?? [],
             'model' => $this->model,
             'output' => array_map(
-                fn (OutputMessage|OutputComputerToolCall|OutputFileSearchToolCall|OutputWebSearchToolCall|OutputFunctionToolCall|OutputReasoning|OutputMcpListTools|OutputMcpApprovalRequest|OutputMcpCall|OutputImageGenerationToolCall|OutputCodeInterpreterToolCall|OutputLocalShellCall|OutputCustomToolCall $output): array => $output->toArray(),
+                fn (OutputMessage|OutputComputerToolCall|OutputFileSearchToolCall|OutputWebSearchToolCall|OutputFunctionToolCall|OutputReasoning|OutputMcpListTools|OutputMcpApprovalRequest|OutputMcpCall|OutputImageGenerationToolCall|OutputCodeInterpreterToolCall|OutputLocalShellCall|OutputCustomToolCall|OutputToolSearchCall|OutputToolSearchOutput $output): array => $output->toArray(),
                 $this->output
             ),
             'output_text' => $this->outputText,
@@ -205,7 +212,7 @@ final class RetrieveResponse implements ResponseContract, ResponseHasMetaInforma
                 ? $this->toolChoice
                 : $this->toolChoice->toArray(),
             'tools' => array_map(
-                fn (ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool|RemoteMcpTool|CodeInterpreterTool $tool): array => $tool->toArray(),
+                fn (ComputerUseTool|FileSearchTool|FunctionTool|WebSearchTool|ImageGenerationTool|RemoteMcpTool|CodeInterpreterTool|ToolSearchTool|NamespaceTool $tool): array => $tool->toArray(),
                 $this->tools
             ),
             'top_logprobs' => $this->topLogProbs,

--- a/src/Responses/Responses/Tool/CustomTool.php
+++ b/src/Responses/Responses/Tool/CustomTool.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Responses\Responses\Tool;
+
+use OpenAI\Actions\Responses\CustomToolInputObjects;
+use OpenAI\Contracts\ResponseContract;
+use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Responses\Responses\Tool\CustomToolInputs\GrammarInput;
+use OpenAI\Responses\Responses\Tool\CustomToolInputs\TextInput;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * @phpstan-import-type CustomToolInputTypes from CustomToolInputObjects
+ *
+ * @phpstan-type CustomToolType array{name: string, type: 'custom', defer_loading?: bool, description?: string, format?: CustomToolInputTypes}
+ *
+ * @implements ResponseContract<CustomToolType>
+ */
+final class CustomTool implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<CustomToolType>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+
+    /**
+     * @param  'custom'  $type
+     */
+    private function __construct(
+        public readonly string $name,
+        public readonly string $type,
+        public readonly ?bool $deferLoading = null,
+        public readonly ?string $description = null,
+        public readonly TextInput|GrammarInput|null $format = null,
+    ) {}
+
+    /**
+     * @param  CustomToolType  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            name: $attributes['name'],
+            type: $attributes['type'],
+            deferLoading: $attributes['defer_loading'] ?? null,
+            description: $attributes['description'] ?? null,
+            format: isset($attributes['format'])
+                ? CustomToolInputObjects::parse($attributes['format'])
+                : null,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return array_filter([
+            'name' => $this->name,
+            'type' => $this->type,
+            'defer_loading' => $this->deferLoading,
+            'description' => $this->description,
+            'format' => $this->format?->toArray(),
+        ], fn (mixed $value): bool => $value !== null);
+    }
+}

--- a/src/Responses/Responses/Tool/CustomToolInputs/GrammarInput.php
+++ b/src/Responses/Responses/Tool/CustomToolInputs/GrammarInput.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Responses\Responses\Tool\CustomToolInputs;
+
+use OpenAI\Contracts\ResponseContract;
+use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * @phpstan-type GrammarInputType array{type: 'grammar', definition: string, syntax: string}
+ *
+ * @implements ResponseContract<GrammarInputType>
+ */
+final class GrammarInput implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<GrammarInputType>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+
+    /**
+     * @param  'grammar'  $type
+     */
+    private function __construct(
+        public readonly string $type,
+        public readonly string $definition,
+        public readonly string $syntax,
+    ) {}
+
+    /**
+     * @param  GrammarInputType  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            type: $attributes['type'],
+            definition: $attributes['definition'],
+            syntax: $attributes['syntax'],
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'type' => $this->type,
+            'definition' => $this->definition,
+            'syntax' => $this->syntax,
+        ];
+    }
+}

--- a/src/Responses/Responses/Tool/CustomToolInputs/TextInput.php
+++ b/src/Responses/Responses/Tool/CustomToolInputs/TextInput.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Responses\Responses\Tool\CustomToolInputs;
+
+use OpenAI\Contracts\ResponseContract;
+use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * @phpstan-type TextInputType array{type: 'text'}
+ *
+ * @implements ResponseContract<TextInputType>
+ */
+final class TextInput implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<TextInputType>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+
+    /**
+     * @param  'text'  $type
+     */
+    private function __construct(
+        public readonly string $type,
+    ) {}
+
+    /**
+     * @param  TextInputType  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            type: $attributes['type'],
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'type' => $this->type,
+        ];
+    }
+}

--- a/src/Responses/Responses/Tool/NamespaceTool.php
+++ b/src/Responses/Responses/Tool/NamespaceTool.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Responses\Responses\Tool;
+
+use OpenAI\Contracts\ResponseContract;
+use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * @phpstan-type NamespaceToolType array{description: string, name: string, tools: mixed, type: 'namespace'}
+ *
+ * @implements ResponseContract<NamespaceToolType>
+ */
+final class NamespaceTool implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<NamespaceToolType>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+
+    /**
+     * @param  'namespace'  $type
+     */
+    private function __construct(
+        public readonly string $description,
+        public readonly string $name,
+        public readonly mixed $tools,
+        public readonly string $type,
+    ) {}
+
+    /**
+     * @param  NamespaceToolType  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            description: $attributes['description'],
+            name: $attributes['name'],
+            tools: $attributes['tools'],
+            type: $attributes['type'],
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'description' => $this->description,
+            'name' => $this->name,
+            'tools' => $this->tools,
+            'type' => $this->type,
+        ];
+    }
+}

--- a/src/Responses/Responses/Tool/NamespaceTool.php
+++ b/src/Responses/Responses/Tool/NamespaceTool.php
@@ -4,12 +4,19 @@ declare(strict_types=1);
 
 namespace OpenAI\Responses\Responses\Tool;
 
+use OpenAI\Actions\Responses\ToolObjects;
 use OpenAI\Contracts\ResponseContract;
 use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Responses\Responses\Tool\CustomTool;
+use OpenAI\Responses\Responses\Tool\FunctionTool;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
- * @phpstan-type NamespaceToolType array{description: string, name: string, tools: mixed, type: 'namespace'}
+ * @phpstan-import-type FunctionToolType from FunctionTool
+ * @phpstan-import-type CustomToolType from CustomTool
+ * @phpstan-import-type ResponseToolObjectReturnType from ToolObjects
+ *
+ * @phpstan-type NamespaceToolType array{description: string, name: string, tools: array<int, FunctionToolType|CustomToolType>, type: 'namespace'}
  *
  * @implements ResponseContract<NamespaceToolType>
  */
@@ -24,11 +31,12 @@ final class NamespaceTool implements ResponseContract
 
     /**
      * @param  'namespace'  $type
+     * @param  array<int, FunctionTool|CustomTool>  $tools
      */
     private function __construct(
         public readonly string $description,
         public readonly string $name,
-        public readonly mixed $tools,
+        public readonly array $tools,
         public readonly string $type,
     ) {}
 
@@ -37,10 +45,13 @@ final class NamespaceTool implements ResponseContract
      */
     public static function from(array $attributes): self
     {
+        /** @var array<int, FunctionTool|CustomTool> $tools */
+        $tools = ToolObjects::parse($attributes['tools']);
+
         return new self(
             description: $attributes['description'],
             name: $attributes['name'],
-            tools: $attributes['tools'],
+            tools: $tools,
             type: $attributes['type'],
         );
     }
@@ -53,7 +64,10 @@ final class NamespaceTool implements ResponseContract
         return [
             'description' => $this->description,
             'name' => $this->name,
-            'tools' => $this->tools,
+            'tools' => array_map(
+                fn (FunctionTool|CustomTool $tool): array => $tool->toArray(),
+                $this->tools,
+            ),
             'type' => $this->type,
         ];
     }

--- a/src/Responses/Responses/Tool/NamespaceTool.php
+++ b/src/Responses/Responses/Tool/NamespaceTool.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace OpenAI\Responses\Responses\Tool;
 
-use OpenAI\Actions\Responses\ToolObjects;
+use OpenAI\Actions\Responses\NamespaceToolObjects;
 use OpenAI\Contracts\ResponseContract;
 use OpenAI\Responses\Concerns\ArrayAccessible;
-use OpenAI\Responses\Responses\Tool\CustomTool;
-use OpenAI\Responses\Responses\Tool\FunctionTool;
+use OpenAI\Responses\Responses\Tool\NamespaceTools\CustomTool;
+use OpenAI\Responses\Responses\Tool\NamespaceTools\FunctionTool;
 use OpenAI\Testing\Responses\Concerns\Fakeable;
 
 /**
  * @phpstan-import-type FunctionToolType from FunctionTool
  * @phpstan-import-type CustomToolType from CustomTool
- * @phpstan-import-type ResponseToolObjectReturnType from ToolObjects
+ * @phpstan-import-type ResponseNamespaceToolObjectReturnType from NamespaceToolObjects
  *
  * @phpstan-type NamespaceToolType array{description: string, name: string, tools: array<int, FunctionToolType|CustomToolType>, type: 'namespace'}
  *
@@ -46,7 +46,7 @@ final class NamespaceTool implements ResponseContract
     public static function from(array $attributes): self
     {
         /** @var array<int, FunctionTool|CustomTool> $tools */
-        $tools = ToolObjects::parse($attributes['tools']);
+        $tools = NamespaceToolObjects::parse($attributes['tools']);
 
         return new self(
             description: $attributes['description'],

--- a/src/Responses/Responses/Tool/NamespaceTools/CustomTool.php
+++ b/src/Responses/Responses/Tool/NamespaceTools/CustomTool.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Responses\Responses\Tool\NamespaceTools;
+
+use OpenAI\Actions\Responses\CustomToolInputObjects;
+use OpenAI\Contracts\ResponseContract;
+use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Responses\Responses\Tool\CustomToolInputs\GrammarInput;
+use OpenAI\Responses\Responses\Tool\CustomToolInputs\TextInput;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * @phpstan-import-type CustomToolInputTypes from CustomToolInputObjects
+ *
+ * @phpstan-type CustomToolType array{name: string, type: 'custom', defer_loading?: bool, description?: string, format?: CustomToolInputTypes}
+ *
+ * @implements ResponseContract<CustomToolType>
+ */
+final class CustomTool implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<CustomToolType>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+
+    /**
+     * @param  'custom'  $type
+     */
+    private function __construct(
+        public readonly string $name,
+        public readonly string $type,
+        public readonly ?bool $deferLoading = null,
+        public readonly ?string $description = null,
+        public readonly TextInput|GrammarInput|null $format = null,
+    ) {}
+
+    /**
+     * @param  CustomToolType  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            name: $attributes['name'],
+            type: $attributes['type'],
+            deferLoading: $attributes['defer_loading'] ?? null,
+            description: $attributes['description'] ?? null,
+            format: isset($attributes['format'])
+                ? CustomToolInputObjects::parse($attributes['format'])
+                : null,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return array_filter([
+            'name' => $this->name,
+            'type' => $this->type,
+            'defer_loading' => $this->deferLoading,
+            'description' => $this->description,
+            'format' => $this->format?->toArray(),
+        ], fn (mixed $value): bool => $value !== null);
+    }
+}

--- a/src/Responses/Responses/Tool/NamespaceTools/FunctionTool.php
+++ b/src/Responses/Responses/Tool/NamespaceTools/FunctionTool.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Responses\Responses\Tool\NamespaceTools;
+
+use OpenAI\Contracts\ResponseContract;
+use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * @phpstan-type FunctionToolType array{name: string, parameters: array<string, mixed>, strict: bool, type: 'function', description: ?string}
+ *
+ * @implements ResponseContract<FunctionToolType>
+ */
+final class FunctionTool implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<FunctionToolType>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+
+    /**
+     * @param  array<string, mixed>  $parameters
+     * @param  'function'  $type
+     */
+    private function __construct(
+        public readonly string $name,
+        public readonly array $parameters,
+        public readonly bool $strict,
+        public readonly string $type,
+        public readonly ?string $description = null,
+    ) {}
+
+    /**
+     * @param  FunctionToolType  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            name: $attributes['name'],
+            parameters: $attributes['parameters'],
+            strict: $attributes['strict'],
+            type: $attributes['type'],
+            description: $attributes['description'] ?? null,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'parameters' => $this->parameters,
+            'strict' => $this->strict,
+            'type' => $this->type,
+            'description' => $this->description,
+        ];
+    }
+}

--- a/src/Responses/Responses/Tool/ToolSearchTool.php
+++ b/src/Responses/Responses/Tool/ToolSearchTool.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenAI\Responses\Responses\Tool;
+
+use OpenAI\Contracts\ResponseContract;
+use OpenAI\Responses\Concerns\ArrayAccessible;
+use OpenAI\Testing\Responses\Concerns\Fakeable;
+
+/**
+ * @phpstan-type ToolSearchToolType array{type: 'tool_search', description?: ?string, execution?: null|'server'|'client', parameters: mixed}
+ *
+ * @implements ResponseContract<ToolSearchToolType>
+ */
+final class ToolSearchTool implements ResponseContract
+{
+    /**
+     * @use ArrayAccessible<ToolSearchToolType>
+     */
+    use ArrayAccessible;
+
+    use Fakeable;
+
+    /**
+     * @param  'tool_search'  $type
+     * @param  'server'|'client'|null  $execution
+     */
+    private function __construct(
+        public readonly string $type,
+        public readonly ?string $description,
+        public readonly ?string $execution,
+        public readonly mixed $parameters
+    ) {}
+
+    /**
+     * @param  ToolSearchToolType  $attributes
+     */
+    public static function from(array $attributes): self
+    {
+        return new self(
+            type: $attributes['type'],
+            description: $attributes['description'] ?? null,
+            execution: $attributes['execution'] ?? null,
+            parameters: $attributes['parameters'],
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'type' => $this->type,
+            'description' => $this->description,
+            'execution' => $this->execution,
+            'parameters' => $this->parameters,
+        ];
+    }
+}

--- a/tests/Fixtures/Responses.php
+++ b/tests/Fixtures/Responses.php
@@ -971,7 +971,13 @@ function outputToolSearchOutput(): array
         'call_id' => 'call_67ccf18f64008190a39b619f4c8455ef087bb177ab789d5c',
         'execution' => 'server',
         'status' => 'completed',
-        'tools' => [],
+        'tools' => [
+            [
+                'type' => 'web_search',
+                'search_context_size' => 'low',
+                'user_location' => null,
+            ],
+        ],
         'type' => 'tool_search_output',
         'created_by' => 'user_123',
     ];

--- a/tests/Fixtures/Responses.php
+++ b/tests/Fixtures/Responses.php
@@ -904,6 +904,64 @@ function toolFileSearchNestedFilters(): array
 }
 
 /**
+ * @return array<string, mixed>
+ */
+function toolNamespace(): array
+{
+    return [
+        'description' => 'A namespace of tools.',
+        'name' => 'my_namespace',
+        'tools' => [],
+        'type' => 'namespace',
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function toolToolSearch(): array
+{
+    return [
+        'type' => 'tool_search',
+        'description' => 'A tool for searching tools.',
+        'execution' => 'server',
+        'parameters' => [],
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function outputToolSearchCall(): array
+{
+    return [
+        'id' => 'tsc_67ccf18f64008190a39b619f4c8455ef087bb177ab789d5c',
+        'arguments' => [],
+        'call_id' => 'call_67ccf18f64008190a39b619f4c8455ef087bb177ab789d5c',
+        'execution' => 'server',
+        'status' => 'completed',
+        'type' => 'tool_search_call',
+        'created_by' => 'user_123',
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function outputToolSearchOutput(): array
+{
+    return [
+        'id' => 'tso_67ccf18f64008190a39b619f4c8455ef087bb177ab789d5c',
+        'call_id' => 'call_67ccf18f64008190a39b619f4c8455ef087bb177ab789d5c',
+        'execution' => 'server',
+        'status' => 'completed',
+        'tools' => [],
+        'type' => 'tool_search_output',
+        'created_by' => 'user_123',
+    ];
+}
+
+/**
  * @return resource
  */
 function responseCompletionStream()

--- a/tests/Fixtures/Responses.php
+++ b/tests/Fixtures/Responses.php
@@ -906,6 +906,22 @@ function toolFileSearchNestedFilters(): array
 /**
  * @return array<string, mixed>
  */
+function toolCustom(): array
+{
+    return [
+        'name' => 'my_custom_tool',
+        'type' => 'custom',
+        'defer_loading' => false,
+        'description' => 'A custom tool.',
+        'format' => [
+            'type' => 'text',
+        ],
+    ];
+}
+
+/**
+ * @return array<string, mixed>
+ */
 function toolNamespace(): array
 {
     return [

--- a/tests/Responses/Responses/Output/OutputToolSearchCall.php
+++ b/tests/Responses/Responses/Output/OutputToolSearchCall.php
@@ -1,0 +1,31 @@
+<?php
+
+use OpenAI\Responses\Responses\Output\OutputToolSearchCall;
+
+test('from', function () {
+    $response = OutputToolSearchCall::from(outputToolSearchCall());
+
+    expect($response)
+        ->toBeInstanceOf(OutputToolSearchCall::class)
+        ->id->toBe('tsc_67ccf18f64008190a39b619f4c8455ef087bb177ab789d5c')
+        ->arguments->toBeArray()
+        ->callId->toBe('call_67ccf18f64008190a39b619f4c8455ef087bb177ab789d5c')
+        ->execution->toBe('server')
+        ->status->toBe('completed')
+        ->type->toBe('tool_search_call')
+        ->createdBy->toBe('user_123');
+});
+
+test('as array accessible', function () {
+    $response = OutputToolSearchCall::from(outputToolSearchCall());
+
+    expect($response['id'])->toBe('tsc_67ccf18f64008190a39b619f4c8455ef087bb177ab789d5c');
+});
+
+test('to array', function () {
+    $response = OutputToolSearchCall::from(outputToolSearchCall());
+
+    expect($response->toArray())
+        ->toBeArray()
+        ->toBe(outputToolSearchCall());
+});

--- a/tests/Responses/Responses/Output/OutputToolSearchOutput.php
+++ b/tests/Responses/Responses/Output/OutputToolSearchOutput.php
@@ -1,0 +1,31 @@
+<?php
+
+use OpenAI\Responses\Responses\Output\OutputToolSearchOutput;
+
+test('from', function () {
+    $response = OutputToolSearchOutput::from(outputToolSearchOutput());
+
+    expect($response)
+        ->toBeInstanceOf(OutputToolSearchOutput::class)
+        ->id->toBe('tso_67ccf18f64008190a39b619f4c8455ef087bb177ab789d5c')
+        ->callId->toBe('call_67ccf18f64008190a39b619f4c8455ef087bb177ab789d5c')
+        ->execution->toBe('server')
+        ->status->toBe('completed')
+        ->tools->toBeArray()
+        ->type->toBe('tool_search_output')
+        ->createdBy->toBe('user_123');
+});
+
+test('as array accessible', function () {
+    $response = OutputToolSearchOutput::from(outputToolSearchOutput());
+
+    expect($response['id'])->toBe('tso_67ccf18f64008190a39b619f4c8455ef087bb177ab789d5c');
+});
+
+test('to array', function () {
+    $response = OutputToolSearchOutput::from(outputToolSearchOutput());
+
+    expect($response->toArray())
+        ->toBeArray()
+        ->toBe(outputToolSearchOutput());
+});

--- a/tests/Responses/Responses/Output/OutputToolSearchOutput.php
+++ b/tests/Responses/Responses/Output/OutputToolSearchOutput.php
@@ -1,6 +1,7 @@
 <?php
 
 use OpenAI\Responses\Responses\Output\OutputToolSearchOutput;
+use OpenAI\Responses\Responses\Tool\WebSearchTool;
 
 test('from', function () {
     $response = OutputToolSearchOutput::from(outputToolSearchOutput());
@@ -12,6 +13,8 @@ test('from', function () {
         ->execution->toBe('server')
         ->status->toBe('completed')
         ->tools->toBeArray()
+        ->tools->toHaveCount(1)
+        ->tools->{0}->toBeInstanceOf(WebSearchTool::class)
         ->type->toBe('tool_search_output')
         ->createdBy->toBe('user_123');
 });

--- a/tests/Responses/Responses/Tool/CustomToolTest.php
+++ b/tests/Responses/Responses/Tool/CustomToolTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use OpenAI\Responses\Responses\Tool\CustomTool;
+use OpenAI\Responses\Responses\Tool\CustomToolInputs\TextInput;
+use OpenAI\Responses\Responses\Tool\NamespaceTool;
+
+test('from with custom tool', function () {
+    $response = CustomTool::from(toolCustom());
+
+    expect($response)
+        ->toBeInstanceOf(CustomTool::class)
+        ->name->toBe('my_custom_tool')
+        ->type->toBe('custom')
+        ->deferLoading->toBeFalse()
+        ->description->toBe('A custom tool.')
+        ->format->toBeInstanceOf(TextInput::class)
+        ->format->type->toBe('text');
+});
+
+test('to array with custom tool', function () {
+    $response = CustomTool::from(toolCustom());
+
+    expect($response->toArray())
+        ->toBeArray()
+        ->toBe(toolCustom());
+});
+
+test('namespace tool with custom tool', function () {
+    $data = toolNamespace();
+    $data['tools'] = [
+        toolCustom(),
+    ];
+
+    $response = NamespaceTool::from($data);
+
+    expect($response)
+        ->toBeInstanceOf(NamespaceTool::class)
+        ->tools->toHaveCount(1)
+        ->tools->{0}->toBeInstanceOf(CustomTool::class);
+
+    expect($response->toArray())
+        ->toBe($data);
+});

--- a/tests/Responses/Responses/Tool/CustomToolTest.php
+++ b/tests/Responses/Responses/Tool/CustomToolTest.php
@@ -3,6 +3,7 @@
 use OpenAI\Responses\Responses\Tool\CustomTool;
 use OpenAI\Responses\Responses\Tool\CustomToolInputs\TextInput;
 use OpenAI\Responses\Responses\Tool\NamespaceTool;
+use OpenAI\Responses\Responses\Tool\NamespaceTools\CustomTool as NamespaceCustomTool;
 
 test('from with custom tool', function () {
     $response = CustomTool::from(toolCustom());
@@ -36,7 +37,7 @@ test('namespace tool with custom tool', function () {
     expect($response)
         ->toBeInstanceOf(NamespaceTool::class)
         ->tools->toHaveCount(1)
-        ->tools->{0}->toBeInstanceOf(CustomTool::class);
+        ->tools->{0}->toBeInstanceOf(NamespaceCustomTool::class);
 
     expect($response->toArray())
         ->toBe($data);

--- a/tests/Responses/Responses/Tool/NamespaceTool.php
+++ b/tests/Responses/Responses/Tool/NamespaceTool.php
@@ -1,0 +1,28 @@
+<?php
+
+use OpenAI\Responses\Responses\Tool\NamespaceTool;
+
+test('from', function () {
+    $response = NamespaceTool::from(toolNamespace());
+
+    expect($response)
+        ->toBeInstanceOf(NamespaceTool::class)
+        ->description->toBe('A namespace of tools.')
+        ->name->toBe('my_namespace')
+        ->tools->toBeArray()
+        ->type->toBe('namespace');
+});
+
+test('as array accessible', function () {
+    $response = NamespaceTool::from(toolNamespace());
+
+    expect($response['type'])->toBe('namespace');
+});
+
+test('to array', function () {
+    $response = NamespaceTool::from(toolNamespace());
+
+    expect($response->toArray())
+        ->toBeArray()
+        ->toBe(toolNamespace());
+});

--- a/tests/Responses/Responses/Tool/ToolSearchTool.php
+++ b/tests/Responses/Responses/Tool/ToolSearchTool.php
@@ -1,0 +1,28 @@
+<?php
+
+use OpenAI\Responses\Responses\Tool\ToolSearchTool;
+
+test('from', function () {
+    $response = ToolSearchTool::from(toolToolSearch());
+
+    expect($response)
+        ->toBeInstanceOf(ToolSearchTool::class)
+        ->type->toBe('tool_search')
+        ->description->toBe('A tool for searching tools.')
+        ->execution->toBe('server')
+        ->parameters->toBeArray();
+});
+
+test('as array accessible', function () {
+    $response = ToolSearchTool::from(toolToolSearch());
+
+    expect($response['type'])->toBe('tool_search');
+});
+
+test('to array', function () {
+    $response = ToolSearchTool::from(toolToolSearch());
+
+    expect($response->toArray())
+        ->toBeArray()
+        ->toBe(toolToolSearch());
+});


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Context: [OpenAI Docs](https://developers.openai.com/api/reference/resources/responses/methods/create#(resource)%20responses%20%3E%20(model)%20response%20%3E%20(schema)%20%3E%20(property)%20tools%20%3E%20(items)%20%3E%20(variant)%2011%20%3E%20(property)%20tools%20%3E%20(items)%20%3E%20(variant)%200)

Types out everything related to `tool_search`. Which was a lot. First we needed the new response outputs of:

 * `tool_search_call` - Calling Tool Search
 * `tool_search_output` - Output from Tool Search

This meant we also had to increase our tools:

 * `tool_search` - New Tool
 * `namespace` - Groups Tools
 
Which led to discovering we missed introduction of the `custom_tool`. I also took this change to remove some duplication of types, which we can infer from importing types from another file.

### Related:

fixes: #771 