### PR TITLE
fix(OpenAI): allow null ranking_options and max_num_results in FileSearchTool

### DIFF
--- a/src/Responses/Responses/Tool/FileSearchTool.php
+++ b/src/Responses/Responses/Tool/FileSearchTool.php
@@ -13,7 +13,7 @@ use OpenAI\Testing\Responses\Concerns\Fakeable;
  * @phpstan-import-type ComparisonFilterType from FileSearchComparisonFilter
  * @phpstan-import-type CompoundFilterType from FileSearchCompoundFilter
  *
- * @phpstan-type FileSearchToolType array{type: 'file_search', vector_store_ids: array<int, string>, filters: ComparisonFilterType|CompoundFilterType|null, max_num_results: int, ranking_options: RankingOptionType}
+ * @phpstan-type FileSearchToolType array{type: 'file_search', vector_store_ids: array<int, string>, filters: ComparisonFilterType|CompoundFilterType|null, max_num_results: int|null, ranking_options: RankingOptionType|null}
  *
  * @implements ResponseContract<FileSearchToolType>
  */
@@ -34,8 +34,8 @@ final class FileSearchTool implements ResponseContract
         public readonly string $type,
         public readonly array $vectorStoreIds,
         public readonly FileSearchComparisonFilter|FileSearchCompoundFilter|null $filters,
-        public readonly int $maxNumResults,
-        public readonly FileSearchRankingOption $rankingOptions,
+        public readonly ?int $maxNumResults,
+        public readonly ?FileSearchRankingOption $rankingOptions,
     ) {}
 
     /**
@@ -56,8 +56,8 @@ final class FileSearchTool implements ResponseContract
             type: $attributes['type'],
             vectorStoreIds: $attributes['vector_store_ids'],
             filters: $filters,
-            maxNumResults: $attributes['max_num_results'],
-            rankingOptions: FileSearchRankingOption::from($attributes['ranking_options']),
+            maxNumResults: $attributes['max_num_results'] ?? null,
+            rankingOptions: isset($attributes['ranking_options']) ? FileSearchRankingOption::from($attributes['ranking_options']) : null,
         );
     }
 
@@ -71,7 +71,7 @@ final class FileSearchTool implements ResponseContract
             'vector_store_ids' => $this->vectorStoreIds,
             'filters' => $this->filters?->toArray(),
             'max_num_results' => $this->maxNumResults,
-            'ranking_options' => $this->rankingOptions->toArray(),
+            'ranking_options' => $this->rankingOptions?->toArray(),
         ];
     }
 }

--- a/tests/Responses/Responses/Tool/FileSearchTool.php
+++ b/tests/Responses/Responses/Tool/FileSearchTool.php
@@ -32,6 +32,45 @@ test('from null filters', function () {
         ->filters->toBeNull();
 });
 
+test('from null ranking options', function () {
+    $payload = toolFileSearch();
+    $payload['ranking_options'] = null;
+    $response = FileSearchTool::from($payload);
+
+    expect($response)
+        ->toBeInstanceOf(FileSearchTool::class)
+        ->rankingOptions->toBeNull();
+});
+
+test('from null max num results', function () {
+    $payload = toolFileSearch();
+    $payload['max_num_results'] = null;
+    $response = FileSearchTool::from($payload);
+
+    expect($response)
+        ->toBeInstanceOf(FileSearchTool::class)
+        ->maxNumResults->toBeNull();
+});
+
+test('from without optional keys', function () {
+    $attributes = toolFileSearch();
+
+    unset($attributes['max_num_results'], $attributes['ranking_options']);
+
+    set_error_handler(static fn (int $errno, string $errstr): bool => throw new ErrorException($errstr), E_WARNING);
+
+    try {
+        $response = FileSearchTool::from($attributes);
+    } finally {
+        restore_error_handler();
+    }
+
+    expect($response)
+        ->toBeInstanceOf(FileSearchTool::class)
+        ->maxNumResults->toBeNull()
+        ->rankingOptions->toBeNull();
+});
+
 test('from complex nested filters', function () {
     $response = FileSearchTool::from(toolFileSearchNestedFilters());
 


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

`FileSearchTool::from()` treats `max_num_results` and `ranking_options` as required, but the Responses API returns both as optional (`Optional[int] = None` and `Optional[RankingOptions] = None` upstream). A response that omits or nulls either field currently throws instead of hydrating. Both fields are now nullable and only hydrated when present.

### Related:

fixes: #796
fixes: #797
