### PR TITLE
Document environment-based custom base URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,17 @@ $client = OpenAI::factory()
     ->make();
 ```
 
+For applications that need to switch between OpenAI and another
+OpenAI-compatible endpoint in different environments, the base URI can be read
+from an environment variable:
+
+```php
+$client = OpenAI::factory()
+    ->withApiKey(getenv('OPENAI_API_KEY'))
+    ->withBaseUri(getenv('OPENAI_BASE_URI') ?: 'api.openai.com/v1')
+    ->make();
+```
+
 ## Usage
 
 ### `Models` Resource


### PR DESCRIPTION
This keeps the default OpenAI behavior unchanged while documenting a portable way to configure an OpenAI-compatible endpoint through an environment variable.\n\nWhy this may be useful:\n- local inference servers\n- private model gateways\n- self-hosted routers\n- observability and enterprise control planes\n\nThe example uses the existing withBaseUri() API and does not add a provider-specific integration.