### PR TITLE
fix(OpenAI): Support streaming 'compaction' output

### DIFF
--- a/src/Responses/Responses/Streaming/OutputItem.php
+++ b/src/Responses/Responses/Streaming/OutputItem.php
@@ -10,6 +10,7 @@ use OpenAI\Responses\Concerns\ArrayAccessible;
 use OpenAI\Responses\Concerns\HasMetaInformation;
 use OpenAI\Responses\Meta\MetaInformation;
 use OpenAI\Responses\Responses\Output\OutputCodeInterpreterToolCall;
+use OpenAI\Responses\Responses\Output\OutputCompaction;
 use OpenAI\Responses\Responses\Output\OutputComputerToolCall;
 use OpenAI\Responses\Responses\Output\OutputFileSearchToolCall;
 use OpenAI\Responses\Responses\Output\OutputFunctionToolCall;
@@ -34,8 +35,9 @@ use OpenAI\Testing\Responses\Concerns\Fakeable;
  * @phpstan-import-type OutputMcpApprovalRequestType from OutputMcpApprovalRequest
  * @phpstan-import-type OutputMcpCallType from OutputMcpCall
  * @phpstan-import-type OutputCodeInterpreterToolCallType from OutputCodeInterpreterToolCall
+ * @phpstan-import-type OutputCompactionType from OutputCompaction
  *
- * @phpstan-type OutputItemType array{type: string, output_index: int, sequence_number: int, item: OutputCodeInterpreterToolCallType|OutputComputerToolCallType|OutputFileSearchToolCallType|OutputFunctionToolCallType|OutputMessageType|OutputReasoningType|OutputWebSearchToolCallType|OutputMcpListToolsType|OutputMcpApprovalRequestType|OutputMcpCallType|OutputImageGenerationToolCallType}
+ * @phpstan-type OutputItemType array{type: string, output_index: int, sequence_number: int, item: OutputCodeInterpreterToolCallType|OutputComputerToolCallType|OutputFileSearchToolCallType|OutputFunctionToolCallType|OutputMessageType|OutputReasoningType|OutputWebSearchToolCallType|OutputMcpListToolsType|OutputMcpApprovalRequestType|OutputMcpCallType|OutputImageGenerationToolCallType|OutputCompactionType}
  *
  * @implements ResponseContract<OutputItemType>
  */
@@ -53,7 +55,7 @@ final class OutputItem implements ResponseContract, ResponseHasMetaInformationCo
         public readonly string $type,
         public readonly int $outputIndex,
         public readonly int $sequenceNumber,
-        public readonly OutputMessage|OutputCodeInterpreterToolCall|OutputFileSearchToolCall|OutputFunctionToolCall|OutputWebSearchToolCall|OutputComputerToolCall|OutputReasoning|OutputMcpListTools|OutputMcpApprovalRequest|OutputMcpCall|OutputImageGenerationToolCall $item,
+        public readonly OutputMessage|OutputCodeInterpreterToolCall|OutputFileSearchToolCall|OutputFunctionToolCall|OutputWebSearchToolCall|OutputComputerToolCall|OutputReasoning|OutputMcpListTools|OutputMcpApprovalRequest|OutputMcpCall|OutputImageGenerationToolCall|OutputCompaction $item,
         private readonly MetaInformation $meta,
     ) {}
 
@@ -74,6 +76,7 @@ final class OutputItem implements ResponseContract, ResponseHasMetaInformationCo
             'mcp_approval_request' => OutputMcpApprovalRequest::from($attributes['item']),
             'mcp_call' => OutputMcpCall::from($attributes['item']),
             'code_interpreter_call' => OutputCodeInterpreterToolCall::from($attributes['item']),
+            'compaction' => OutputCompaction::from($attributes['item']),
         };
 
         return new self(

--- a/tests/Fixtures/Responses.php
+++ b/tests/Fixtures/Responses.php
@@ -1042,3 +1042,8 @@ function responseRateLimitsUpdatedEvent()
 {
     return fopen(__DIR__.'/Streams/ResponseRateLimitsUpdated.txt', 'r');
 }
+
+function responseOutputItemCompactionDoneEvent()
+{
+    return fopen(__DIR__.'/Streams/ResponseOutputItemCompactionDone.txt', 'r');
+}

--- a/tests/Fixtures/Streams/ResponseOutputItemCompactionDone.txt
+++ b/tests/Fixtures/Streams/ResponseOutputItemCompactionDone.txt
@@ -1,0 +1,1 @@
+data: {"type":"response.output_item.done","output_index":0,"sequence_number":11,"item":{"id":"cmp_67ccf18f64008190a39b619f4c8455ef087bb177ab789d5c","encrypted_content":"encrypted_string_value","type":"compaction","created_by":"user_123"}}

--- a/tests/Responses/Responses/CreateStreamedResponse.php
+++ b/tests/Responses/Responses/CreateStreamedResponse.php
@@ -2,6 +2,8 @@
 
 use OpenAI\Responses\Responses\CreateResponse;
 use OpenAI\Responses\Responses\CreateStreamedResponse;
+use OpenAI\Responses\Responses\Output\OutputCompaction;
+use OpenAI\Responses\Responses\Streaming\OutputItem;
 use OpenAI\Responses\Responses\Streaming\RateLimits;
 use OpenAI\Responses\Responses\Streaming\ReasoningTextDelta;
 use OpenAI\Responses\Responses\Streaming\ReasoningTextDone;
@@ -67,4 +69,19 @@ test('rate limits updated event', function () {
         ->response->toArray()->toBe([
             'type' => 'response.rate_limits.updated',
         ]);
+});
+
+test('output item done event with compaction item', function () {
+    $response = CreateStreamedResponse::fake(responseOutputItemCompactionDoneEvent());
+
+    expect($response->getIterator()->current())
+        ->toBeInstanceOf(CreateStreamedResponse::class)
+        ->event->toBe('response.output_item.done')
+        ->response->toBeInstanceOf(OutputItem::class)
+        ->response->outputIndex->toBe(0)
+        ->response->sequenceNumber->toBe(11)
+        ->response->item->toBeInstanceOf(OutputCompaction::class)
+        ->response->item->id->toBe('cmp_67ccf18f64008190a39b619f4c8455ef087bb177ab789d5c')
+        ->response->item->encryptedContent->toBe('encrypted_string_value')
+        ->response->item->createdBy->toBe('user_123');
 });


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

- Add compaction output parsing to Responses streaming OutputItem
- Add a stream fixture and regression test for response.output_item.done with a compaction item

## Why
Streaming response output items could not parse the new compaction output object even though non-streamed Responses output already supported it.

