### PR TITLE
fix(OpenAI): default missing optional keys to null in from()

### DIFF
--- a/src/Responses/Responses/Output/OutputMcpCall.php
+++ b/src/Responses/Responses/Output/OutputMcpCall.php
@@ -69,9 +69,9 @@ final class OutputMcpCall implements ResponseContract
             type: $attributes['type'],
             arguments: $attributes['arguments'],
             name: $attributes['name'],
-            approvalRequestId: $attributes['approval_request_id'],
+            approvalRequestId: $attributes['approval_request_id'] ?? null,
             error: $errorType,
-            output: $attributes['output'],
+            output: $attributes['output'] ?? null,
         );
     }
 

--- a/src/Responses/Responses/Tool/WebSearchUserLocation.php
+++ b/src/Responses/Responses/Tool/WebSearchUserLocation.php
@@ -40,10 +40,10 @@ final class WebSearchUserLocation implements ResponseContract
     {
         return new self(
             type: $attributes['type'],
-            city: $attributes['city'],
+            city: $attributes['city'] ?? null,
             country: $attributes['country'],
-            region: $attributes['region'],
-            timezone: $attributes['timezone'],
+            region: $attributes['region'] ?? null,
+            timezone: $attributes['timezone'] ?? null,
         );
     }
 

--- a/tests/Responses/Responses/Output/OutputMcpCall.php
+++ b/tests/Responses/Responses/Output/OutputMcpCall.php
@@ -19,6 +19,25 @@ test('from', function () {
         ->output->toBeNull();
 });
 
+test('from without optional keys', function () {
+    $attributes = outputMcpCall();
+
+    unset($attributes['approval_request_id'], $attributes['output']);
+
+    set_error_handler(static fn (int $errno, string $errstr): bool => throw new ErrorException($errstr), E_WARNING);
+
+    try {
+        $response = OutputMcpCall::from($attributes);
+    } finally {
+        restore_error_handler();
+    }
+
+    expect($response)
+        ->toBeInstanceOf(OutputMcpCall::class)
+        ->approvalRequestId->toBeNull()
+        ->output->toBeNull();
+});
+
 test('from error as http object', function () {
     $response = OutputMcpCall::from(outputMcpErrorCallObject());
 

--- a/tests/Responses/Responses/Tool/WebSearchUserLocation.php
+++ b/tests/Responses/Responses/Tool/WebSearchUserLocation.php
@@ -1,0 +1,42 @@
+<?php
+
+use OpenAI\Responses\Responses\Tool\WebSearchUserLocation;
+
+test('from', function () {
+    $response = WebSearchUserLocation::from([
+        'type' => 'approximate',
+        'city' => 'San Francisco',
+        'country' => 'US',
+        'region' => 'California',
+        'timezone' => 'America/Los_Angeles',
+    ]);
+
+    expect($response)
+        ->toBeInstanceOf(WebSearchUserLocation::class)
+        ->type->toBe('approximate')
+        ->city->toBe('San Francisco')
+        ->country->toBe('US')
+        ->region->toBe('California')
+        ->timezone->toBe('America/Los_Angeles');
+});
+
+test('from without optional keys', function () {
+    set_error_handler(static fn (int $errno, string $errstr): bool => throw new ErrorException($errstr), E_WARNING);
+
+    try {
+        $response = WebSearchUserLocation::from([
+            'type' => 'approximate',
+            'country' => 'US',
+        ]);
+    } finally {
+        restore_error_handler();
+    }
+
+    expect($response)
+        ->toBeInstanceOf(WebSearchUserLocation::class)
+        ->type->toBe('approximate')
+        ->country->toBe('US')
+        ->city->toBeNull()
+        ->region->toBeNull()
+        ->timezone->toBeNull();
+});


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

`WebSearchUserLocation::from()` and `OutputMcpCall::from()` read their nullable keys straight from `$attributes`, so a response that omits those optional keys triggers an "Undefined array key" warning. This defaults them to `null` with `?? null`, the same way the other `from()` methods already handle optional keys.

### Related:

fixes: #781
