### PR TITLE
docs: add custom base URI gateway example

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,18 @@ $client = OpenAI::factory()
     ->make();
 ```
 
+The same factory pattern can be used with OpenAI-compatible gateways. For
+example, Tuning Engines exposes an OpenAI-compatible API for teams that want
+centralized model access, policy checks, audit logs, traces, and usage/cost
+reporting while keeping their PHP application code on this client:
+
+```php
+$client = OpenAI::factory()
+    ->withApiKey(getenv('TUNING_ENGINES_API_KEY'))
+    ->withBaseUri('https://api.tuningengines.com/v1')
+    ->make();
+```
+
 ## Usage
 
 ### `Models` Resource


### PR DESCRIPTION
## Summary
- add a small custom base URI example using Tuning Engines
- show the existing factory pattern with TUNING_ENGINES_API_KEY and https://api.tuningengines.com/v1
- keep the example limited to the README section that already documents custom base URIs

## Why
We are a Rails/PHP-friendly AI infrastructure team using this client with Tuning Engines. Since the README already documents custom base URI support, this gives PHP teams a concrete OpenAI-compatible gateway example for centralized model access, policy checks, traces, audit logs, and usage/cost reporting. It would mean a lot to us if this is useful for your users, and I am happy to adjust or shorten the wording.

## Validation
- git diff --check