### PR TITLE
docs: fix typo in README.md (reponse -> response)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2988,7 +2988,7 @@ $meta->toArray();
 // ]
 ```
 
-On streaming responses you can access the meta information on the reponse stream object.
+On streaming responses you can access the meta information on the response stream object.
 
 ```php
 $stream = $client->completions()->createStreamed([


### PR DESCRIPTION
## Summary

Fixed a typo in README.md: `reponse` → `response`.

### Changes

- Corrected "reponse" to "response" in the streaming responses section

### Context

Found while reviewing the documentation for the streaming responses feature.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
