### PR TITLE
docs: document MiniMax OpenAI-compatible service and regional endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ If you or your business relies on this package, it's important to support the de
 - [Webhooks][#webhooks]
 - [Services](#services)
   - [Azure](#azure)
+  - [MiniMax](#minimax)
 
 ## Get Started
 
@@ -3156,7 +3157,39 @@ Therefore, a basic sample completion call would be:
 $result = $client->completions()->create([
     'prompt' => 'PHP is'
 ]);
-``` 
+```
+
+### MiniMax
+
+The MiniMax service exposes an OpenAI-compatible API. It is not necessary to
+construct a dedicated client; instead, point the factory at the regional
+OpenAI-compatible base URI for your account. Two regional endpoints are
+available:
+
+| Region | OpenAI-compatible base URI |
+| --- | --- |
+| `global_en` | `api.minimax.io/v1` |
+| `cn_zh` | `api.minimaxi.com/v1` |
+
+```php
+$client = OpenAI::factory()
+    ->withApiKey('{your-api-key}')
+    ->withBaseUri('api.minimax.io/v1') // use 'api.minimaxi.com/v1' for the cn_zh region
+    ->make();
+```
+
+The current MiniMax text models, such as `MiniMax-M3` and `MiniMax-M2.7`, are
+selected through the `model` parameter of each request, just like the default
+OpenAI models:
+
+```php
+$result = $client->chat()->create([
+    'model' => 'MiniMax-M3',
+    'messages' => [
+        ['role' => 'user', 'content' => 'PHP is'],
+    ],
+]);
+```
 
 ---
 


### PR DESCRIPTION
Reason: Document the MiniMax OpenAI-compatible service, including its two regional endpoints and current text models.

## Changes

- Add a `### MiniMax` section under `## Services` in the README, mirroring the existing Azure service documentation.
- Document the two regional OpenAI-compatible base URIs (`api.minimax.io/v1` for `global_en` and `api.minimaxi.com/v1` for `cn_zh`).
- Show how to configure the existing factory (`withBaseUri`) to target MiniMax and how to select the current text models (`MiniMax-M3`, `MiniMax-M2.7`) through the request `model` parameter.
- Add the section to the table of contents.

## How it follows the existing pattern

The Azure service is already documented as a README `Services` section that composes the generic factory extension points (`src/Factory.php` `withBaseUri`/`withHttpHeader`/`withQueryParam` and `src/ValueObjects/Transporter/BaseUri.php`). MiniMax is OpenAI-compatible and is added the same way, without introducing provider-specific source code, which keeps the client provider-agnostic.

## Checks

- Verified the new `### MiniMax` heading produces the `#minimax` anchor referenced in the table of contents.
- This change is documentation-only; no PHP source files were modified, so the PHP lint/type/test toolchain is unaffected.
